### PR TITLE
Fixed project reference for main solution

### DIFF
--- a/XamarinCommunityToolkit.sln
+++ b/XamarinCommunityToolkit.sln
@@ -1,7 +1,8 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XamarinCommunityToolkit", "XamarinCommunityToolkit\XamarinCommunityToolkit.csproj", "{EEE96FCB-F0A5-4692-9852-8D018C5C4536}"
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30320.27
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Toolkit.Xamarin.Forms", "XamarinCommunityToolkit\Microsoft.Toolkit.Xamarin.Forms.csproj", "{A60AC9C0-F01A-4CA6-B967-F774343A5290}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -9,9 +10,15 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EEE96FCB-F0A5-4692-9852-8D018C5C4536}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EEE96FCB-F0A5-4692-9852-8D018C5C4536}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EEE96FCB-F0A5-4692-9852-8D018C5C4536}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EEE96FCB-F0A5-4692-9852-8D018C5C4536}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A60AC9C0-F01A-4CA6-B967-F774343A5290}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A60AC9C0-F01A-4CA6-B967-F774343A5290}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A60AC9C0-F01A-4CA6-B967-F774343A5290}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A60AC9C0-F01A-4CA6-B967-F774343A5290}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0E25B668-D1CB-4A23-9EA6-EE710C8E148A}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
### Description of Change ###

The main solution file XamarinCommunityToolkit.sln has been fixed to reference the newly renamed project (Microsoft.Toolkit.Xamarin.Forms).

I've chosen to disregard the PR checklist for this PR since it doesn't really add any functionality.

### Bugs Fixed ###

No reported bugs, but I got an error when I tried to open the solution. The sample solution worked fine, so I just removed the project from the main solution and added the reference back with the new project name.

### API Changes ###

None.

### Behavioral Changes ###

None.