### PR TITLE
Support VS Mac 8.3

### DIFF
--- a/Toolkit/Animations/Animations.csproj
+++ b/Toolkit/Animations/Animations.csproj
@@ -9,7 +9,6 @@
     <Description>Xamarin Community Toolkit Animations Library</Description>
     <EnableDefaultCompileItems>true</EnableDefaultCompileItems>
   </PropertyGroup>
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
   <Import Project="$(MSBuildThisFileDirectory)..\mdoc.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\CodeStyles.targets" />
 </Project>

--- a/Toolkit/Behaviors/Behaviors.csproj
+++ b/Toolkit/Behaviors/Behaviors.csproj
@@ -9,7 +9,6 @@
     <Description>Xamarin Community Toolkit Behaviors Library</Description>
     <EnableDefaultCompileItems>true</EnableDefaultCompileItems>
   </PropertyGroup>
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
   <Import Project="$(MSBuildThisFileDirectory)..\mdoc.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\CodeStyles.targets" />
 </Project>

--- a/Toolkit/Converters/Converters.csproj
+++ b/Toolkit/Converters/Converters.csproj
@@ -9,7 +9,6 @@
     <Description>Xamarin Community Toolkit Converters Library</Description>
     <EnableDefaultCompileItems>true</EnableDefaultCompileItems>
   </PropertyGroup>
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
   <Import Project="$(MSBuildThisFileDirectory)..\mdoc.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\CodeStyles.targets" />
 </Project>

--- a/Toolkit/Directory.build.targets
+++ b/Toolkit/Directory.build.targets
@@ -1,7 +1,6 @@
 <Project>  
   <ItemGroup>
     <PackageReference Include="mdoc" Version="5.7.1" PrivateAssets="All" />
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.20-preview" PrivateAssets="All" />
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.583944" />
   </ItemGroup>
 </Project>

--- a/Toolkit/Effects/Effects.csproj
+++ b/Toolkit/Effects/Effects.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFrameworks></TargetFrameworks>
@@ -52,7 +52,6 @@
     <Compile Include="**\*.ios.cs" />
     <Compile Include="**\*.ios.*.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
   <Import Project="$(MSBuildThisFileDirectory)..\mdoc.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\CodeStyles.targets" />
 </Project>

--- a/Toolkit/Effects/Effects.csproj
+++ b/Toolkit/Effects/Effects.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid71;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid71;</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.0;netstandard2.0;xamarin.ios10;monoandroid71;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0;xamarin.ios10;monoandroid71;</TargetFrameworks>
     <AssemblyName>Xamarin.Toolkit.Effects</AssemblyName>
     <RootNamespace>Xamarin.Toolkit.Effects</RootNamespace>
     <PackageId>Xamarin.Toolkit.Effects</PackageId>
@@ -15,21 +15,30 @@
 
   <ItemGroup>
     <None Include="**\*.cs;**\*.xml;**\*.axml;**\*.png" Exclude="obj\**\*.*;bin\**\*.*" />
+    <None Remove="GlobalSuppressions.cs" />
+    <None Remove="**\*.shared.cs" />
+    <None Remove="**\*.shared.*.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="**\*.shared.cs" />
     <Compile Include="**\*.shared.*.cs" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
+    <None Remove="**\*.netstandard.cs" />
+    <None Remove="**\*.netstandard.*.cs" />
     <Compile Include="**\*.netstandard.cs" />
     <Compile Include="**\*.netstandard.*.cs" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.5" />
     <PackageReference Include="Win2D.uwp" Version="1.21.0" />
+    <None Remove="**\*.uwp.cs" />
+    <None Remove="**\*.uwp.*.cs" />
     <Compile Include="**\*.uwp.cs" />
     <Compile Include="**\*.uwp.*.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('monoandroid')) ">
+    <None Remove="**\*.android.cs" />
+    <None Remove="**\*.android.*.cs" />
     <Compile Include="**\*.android.cs" />
     <Compile Include="**\*.android.*.cs" />
 
@@ -37,7 +46,9 @@
     <AndroidResource Include="Resources\**\*.xml" />
     <AndroidResource Include="Resources\**\*.png" />
   </ItemGroup>
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarin.ios')) ">
+    <None Remove="**\*.ios.cs" />
+    <None Remove="**\*.ios.*.cs" />
     <Compile Include="**\*.ios.cs" />
     <Compile Include="**\*.ios.*.cs" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "msbuild-sdks": {
+    "MSBuild.Sdk.Extras": "2.0.41"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,4 +1,7 @@
 {
+  "sdk": {
+    "version": "2.1.701"
+  },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "2.0.41"
   }


### PR DESCRIPTION
Fix some things which were preventing multi-target code completion from working with VS Mac 8.3.

- Remove duplicate None items preventing code completion from working properly.
- Lower case target frameworks in conditions which was preventing files from being included in code completion.
- Update to MSBuild.Sdk.Extras 2.0.41
- Use .NET Core 2.1.701 sdk. Some problems building when .NET Core 3.0 is installed (A numeric comparison was attempted on "$(_TargetFrameworkVersionWithoutV)" error).

These changes allow me to build the solution in VS Mac, code completion working, and the tests pass. Not tried the sample solutions.

Not sure if you want to tie this to .NET Core 2.1.701. That change is in a separate commit.