### PR TITLE
Implement IMarkupExtension in converters

### DIFF
--- a/XamarinCommunityToolkit/Converters/BoolToObjectConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/BoolToObjectConverter.shared.cs
@@ -7,7 +7,14 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Converts boolean to object and vice versa.
     /// </summary>
-    public class BoolToObjectConverter<TObject> : IValueConverter
+    public class BoolToObjectConverter : BoolToObjectConverter<object>
+    {
+    }
+
+    /// <summary>
+    /// Converts boolean to object and vice versa.
+    /// </summary>
+    public class BoolToObjectConverter<TObject> : ValueConverterMarkupExtension, IValueConverter
     {
         /// <summary>
         /// The object that corresponds to True value.

--- a/XamarinCommunityToolkit/Converters/BoolToObjectConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/BoolToObjectConverter.shared.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Xamarin.Forms;
+using XamarinCommunityToolkit.Extensions;
 
 namespace XamarinCommunityToolkit.Converters
 {
@@ -14,7 +15,7 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Converts boolean to object and vice versa.
     /// </summary>
-    public class BoolToObjectConverter<TObject> : ValueConverterMarkupExtension, IValueConverter
+    public class BoolToObjectConverter<TObject> : ValueConverterExtension, IValueConverter
     {
         /// <summary>
         /// The object that corresponds to True value.

--- a/XamarinCommunityToolkit/Converters/DoubleToIntConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/DoubleToIntConverter.shared.cs
@@ -7,8 +7,14 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Converts double to integer and vice versa.
     /// </summary>
-    public class DoubleToIntConverter : IValueConverter
+    [ContentProperty(nameof(Ratio))]
+    public class DoubleToIntConverter : ValueConverterMarkupExtension, IValueConverter
     {
+        /// <summary>
+        /// Multiplier / Denominator (Equals 1 by default).
+        /// </summary>
+        public double Ratio { get; set; } = 1;
+
         /// <summary>
         /// Converts double to integer.
         /// </summary>
@@ -36,7 +42,9 @@ namespace XamarinCommunityToolkit.Converters
                 : throw new ArgumentException("Value is not a valid integer", nameof(value));
 
         double GetParameter(object parameter)
-            => parameter switch
+            => parameter == null
+            ? Ratio
+            : parameter switch
             {
                 double d => d,
                 int i => i,

--- a/XamarinCommunityToolkit/Converters/DoubleToIntConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/DoubleToIntConverter.shared.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Xamarin.Forms;
+using XamarinCommunityToolkit.Extensions;
 
 namespace XamarinCommunityToolkit.Converters
 {
@@ -8,7 +9,7 @@ namespace XamarinCommunityToolkit.Converters
     /// Converts double to integer and vice versa.
     /// </summary>
     [ContentProperty(nameof(Ratio))]
-    public class DoubleToIntConverter : ValueConverterMarkupExtension, IValueConverter
+    public class DoubleToIntConverter : ValueConverterExtension, IValueConverter
     {
         /// <summary>
         /// Multiplier / Denominator (Equals 1 by default).

--- a/XamarinCommunityToolkit/Converters/EqualConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/EqualConverter.shared.cs
@@ -7,7 +7,7 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Checks whether the incoming value equals the provided parameter.
     /// </summary>
-    public class EqualConverter : IValueConverter
+    public class EqualConverter : ValueConverterMarkupExtension, IValueConverter
     {
         /// <summary>
         /// Checks whether the incoming value equals the provided parameter.

--- a/XamarinCommunityToolkit/Converters/EqualConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/EqualConverter.shared.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Globalization;
 using Xamarin.Forms;
+using XamarinCommunityToolkit.Extensions;
 
 namespace XamarinCommunityToolkit.Converters
 {
     /// <summary>
     /// Checks whether the incoming value equals the provided parameter.
     /// </summary>
-    public class EqualConverter : ValueConverterMarkupExtension, IValueConverter
+    public class EqualConverter : ValueConverterExtension, IValueConverter
     {
         /// <summary>
         /// Checks whether the incoming value equals the provided parameter.

--- a/XamarinCommunityToolkit/Converters/IndexToArrayItemConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/IndexToArrayItemConverter.shared.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Globalization;
 using Xamarin.Forms;
+using XamarinCommunityToolkit.Extensions;
 
 namespace XamarinCommunityToolkit.Converters
 {
     /// <summary>
     /// Converts an integer index to corresponding array item and vice versa.
     /// </summary>
-    public class IndexToArrayItemConverter : ValueConverterMarkupExtension, IValueConverter
+    public class IndexToArrayItemConverter : ValueConverterExtension, IValueConverter
     {
         /// <summary>
         /// Converts an integer index to corresponding array item.

--- a/XamarinCommunityToolkit/Converters/IndexToArrayItemConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/IndexToArrayItemConverter.shared.cs
@@ -7,7 +7,7 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Converts an integer index to corresponding array item and vice versa.
     /// </summary>
-    public class IndexToArrayItemConverter : IValueConverter
+    public class IndexToArrayItemConverter : ValueConverterMarkupExtension, IValueConverter
     {
         /// <summary>
         /// Converts an integer index to corresponding array item.

--- a/XamarinCommunityToolkit/Converters/IntToBoolConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/IntToBoolConverter.shared.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Globalization;
 using Xamarin.Forms;
+using XamarinCommunityToolkit.Extensions;
 
 namespace XamarinCommunityToolkit.Converters
 {
     /// <summary>
     /// Converts an integer to corresponding boolean and vice versa.
     /// </summary>
-    public class IntToBoolConverter : ValueConverterMarkupExtension, IValueConverter
+    public class IntToBoolConverter : ValueConverterExtension, IValueConverter
     {
         /// <summary>
         /// Converts an integer to corresponding boolean.

--- a/XamarinCommunityToolkit/Converters/IntToBoolConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/IntToBoolConverter.shared.cs
@@ -7,7 +7,7 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Converts an integer to corresponding boolean and vice versa.
     /// </summary>
-    public class IntToBoolConverter : IValueConverter
+    public class IntToBoolConverter : ValueConverterMarkupExtension, IValueConverter
     {
         /// <summary>
         /// Converts an integer to corresponding boolean.

--- a/XamarinCommunityToolkit/Converters/InvertedBoolConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/InvertedBoolConverter.shared.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Globalization;
 using Xamarin.Forms;
+using XamarinCommunityToolkit.Extensions;
 
 namespace XamarinCommunityToolkit.Converters
 {
     /// <summary>
     /// Converts true to false and false to true.
     /// </summary>
-    public class InvertedBoolConverter : ValueConverterMarkupExtension, IValueConverter
+    public class InvertedBoolConverter : ValueConverterExtension, IValueConverter
     {
         /// <summary>
         /// Converts a boolean to its inverse value.

--- a/XamarinCommunityToolkit/Converters/InvertedBoolConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/InvertedBoolConverter.shared.cs
@@ -7,7 +7,7 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Converts true to false and false to true.
     /// </summary>
-    public class InvertedBoolConverter : IValueConverter
+    public class InvertedBoolConverter : ValueConverterMarkupExtension, IValueConverter
     {
         /// <summary>
         /// Converts a boolean to its inverse value.

--- a/XamarinCommunityToolkit/Converters/IsNotNullOrEmptyConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/IsNotNullOrEmptyConverter.shared.cs
@@ -7,7 +7,7 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Converts the incoming value to a boolean indicating whether or not the value is not null and not empty.
     /// </summary>
-    public class IsNotNullOrEmptyConverter : IValueConverter
+    public class IsNotNullOrEmptyConverter : ValueConverterMarkupExtension, IValueConverter
     {
         /// <summary>
         /// Converts the incoming value to a boolean indicating whether or not the value is not null and not empty.

--- a/XamarinCommunityToolkit/Converters/IsNotNullOrEmptyConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/IsNotNullOrEmptyConverter.shared.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Globalization;
 using Xamarin.Forms;
+using XamarinCommunityToolkit.Extensions;
 
 namespace XamarinCommunityToolkit.Converters
 {
     /// <summary>
     /// Converts the incoming value to a boolean indicating whether or not the value is not null and not empty.
     /// </summary>
-    public class IsNotNullOrEmptyConverter : ValueConverterMarkupExtension, IValueConverter
+    public class IsNotNullOrEmptyConverter : ValueConverterExtension, IValueConverter
     {
         /// <summary>
         /// Converts the incoming value to a boolean indicating whether or not the value is not null and not empty.

--- a/XamarinCommunityToolkit/Converters/IsNullOrEmptyConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/IsNullOrEmptyConverter.shared.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Globalization;
 using Xamarin.Forms;
+using XamarinCommunityToolkit.Extensions;
 
 namespace XamarinCommunityToolkit.Converters
 {
     /// <summary>
     /// Converts the incoming value to a boolean indicating whether or not the value is null or empty.
     /// </summary>
-    public class IsNullOrEmptyConverter : ValueConverterMarkupExtension, IValueConverter
+    public class IsNullOrEmptyConverter : ValueConverterExtension, IValueConverter
     {
         /// <summary>
         /// Converts the incoming value to a boolean indicating whether or not the value is null or empty.

--- a/XamarinCommunityToolkit/Converters/IsNullOrEmptyConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/IsNullOrEmptyConverter.shared.cs
@@ -7,7 +7,7 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Converts the incoming value to a boolean indicating whether or not the value is null or empty.
     /// </summary>
-    public class IsNullOrEmptyConverter : IValueConverter
+    public class IsNullOrEmptyConverter : ValueConverterMarkupExtension, IValueConverter
     {
         /// <summary>
         /// Converts the incoming value to a boolean indicating whether or not the value is null or empty.

--- a/XamarinCommunityToolkit/Converters/ListIsNotNullOrEmptyConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/ListIsNotNullOrEmptyConverter.shared.cs
@@ -3,13 +3,14 @@ using System.Collections;
 using System.Globalization;
 using Xamarin.Forms;
 using System.Linq;
+using XamarinCommunityToolkit.Extensions;
 
 namespace XamarinCommunityToolkit.Converters
 {
     /// <summary>
     /// Converts the incoming value to a boolean indicating whether or not the value is not null and not empty.
     /// </summary>
-    public class ListIsNotNullOrEmptyConverter : ValueConverterMarkupExtension, IValueConverter
+    public class ListIsNotNullOrEmptyConverter : ValueConverterExtension, IValueConverter
     {
         /// <summary>
         /// Converts the incoming value to a boolean indicating whether or not the value is not null and not empty.

--- a/XamarinCommunityToolkit/Converters/ListIsNotNullOrEmptyConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/ListIsNotNullOrEmptyConverter.shared.cs
@@ -9,7 +9,7 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Converts the incoming value to a boolean indicating whether or not the value is not null and not empty.
     /// </summary>
-    public class ListIsNotNullOrEmptyConverter : IValueConverter
+    public class ListIsNotNullOrEmptyConverter : ValueConverterMarkupExtension, IValueConverter
     {
         /// <summary>
         /// Converts the incoming value to a boolean indicating whether or not the value is not null and not empty.

--- a/XamarinCommunityToolkit/Converters/ListIsNullOrEmptyConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/ListIsNullOrEmptyConverter.shared.cs
@@ -8,7 +8,7 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Converts the incoming value to a boolean indicating whether or not the value is null or empty.
     /// </summary>
-    public class ListIsNullOrEmptyConverter : IValueConverter
+    public class ListIsNullOrEmptyConverter : ValueConverterMarkupExtension, IValueConverter
     {
         /// <summary>
         /// Converts the incoming value to a boolean indicating whether or not the value is null or empty.

--- a/XamarinCommunityToolkit/Converters/ListIsNullOrEmptyConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/ListIsNullOrEmptyConverter.shared.cs
@@ -2,13 +2,14 @@
 using System.Collections;
 using System.Globalization;
 using Xamarin.Forms;
+using XamarinCommunityToolkit.Extensions;
 
 namespace XamarinCommunityToolkit.Converters
 {
     /// <summary>
     /// Converts the incoming value to a boolean indicating whether or not the value is null or empty.
     /// </summary>
-    public class ListIsNullOrEmptyConverter : ValueConverterMarkupExtension, IValueConverter
+    public class ListIsNullOrEmptyConverter : ValueConverterExtension, IValueConverter
     {
         /// <summary>
         /// Converts the incoming value to a boolean indicating whether or not the value is null or empty.

--- a/XamarinCommunityToolkit/Converters/NotEqualConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/NotEqualConverter.shared.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Globalization;
 using Xamarin.Forms;
+using XamarinCommunityToolkit.Extensions;
 
 namespace XamarinCommunityToolkit.Converters
 {
     /// <summary>
     /// Checks whether the incoming value doesn't equal the provided parameter.
     /// </summary>
-    public class NotEqualConverter : ValueConverterMarkupExtension, IValueConverter
+    public class NotEqualConverter : ValueConverterExtension, IValueConverter
     {
         /// <summary>
         /// Checks whether the incoming value doesn't equal the provided parameter.

--- a/XamarinCommunityToolkit/Converters/NotEqualConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/NotEqualConverter.shared.cs
@@ -7,7 +7,7 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Checks whether the incoming value doesn't equal the provided parameter.
     /// </summary>
-    public class NotEqualConverter : IValueConverter
+    public class NotEqualConverter : ValueConverterMarkupExtension, IValueConverter
     {
         /// <summary>
         /// Checks whether the incoming value doesn't equal the provided parameter.

--- a/XamarinCommunityToolkit/Converters/TextCaseConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/TextCaseConverter.shared.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Xamarin.Forms;
+using XamarinCommunityToolkit.Extensions;
 
 namespace XamarinCommunityToolkit.Converters
 {
@@ -8,19 +9,19 @@ namespace XamarinCommunityToolkit.Converters
     /// Converts text (string, char) to certain case.
     /// </summary>
     [ContentProperty(nameof(Type))]
-    public class TextCaseConverter : ValueConverterMarkupExtension, IValueConverter
+    public class TextCaseConverter : ValueConverterExtension, IValueConverter
     {
         /// <summary>
         /// The desired text case that the text should be converted to.
         /// </summary>
-        public TextCaseConverterType Type { get; set; }
+        public TextCaseType Type { get; set; }
 
         /// <summary>
         /// Converts text (string, char) to certain case.
         /// </summary>
         /// <param name="value">The text to convert.</param>
         /// <param name="targetType">The type of the binding target property.</param>
-        /// <param name="parameter">The desired text case that the text should be converted to (TextCaseConverterType enum value).</param>
+        /// <param name="parameter">The desired text case that the text should be converted to (TextCaseType enum value).</param>
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>The lowercase text representation.</returns>
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
@@ -34,24 +35,24 @@ namespace XamarinCommunityToolkit.Converters
         object Convert(string value, object parameter)
             => GetParameter(parameter) switch
             {
-                TextCaseConverterType.Lower => value?.ToLowerInvariant(),
-                TextCaseConverterType.Upper => value?.ToUpperInvariant(),
+                TextCaseType.Lower => value?.ToLowerInvariant(),
+                TextCaseType.Upper => value?.ToUpperInvariant(),
                 _ => value
             };
 
-        TextCaseConverterType GetParameter(object parameter)
+        TextCaseType GetParameter(object parameter)
             => parameter == null
             ? Type
             : parameter switch
             {
-                TextCaseConverterType type => type,
-                string typeString => Enum.TryParse(typeString, out TextCaseConverterType result)
+                TextCaseType type => type,
+                string typeString => Enum.TryParse(typeString, out TextCaseType result)
                     ? result
                     : throw new ArgumentException("Cannot parse text case from the string", nameof(parameter)),
-                int typeInt => Enum.IsDefined(typeof(TextCaseConverterType), typeInt)
-                    ? (TextCaseConverterType)typeInt
+                int typeInt => Enum.IsDefined(typeof(TextCaseType), typeInt)
+                    ? (TextCaseType)typeInt
                     : throw new ArgumentException("Cannot convert integer to text case enum value", nameof(parameter)),
-                _ => TextCaseConverterType.None,
+                _ => TextCaseType.None,
             };
     }
 }

--- a/XamarinCommunityToolkit/Converters/TextCaseConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/TextCaseConverter.shared.cs
@@ -7,8 +7,14 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// Converts text (string, char) to certain case.
     /// </summary>
-    public class TextCaseConverter : IValueConverter
+    [ContentProperty(nameof(Type))]
+    public class TextCaseConverter : ValueConverterMarkupExtension, IValueConverter
     {
+        /// <summary>
+        /// The desired text case that the text should be converted to.
+        /// </summary>
+        public TextCaseConverterType Type { get; set; }
+
         /// <summary>
         /// Converts text (string, char) to certain case.
         /// </summary>
@@ -34,7 +40,9 @@ namespace XamarinCommunityToolkit.Converters
             };
 
         TextCaseConverterType GetParameter(object parameter)
-            => parameter switch
+            => parameter == null
+            ? Type
+            : parameter switch
             {
                 TextCaseConverterType type => type,
                 string typeString => Enum.TryParse(typeString, out TextCaseConverterType result)

--- a/XamarinCommunityToolkit/Converters/TextCaseType.shared.cs
+++ b/XamarinCommunityToolkit/Converters/TextCaseType.shared.cs
@@ -4,7 +4,7 @@ namespace XamarinCommunityToolkit.Converters
     /// <summary>
     /// The text case that the TextCaseConverter should convert a value.
     /// </summary>
-    public enum TextCaseConverterType
+    public enum TextCaseType
     {
         None,
         Upper,

--- a/XamarinCommunityToolkit/Converters/ValueConverterMarkupExtension.shared.cs
+++ b/XamarinCommunityToolkit/Converters/ValueConverterMarkupExtension.shared.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.ComponentModel;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace XamarinCommunityToolkit.Converters
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public abstract class ValueConverterMarkupExtension : IMarkupExtension<IValueConverter>
+    {
+        public IValueConverter ProvideValue(IServiceProvider serviceProvider)
+            => (IValueConverter)this;
+
+        object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
+            => ((IMarkupExtension<IValueConverter>)this).ProvideValue(serviceProvider);
+    }
+}

--- a/XamarinCommunityToolkit/Extensions/ValueConverterExtension.shared.cs
+++ b/XamarinCommunityToolkit/Extensions/ValueConverterExtension.shared.cs
@@ -3,10 +3,10 @@ using System.ComponentModel;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
-namespace XamarinCommunityToolkit.Converters
+namespace XamarinCommunityToolkit.Extensions
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public abstract class ValueConverterMarkupExtension : IMarkupExtension<IValueConverter>
+    public abstract class ValueConverterExtension : IMarkupExtension<IValueConverter>
     {
         public IValueConverter ProvideValue(IServiceProvider serviceProvider)
             => (IValueConverter)this;

--- a/XamarinCommunityToolkit/XamarinCommunityToolkit.csproj
+++ b/XamarinCommunityToolkit/XamarinCommunityToolkit.csproj
@@ -62,6 +62,7 @@
     <Folder Include="Interfaces\" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard1.')) ">
+    <PackageReference Include="System.ComponentModel" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
   </ItemGroup>

--- a/XamarinCommunityToolkit/XamarinCommunityToolkit.csproj
+++ b/XamarinCommunityToolkit/XamarinCommunityToolkit.csproj
@@ -60,6 +60,7 @@
     <Folder Include="Converters\" />
     <Folder Include="Helpers\" />
     <Folder Include="Interfaces\" />
+    <Folder Include="Extensions\" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard1.')) ">
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />


### PR DESCRIPTION
### Description of Change ###

Implemented IMarkupExtension for converters.

Now they can be used as:
```xaml
 <Label Text="{Binding MyString, Converter={kit:TextCaseConverter Upper}}" />
```

Since default interface implementations are not supported by nestandard 1 and 2 we **cannot** use them. So I decided to go ahead with the abstract class.
Also, I had to add *System.ComponentModel* nuget for nestandard1.0 **only** due to nestandard1.0 needs (IServiceProvider is presented there)

### Bugs Fixed ###

- Related to issue #133 

### API Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation