### PR TITLE
TextDecorationFlags for TextValidationBehavior

### DIFF
--- a/XamarinCommunityToolkit/Behaviors/TextDecorationFlags.shared.cs
+++ b/XamarinCommunityToolkit/Behaviors/TextDecorationFlags.shared.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace XamarinCommunityToolkit.Behaviors
+{
+    [Flags]
+    public enum TextDecorationFlags
+    {
+        None = 0,
+        TrimStart = 1,
+        TrimEnd = 2,
+        Trim = 3,
+        NullToEmpty = 4,
+        ReduceWhiteSpaces = 8
+    }
+}

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/EmailValidationBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/EmailValidationBehaviorPage.xaml
@@ -16,7 +16,7 @@
         <Label Text="Text color will change accordingly to the style that is configured when a invalid value (email address) is entered" />
         <Entry Placeholder="Email">
             <Entry.Behaviors>
-                <behaviors:EmailValidationBehavior InvalidStyle="{StaticResource InvalidEntryStyle}"/>
+                <behaviors:EmailValidationBehavior DecorationFlags="Trim" InvalidStyle="{StaticResource InvalidEntryStyle}"/>
             </Entry.Behaviors>
         </Entry>
     </StackLayout>


### PR DESCRIPTION
### Description of Change ###

Replaces a bunch of properties by one "flags" property.

### Ticket Fixed ###
- Related to issue #149 

### API Changes ###

Added: 
 
- `TextDecorationFlags TextValidationBehavior.DecorationFlags { get; set; }`
- `TextDecorationFlags`

Removed:

 - `bool TextValidationBehavior.ShouldTrimValue`
 - `bool TextValidationBehavior.ShouldConvertNullToEmptyValue`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
    [Flags]
    public enum TextDecorationFlags
    {
        None = 0,
        TrimStart = 1,
        TrimEnd = 2,
        Trim = 3,
        NullToEmpty = 4,
        ReduceWhiteSpaces = 8
    }
```

### Behavioral Changes ###

More convenient for use (need to set up only one property with necessary flags instead of several)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation