### PR TITLE
Lower Forms dependency to 3.5

### DIFF
--- a/XamarinCommunityToolkit/XamarinCommunityToolkit.csproj
+++ b/XamarinCommunityToolkit/XamarinCommunityToolkit.csproj
@@ -55,7 +55,7 @@
         <Compile Include="**/*.shared.cs" />
         <Compile Include="**/*.shared.*.cs" />
         <None Include="..\LICENSE" PackagePath="" Pack="true" />
-        <PackageReference Include="Xamarin.Forms" Version="4.5.0.495" />
+        <PackageReference Include="Xamarin.Forms" Version="3.5.0.129452" />
         <Folder Include="Converters\" />
     </ItemGroup>
     <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard1.')) ">


### PR DESCRIPTION
### Description of Change ###

Like it says in the title! Let's start out with a low dependency and see if we need to move up whenever we need something specific in newer Forms versions.

This should also fix the build error we're seeing right now