### PR TITLE
Add observable collection extensions

### DIFF
--- a/XamarinCommunityToolkit/Extensions/ObservableCollectionExtension.shared.cs
+++ b/XamarinCommunityToolkit/Extensions/ObservableCollectionExtension.shared.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Microsoft.Toolkit.Xamarin.Forms.Extensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="ObservableCollection{T}"/>.
+    /// </summary>
+    public static class ObservableCollectionExtension
+    {
+        /// <summary>
+        /// Adds a range of items to a <paramref name="collection"/>.
+        /// </summary>
+        /// <param name="collection">Collection where the items will be added to.</param>
+        /// <param name="items">Items to add to the collection.</param>
+        public static void AddRange<T>(this ObservableCollection<T> collection, IEnumerable<T> items)
+        {
+            foreach (var item in items)
+            {
+                collection.Add(item);
+            }
+        }
+
+        /// <summary>
+        /// Sets a range of items in a <paramref name="collection"/> and clears existing items.
+        /// </summary>
+        /// <param name="collection">Collection where the items will be added to.</param>
+        /// <param name="items">Items to set in the collection.</param>
+        public static void SetRange<T>(this ObservableCollection<T> collection, IEnumerable<T> items)
+        {
+            collection.Clear();
+            collection.AddRange(items);
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

Adds helpfull extension methods for `ObservableCollection<T>`. 

### Bugs Fixed ###

none

### API Changes ###

Added: 
 
- `public static void AddRange(this ObservableCollection<T> collection, IEnumerable<T> items)`
- `public static void SetRange(this ObservableCollection<T> collection, IEnumerable<T> items)`
 
### Behavioral Changes ###

none 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description) -> Can add some if this is interesting
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation