### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,7 @@ indent_size = 4
 # Code files
 [*.{cs,csx,vb,vbx}]
 indent_style = tab
+indent_size = 4
 
 # Code files
 [*.sln]


### PR DESCRIPTION
Tabs in https://github.com/xamarin/XamarinCommunityToolkit/pull/209 were rendering wider than 4 spaces
