### PR TITLE
Multiconverter

### DIFF
--- a/XamarinCommunityToolkit/Converters/MultiConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/MultiConverter.shared.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xamarin.Forms;
+
+namespace XamarinCommunityToolkit.Converters
+{
+    /// <summary>
+    /// Converts an incoming value using all of the incoming converters in sequence.
+    /// </summary>
+    public class MultiConverter : List<IValueConverter>, IValueConverter
+    {
+        /// <summary>
+        /// Uses the incoming converters to convert the value.
+        /// </summary>
+        /// <param name="value">Value to convert.</param>
+        /// <param name="targetType">The type of the binding target property.</param>
+        /// <param name="parameter">Parameter to pass into subsequent converters.</param>
+        /// <param name="culture">The culture to use in the converter.</param>
+        /// <returns>The converted value.</returns>
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+            => this.Aggregate(value, (current, converter) => converter.Convert(current, targetType, parameter, culture));
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+            => throw new NotImplementedException();
+    }
+}

--- a/XamarinCommunityToolkit/Converters/MultiConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/MultiConverter.shared.cs
@@ -19,9 +19,28 @@ namespace XamarinCommunityToolkit.Converters
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>The converted value.</returns>
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-            => this.Aggregate(value, (current, converter) => converter.Convert(current, targetType, parameter, culture));
+        {
+            // If it's a list of MultiConverterParameter, use those and propagate them into the converters.
+            if (parameter is IList<MultiConverterParameter> parameters)
+            {
+                return this.Aggregate(value, (current, converter) => converter.Convert(current, targetType,
+                    parameters.FirstOrDefault(x => x.ConverterType == converter.GetType())?.Value, culture));
+            }
+
+            return this.Aggregate(value, (current, converter) => converter.Convert(current, targetType, parameter, culture));
+        }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
             => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Represents a parameter to be used in the MultiConverter.
+    /// </summary>
+    public class MultiConverterParameter : BindableObject
+    {
+        public Type ConverterType { get; set; }
+
+        public object Value { get; set; }
     }
 }

--- a/XamarinCommunityToolkit/Converters/MultiConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/MultiConverter.shared.cs
@@ -19,28 +19,12 @@ namespace XamarinCommunityToolkit.Converters
         /// <param name="culture">The culture to use in the converter.</param>
         /// <returns>The converted value.</returns>
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
-        {
-            // If it's a list of MultiConverterParameter, use those and propagate them into the converters.
-            if (parameter is IList<MultiConverterParameter> parameters)
-            {
-                return this.Aggregate(value, (current, converter) => converter.Convert(current, targetType,
-                    parameters.FirstOrDefault(x => x.ConverterType == converter.GetType())?.Value, culture));
-            }
-
-            return this.Aggregate(value, (current, converter) => converter.Convert(current, targetType, parameter, culture));
-        }
+            => parameter is IList<MultiConverterParameter> parameters
+            ? this.Aggregate(value, (current, converter) => converter.Convert(current, targetType,
+                     parameters.FirstOrDefault(x => x.ConverterType == converter.GetType())?.Value, culture))
+            : this.Aggregate(value, (current, converter) => converter.Convert(current, targetType, parameter, culture));
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
             => throw new NotImplementedException();
-    }
-
-    /// <summary>
-    /// Represents a parameter to be used in the MultiConverter.
-    /// </summary>
-    public class MultiConverterParameter : BindableObject
-    {
-        public Type ConverterType { get; set; }
-
-        public object Value { get; set; }
     }
 }

--- a/XamarinCommunityToolkit/Converters/MultiConverterParameter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/MultiConverterParameter.shared.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace XamarinCommunityToolkit.Converters
+{
+    /// <summary>
+    /// Represents a parameter to be used in the MultiConverter.
+    /// </summary>
+    public class MultiConverterParameter : BindableObject
+    {
+        public Type ConverterType { get; set; }
+
+        public object Value { get; set; }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

This is a converter that allows for multiple converters to be applied in series.

#### Sample

```
<ResourceDictionary>
    <xct:MultiConverter x:Key="myMultiConverter">
        <xct:TextCaseConverter />
        <xct:NotEqualConverter />
    </xct:MultiConverter>
    <x:Array x:Key="multiParams" Type="{x:Type xct:MultiConverterParameter}">
        <xct:MultiConverterParameter ConverterType="{x:Type xct:TextCaseConverter}" Value="{x:Static xct:TextCaseConverterType.Upper}" />
        <xct:MultiConverterParameter ConverterType="{x:Type xct:NotEqualConverter}" Value="ANDREI" />
    </x:Array>
</ResourceDictionary>
```

In your control e.g.:

 ```
<Label Text="{Binding X, Converter={StaticResource myMultiConverter}, ConverterParameter={StaticResource multiParams}}"
                VerticalOptions="CenterAndExpand" 
                HorizontalOptions="CenterAndExpand" />
```

With a binding context of:

```
BindingContext = new JustATest { X = "Andrei" };
```

### Bugs Fixed ###

- Related to issue #137 

### API Changes ###

Added: 
 
- `MultiConverter`

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation