### PR TITLE
Make Xamarin CommunityToolkit linker safe

### DIFF
--- a/XamarinCommunityToolkit/AssemblyInfo/AssemblyInfo.android.cs
+++ b/XamarinCommunityToolkit/AssemblyInfo/AssemblyInfo.android.cs
@@ -1,3 +1,3 @@
 ﻿using Android;
 
-//[assembly:LinkerSafe]
+[assembly:LinkerSafe]

--- a/XamarinCommunityToolkit/AssemblyInfo/AssemblyInfo.android.cs
+++ b/XamarinCommunityToolkit/AssemblyInfo/AssemblyInfo.android.cs
@@ -1,0 +1,3 @@
+﻿using Android;
+
+//[assembly:LinkerSafe]

--- a/XamarinCommunityToolkit/AssemblyInfo/AssemblyInfo.ios.tvos.watchos.macos.cs
+++ b/XamarinCommunityToolkit/AssemblyInfo/AssemblyInfo.ios.tvos.watchos.macos.cs
@@ -1,0 +1,3 @@
+﻿using Foundation;
+
+[assembly: LinkerSafe]


### PR DESCRIPTION
### Description of Change ###
Bring some of the linker love to this library, now the output dll is the same size in `Linker all` or` Link Framework SDKs Only`

### Bugs Fixed ###

As we discuss on the Discord server, we want this lib to be linker safe, this way devs don't need to use `Linker all` to strip out unused code.

### API Changes ###

Added two files inside the `AssemblyInfo` folder the LinkerSafe attribute in `Android` and `iOS` platform.

Added: 
` [assembly: LinkerSafe]`


### Behavioral Changes ###

Now when the build is configured to `Link Framework SDKs Only` the XamarinCommunityToolkit will remove unused code.

### Steps to test ###

Test this isn't obvious so I'll describe how I validated this. I create a blank project and add the XamarinCommunityToolkit (XCT) to it, and just use one item from the lib.

```csharp 
var area = new Xamarin.CommunityToolkit.Helpers.SafeArea(); 
``` 

1. On my iOS project (using debug mode), I set the `Linker Behaviour` as `None` and deploy it into a simulator. 
2. Go to output folder `obj\iPhoneSimulator\Debug\device-builds\Your-Simulator\mtouch-cache` 
3. in this folder a look into the `1-Link` folder and search for the XCT dll and see his size (63kb).
4. Also a look into the `3-Build` folder and search for the XCT dll and see his size (63)kb

Then I clean my solution and change my `Linker Behaviour` to `Link Framework SDKs Only`, repeat all steps above, and now on `step 3` the dll should be 63kb but on `step 4` the dll is 9kb.

If you run using the `Linker Behaviour` as `Linker all` the result should be the same as the `Link Framework SDKs Only`

<img width="1071" alt="Screen Shot 2020-08-18 at 22 16 51" src="https://user-images.githubusercontent.com/20712372/90580973-858f4f00-e1a0-11ea-9cb4-2c179ce6e052.png">

The linker doesn't run when we build the project (`bin` folder) so we need to do all these steps.

**I'm 99% sure that is the right way to test.**

### References ###

https://docs.microsoft.com/pt-br/xamarin/ios/deploy-test/linker?tabs=windows#marking-your-assembly-as-linker-ready
https://github.com/xamarin/Essentials/tree/develop/Xamarin.Essentials/AssemblyInfo
https://github.com/xamarin/Essentials/pull/1209#discussion_r405051562

James Clancey and James Montemagno playing with Linker:
https://youtu.be/aEMTb-yDs5A?t=4097

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation