### PR TITLE
Implement ItemSelectedEventArgsConverter in converters

### DIFF
--- a/XamarinCommunityToolkit.UnitTests/Converters/ItemSelectedEventArgsConverter_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/Converters/ItemSelectedEventArgsConverter_Tests.cs
@@ -9,7 +9,7 @@ namespace XamarinCommunityToolkit.UnitTests.Converters
 {
     public class ItemSelectedEventArgsConverter_Tests
     {
-        public static object expectedValue = 100;
+        static object expectedValue = 100;
 
         public static IEnumerable<object[]> GetData() => new List<object[]>
         {
@@ -18,7 +18,7 @@ namespace XamarinCommunityToolkit.UnitTests.Converters
 
         [Theory]
         [MemberData(nameof(GetData))]
-        public void InverterBoolConverter(SelectedItemChangedEventArgs value, object expectedResult)
+        public void ItemSelectedEventArgsConverter(SelectedItemChangedEventArgs value, object expectedResult)
         {
             var itemSelectedEventArgsConverter = new ItemSelectedEventArgsConverter();
 
@@ -28,7 +28,7 @@ namespace XamarinCommunityToolkit.UnitTests.Converters
 
         [Theory]
         [InlineData("Random String")]
-        public void InValidConverterValuesThrowArgumenException(object value)
+        public void InvalidConverterValuesThrowsArgumenException(object value)
         {
             var itemSelectedEventArgsConverter = new ItemSelectedEventArgsConverter();
             Assert.Throws<ArgumentException>(() => itemSelectedEventArgsConverter.Convert(value, typeof(ItemSelectedEventArgsConverter), null, CultureInfo.CurrentCulture));

--- a/XamarinCommunityToolkit.UnitTests/Converters/ItemSelectedEventArgsConverter_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/Converters/ItemSelectedEventArgsConverter_Tests.cs
@@ -1,0 +1,37 @@
+﻿using XamarinCommunityToolkit.Converters;
+using System.Collections.Generic;
+using System.Globalization;
+using Xamarin.Forms;
+using System;
+using Xunit;
+
+namespace XamarinCommunityToolkit.UnitTests.Converters
+{
+    public class ItemSelectedEventArgsConverter_Tests
+    {
+        public static object expectedValue = 100;
+
+        public static IEnumerable<object[]> GetData() => new List<object[]>
+        {
+            new object[] { new SelectedItemChangedEventArgs(expectedValue), expectedValue},
+        };
+
+        [Theory]
+        [MemberData(nameof(GetData))]
+        public void InverterBoolConverter(SelectedItemChangedEventArgs value, object expectedResult)
+        {
+            var itemSelectedEventArgsConverter = new ItemSelectedEventArgsConverter();
+
+            var result = itemSelectedEventArgsConverter.Convert(value, typeof(ItemSelectedEventArgsConverter), null, CultureInfo.CurrentCulture);
+            Assert.Equal(result, expectedResult);
+        }
+
+        [Theory]
+        [InlineData("Random String")]
+        public void InValidConverterValuesThrowArgumenException(object value)
+        {
+            var itemSelectedEventArgsConverter = new ItemSelectedEventArgsConverter();
+            Assert.Throws<ArgumentException>(() => itemSelectedEventArgsConverter.Convert(value, typeof(ItemSelectedEventArgsConverter), null, CultureInfo.CurrentCulture));
+        }
+    }
+}

--- a/XamarinCommunityToolkit.UnitTests/Converters/ItemTappedEventArgsConverter_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/Converters/ItemTappedEventArgsConverter_Tests.cs
@@ -9,7 +9,7 @@ namespace XamarinCommunityToolkit.UnitTests.Converters
 {
     public class ItemTappedEventArgsConverter_Tests
     {
-        public static object expectedValue = 100;
+        static object expectedValue = 100;
 
         public static IEnumerable<object[]> GetData() => new List<object[]>
             {
@@ -18,7 +18,7 @@ namespace XamarinCommunityToolkit.UnitTests.Converters
 
         [Theory]
         [MemberData(nameof(GetData))]
-        public void InverterBoolConverter(ItemTappedEventArgs value, object expectedResult)
+        public void ItemTappedEventArgsConverter(ItemTappedEventArgs value, object expectedResult)
         {
             var itemTappedEventArgsConverter = new ItemTappedEventArgsConverter();
 

--- a/XamarinCommunityToolkit/Converters/ItemSelectedEventArgsConverter.shared.cs
+++ b/XamarinCommunityToolkit/Converters/ItemSelectedEventArgsConverter.shared.cs
@@ -1,0 +1,29 @@
+﻿using XamarinCommunityToolkit.Extensions;
+using System.Globalization;
+using Xamarin.Forms;
+using System;
+
+namespace XamarinCommunityToolkit.Converters
+{
+    /// <summary>
+    /// Converts/Extracts the incoming value from SelectedItemChangedEventArgs object and returns the value of SelectedItem property from it.
+    /// </summary>
+    public class ItemSelectedEventArgsConverter : ValueConverterExtension, IValueConverter
+    {
+        /// <summary>
+        /// Converts/Extracts the incoming value from SelectedItemChangedEventArgs object and returns the value of SelectedItem property from it.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <param name="targetType">The type of the binding target property.</param>
+        /// <param name="parameter">Additional parameter for the converter to handle. Not implemented.</param>
+        /// <param name="culture">The culture to use in the converter.</param>
+        /// <returns>A SelectedItem object from object of type SelectedItemChangedEventArgs.</returns>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+           => value is SelectedItemChangedEventArgs selectedItemChangedEventArgs
+               ? selectedItemChangedEventArgs.SelectedItem
+               : throw new ArgumentException("Expected value to be of type SelectedItemChangedEventArgs", nameof(value));
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => throw new NotImplementedException();
+    }
+}

--- a/XamarinCommunityToolkitSample/Models/Converters/ConverterSectionId.cs
+++ b/XamarinCommunityToolkitSample/Models/Converters/ConverterSectionId.cs
@@ -3,6 +3,7 @@
     public enum ConverterSectionId
     {
         ItemTappedEventArgs,
+        ItemSelectedEventArgs,
     }
 
     public static class ViewSectionIdIdExtensions

--- a/XamarinCommunityToolkitSample/Pages/Converters/ConvertersGalleryPage.xaml.cs
+++ b/XamarinCommunityToolkitSample/Pages/Converters/ConvertersGalleryPage.xaml.cs
@@ -26,6 +26,7 @@ namespace XamarinCommunityToolkitSample.Pages.Converters
             => id switch
             {
                 ConverterSectionId.ItemTappedEventArgs => new ItemTappedEventArgsPage(),
+                ConverterSectionId.ItemSelectedEventArgs => new ItemSelectedEventArgsPage(),
                 _ => throw new NotImplementedException()
             };
     }

--- a/XamarinCommunityToolkitSample/Pages/Converters/ItemSelectedEventArgsPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Converters/ItemSelectedEventArgsPage.xaml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:XamarinCommunityToolkitSample.ViewModels.Converters"
+             xmlns:behaviors="clr-namespace:XamarinCommunityToolkit.Behaviors;assembly=XamarinCommunityToolkit"
+             xmlns:converters="clr-namespace:XamarinCommunityToolkit.Converters;assembly=XamarinCommunityToolkit"
+             x:Class="XamarinCommunityToolkitSample.Pages.Converters.ItemSelectedEventArgsPage">
+
+    <ContentPage.BindingContext>
+        <vm:ItemSelectedEventArgsViewModel />
+    </ContentPage.BindingContext>
+
+    <ContentPage.Resources>
+         <ResourceDictionary>
+             <converters:ItemSelectedEventArgsConverter x:Key="ItemSelectedEventArgsConverter" />
+         </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <ListView ItemsSource="{Binding Items}"
+              HasUnevenRows="True">
+        <ListView.ItemTemplate>
+            <DataTemplate>
+                <ViewCell>
+
+                    <StackLayout Orientation="Vertical"
+                                 Margin="6">
+
+                        <Label>
+                            <Label.FormattedText>
+                                <FormattedString>
+                                    <Span Text="Id:" />
+                                    <Span Text="{Binding Id}" />
+                                </FormattedString>
+                            </Label.FormattedText>
+                        </Label>
+
+                        <Label>
+                            <Label.FormattedText>
+                                <FormattedString>
+                                    <Span Text="Name:" />
+                                    <Span Text="{Binding Name}" />
+                                </FormattedString>
+                            </Label.FormattedText>
+                        </Label>
+
+                    </StackLayout>
+                </ViewCell>
+                
+            </DataTemplate>
+        </ListView.ItemTemplate>
+
+        <ListView.Behaviors>
+            <behaviors:EventToCommandBehavior EventName="ItemSelected"
+                                              Command="{Binding ItemSelectedCommand}"
+                                              EventArgsConverter="{StaticResource ItemSelectedEventArgsConverter}" />
+        </ListView.Behaviors>
+
+    </ListView>
+</ContentPage>

--- a/XamarinCommunityToolkitSample/Pages/Converters/ItemSelectedEventArgsPage.xaml.cs
+++ b/XamarinCommunityToolkitSample/Pages/Converters/ItemSelectedEventArgsPage.xaml.cs
@@ -1,0 +1,10 @@
+﻿using Xamarin.Forms;
+
+namespace XamarinCommunityToolkitSample.Pages.Converters
+{
+    public partial class ItemSelectedEventArgsPage : ContentPage
+    {
+        public ItemSelectedEventArgsPage()
+            => InitializeComponent();
+    }
+}

--- a/XamarinCommunityToolkitSample/ViewModels/Converters/ItemSelectedEventArgsViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Converters/ItemSelectedEventArgsViewModel.cs
@@ -7,14 +7,14 @@ namespace XamarinCommunityToolkitSample.ViewModels.Converters
     public class ItemSelectedEventArgsViewModel
     {
         public IEnumerable<Person> Items { get; } =
-             new List<Person>()
-             {
+            new List<Person>()
+            {
                 new Person() { Id = 1, Name = "Person 1" },
                 new Person() { Id = 2, Name = "Person 2" },
                 new Person() { Id = 3, Name = "Person 3" }
-             };
+            };
 
-        public ICommand ItemSelectedCommand { get; private set; } = new Command<Person>(async (person) =>
-             await Application.Current.MainPage.DisplayAlert("Item Selected:", person.Name, "Cancel"));
+        public ICommand ItemSelectedCommand { get; private set; } = new Command<Person>(async (person)
+            => await Application.Current.MainPage.DisplayAlert("Item Selected:", person.Name, "Cancel"));
     }
 }

--- a/XamarinCommunityToolkitSample/ViewModels/Converters/ItemSelectedEventArgsViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Converters/ItemSelectedEventArgsViewModel.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Windows.Input;
+using Xamarin.Forms;
+
+namespace XamarinCommunityToolkitSample.ViewModels.Converters
+{
+    public class ItemSelectedEventArgsViewModel
+    {
+        public IEnumerable<Person> Items { get; } =
+             new List<Person>()
+             {
+                new Person() { Id = 1, Name = "Person 1" },
+                new Person() { Id = 2, Name = "Person 2" },
+                new Person() { Id = 3, Name = "Person 3" }
+             };
+
+        public ICommand ItemSelectedCommand { get; private set; } = new Command<Person>(async (person) =>
+             await Application.Current.MainPage.DisplayAlert("Item Selected:", person.Name, "Cancel"));
+    }
+}

--- a/XamarinCommunityToolkitSample/ViewModels/Converters/ItemTappedEventArgsViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Converters/ItemTappedEventArgsViewModel.cs
@@ -14,8 +14,8 @@ namespace XamarinCommunityToolkitSample.ViewModels.Converters
                 new Person() { Id = 3, Name = "Person 3" }
             };
 
-        public ICommand ItemTappedCommand { get; private set; } = new Command<Person>(async (person) =>
-             await Application.Current.MainPage.DisplayAlert("Item Tapped:", person.Name, "Cancel"));
+        public ICommand ItemTappedCommand { get; private set; } = new Command<Person>(async (person)
+            => await Application.Current.MainPage.DisplayAlert("Item Tapped:", person.Name, "Cancel"));
     }
 
     public class Person

--- a/XamarinCommunityToolkitSample/ViewModels/Converters/ItemTappedEventArgsViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Converters/ItemTappedEventArgsViewModel.cs
@@ -14,8 +14,8 @@ namespace XamarinCommunityToolkitSample.ViewModels.Converters
                 new Person() { Id = 3, Name = "Person 3" }
             };
 
-        public ICommand ItemTappedCommand = new Command<Person>(async (person) =>
-            await Application.Current.MainPage.DisplayAlert("Item Tapped:", person.Name, "Cancel"));
+        public ICommand ItemTappedCommand { get; private set; } = new Command<Person>(async (person) =>
+             await Application.Current.MainPage.DisplayAlert("Item Tapped:", person.Name, "Cancel"));
     }
 
     public class Person


### PR DESCRIPTION
### Description of Change ###

This is a very simple converter that allows you to extract `SelectedItem` value from `ItemSelectedEventArgs` object and it can be used in combination with `EventToCommandBehavior`.

Added: 
 
- `ItemSelectedEventArgsConverter`

### Sample

```
<c:ItemSelectedEventArgsConverter x:Key="ItemSelectedEventArgsConverter" />

<ListView.Behaviors>
      <b:EventToCommandBehavior EventName="ItemSelected" 
                                Command="{Binding ItemSelectedCommand}"
                                EventArgsConverter="{StaticResource ItemSelectedArgsConverter}" />
</ListView.Behaviors>   
```

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of master at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation