### PR TITLE
Fixed project name in solution file

### DIFF
--- a/XamarinCommunityToolkit.sln
+++ b/XamarinCommunityToolkit.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30320.27
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Toolkit.Xamarin.Forms", "XamarinCommunityToolkit\Microsoft.Toolkit.Xamarin.Forms.csproj", "{A60AC9C0-F01A-4CA6-B967-F774343A5290}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.CommunityToolkit", "XamarinCommunityToolkit\Xamarin.CommunityToolkit.csproj", "{A60AC9C0-F01A-4CA6-B967-F774343A5290}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This is just a small fix to allow us to load the XamarinCommunity project using the `XamarinCommunityToolkit.sln`

Error:
"The project file cannot be found."
![image](https://user-images.githubusercontent.com/20712372/89959695-7134da80-dc13-11ea-883d-fe8bfd537453.png)
