### PR TITLE
Multi binding sample

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,14 @@ Any proposals for new feature work and new APIs should follow the spirit of thes
  * New features should have native APIs available to allow implementation on a reasonable subset of the supported platforms, especially  (iOS, Android, UWP)
  * No new external dependencies should be added to support implementation of new feature work (there can be exceptions but they must be thoroughly considered for the value being added)
 
+#### Approval Process
+* Provide as much detail as possible so the team and community can have a good discussion about your proposal.
+* If the proposal is for a complex issue more detailed specifications might need to be created.
+* For especially large proposals consider how it could be broken up into multiple proposals to make it easier to review. 
+* When you think your proposal is ready to be implemented ask for approval from the XamarinCommunityToolkit team.
+* One or more approvals from XamarinCommunityToolkit team are required to approve a proposal. The number of required approvers will be based on the size and complexity of the proposal.
+* Once the proposal is approved by the XamarinCommunityToolkit team you can ask to be assigned the proposal and you can start on a PR.
+
 #### Proposal States
 ##### Open
 Open proposals are still under discussion. Please leave your concrete, constructive feedback on this proposal. +1s and other clutter posts which do not add to the discussion will be removed.

--- a/XamarinCommunityToolkitSample/Pages/Converters/MultiConverterPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Converters/MultiConverterPage.xaml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pages:BasePage
+    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:xct="clr-namespace:Xamarin.CommunityToolkit.Converters;assembly=Xamarin.CommunityToolkit"
+    xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Converters"
+    x:Class="Xamarin.CommunityToolkit.Sample.Pages.Converters.MultiConverterPage"
+    xmlns:resources="clr-namespace:Xamarin.CommunityToolkit.Sample.Resx">
+    <pages:BasePage.Resources>
+        <ResourceDictionary>
+            <xct:MultiConverter
+                x:Key="myMultiConverter">
+                <xct:TextCaseConverter />
+                <xct:NotEqualConverter />
+            </xct:MultiConverter>
+            <x:Array
+                x:Key="multiParams"
+                Type="{x:Type xct:MultiConverterParameter}">
+                <xct:MultiConverterParameter
+                    ConverterType="{x:Type xct:TextCaseConverter}"
+                    Value="{x:Static xct:TextCaseType.Upper}" />
+                <xct:MultiConverterParameter
+                    ConverterType="{x:Type xct:NotEqualConverter}"
+                    Value="ANDREI" />
+            </x:Array>
+        </ResourceDictionary>
+    </pages:BasePage.Resources>
+    <pages:BasePage.BindingContext>
+        <vm:MultiConverterViewModel />
+    </pages:BasePage.BindingContext>
+    <pages:BasePage.Content>
+        <StackLayout>
+            <Label Text="{x:Static resources:AppResources.MultiConverterDescription}" />
+            <Entry Text="{Binding EnteredName}"></Entry>
+            <Label Text="{Binding EnteredName, Converter={StaticResource myMultiConverter}, ConverterParameter={StaticResource multiParams}}"
+               HorizontalOptions="CenterAndExpand" />
+        </StackLayout>
+    </pages:BasePage.Content>
+</pages:BasePage>

--- a/XamarinCommunityToolkitSample/Pages/Converters/MultiConverterPage.xaml.cs
+++ b/XamarinCommunityToolkitSample/Pages/Converters/MultiConverterPage.xaml.cs
@@ -1,0 +1,14 @@
+using System;
+using Xamarin.Forms;
+
+
+namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
+{
+    public partial class MultiConverterPage 
+    {
+        public MultiConverterPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/XamarinCommunityToolkitSample/Resx/AppResources.Designer.cs
+++ b/XamarinCommunityToolkitSample/Resx/AppResources.Designer.cs
@@ -421,6 +421,24 @@ namespace Xamarin.CommunityToolkit.Sample.Resx {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This sample demonstrates how to use the MultiBinding Converter with the NotEqualConverter and the TextCaseConverter. It converts the entered text to Upper Case and checks that it is Not Equal to the string &apos;ANDREI&apos;..
+        /// </summary>
+        internal static string MultiConverterDescription {
+            get {
+                return ResourceManager.GetString("MultiConverterDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This sample demonstrates how to use Multibinding Converter.
+        /// </summary>
+        internal static string MultiConverterShortDescription {
+            get {
+                return ResourceManager.GetString("MultiConverterShortDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name.
         /// </summary>
         internal static string Name {

--- a/XamarinCommunityToolkitSample/Resx/AppResources.Designer.cs
+++ b/XamarinCommunityToolkitSample/Resx/AppResources.Designer.cs
@@ -240,18 +240,6 @@ namespace Xamarin.CommunityToolkit.Sample.Resx {
             }
         }
         
-        internal static string UriValidationDescription {
-            get {
-                return ResourceManager.GetString("UriValidationDescription", resourceCulture);
-            }
-        }
-        
-        internal static string UriValidationShortDescription {
-            get {
-                return ResourceManager.GetString("UriValidationShortDescription", resourceCulture);
-            }
-        }
-
         /// <summary>
         ///   Looks up a localized string similar to This sample demonstrates how to use EventToCommandBehavior. Here we observe Clicked event of the button and trigger IncrementCommand from ViewModel..
         /// </summary>
@@ -735,6 +723,24 @@ namespace Xamarin.CommunityToolkit.Sample.Resx {
         internal static string UpperThumbViewSet {
             get {
                 return ResourceManager.GetString("UpperThumbViewSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This sample demonstrates how to use UriValidationBehavior to validate if a given Uri is absolute or relative..
+        /// </summary>
+        internal static string UriValidationDescription {
+            get {
+                return ResourceManager.GetString("UriValidationDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Behavior for validating Uris.
+        /// </summary>
+        internal static string UriValidationShortDescription {
+            get {
+                return ResourceManager.GetString("UriValidationShortDescription", resourceCulture);
             }
         }
         

--- a/XamarinCommunityToolkitSample/Resx/AppResources.resx
+++ b/XamarinCommunityToolkitSample/Resx/AppResources.resx
@@ -354,4 +354,10 @@
   <data name="Time" xml:space="preserve">
     <value>Time</value>
   </data>
+  <data name="UriValidationDescription" xml:space="preserve">
+    <value>This sample demonstrates how to use UriValidationBehavior to validate if a given Uri is absolute or relative.</value>
+  </data>
+  <data name="UriValidationShortDescription" xml:space="preserve">
+    <value>Behavior for validating Uris</value>
+  </data>
 </root>

--- a/XamarinCommunityToolkitSample/Resx/AppResources.resx
+++ b/XamarinCommunityToolkitSample/Resx/AppResources.resx
@@ -360,4 +360,10 @@
   <data name="UriValidationShortDescription" xml:space="preserve">
     <value>Behavior for validating Uris</value>
   </data>
+  <data name="MultiConverterDescription" xml:space="preserve">
+    <value>This sample demonstrates how to use the MultiBinding Converter with the NotEqualConverter and the TextCaseConverter. It converts the entered text to Upper Case and checks that it is Not Equal to the string 'ANDREI'.</value>
+  </data>
+  <data name="MultiConverterShortDescription" xml:space="preserve">
+    <value>This sample demonstrates how to use Multibinding Converter</value>
+  </data>
 </root>

--- a/XamarinCommunityToolkitSample/ViewModels/Converters/ConvertersGalleryViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Converters/ConvertersGalleryViewModel.cs
@@ -28,7 +28,14 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
                 "ByteArrayToImageSource",
                 Color.FromHex("#498205"),
                 AppResources.ByteArrayToImageSourceShortDescription
-            )
+            ),
+
+            new SectionModel(
+                typeof(MultiConverterPage),
+                "MultiConverter",
+                Color.FromHex("#CC0000"),
+                AppResources.MultiConverterShortDescription
+            ),
         };
     }
 }

--- a/XamarinCommunityToolkitSample/ViewModels/Converters/MultiConverterViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Converters/MultiConverterViewModel.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
+{
+	public class MultiConverterViewModel : BaseViewModel
+	{
+		string enteredName = "Steven";
+		public string EnteredName
+		{
+			get => enteredName;
+			set
+			{
+				Set(ref enteredName, value);
+			}
+		}
+	}
+}


### PR DESCRIPTION
**DO NOT MERGE** This PR relies on changes in #218, make sure it is merged in before this one. 

### Description of Change ###

Adds a sample for Multiconverters. It is closely based on the sample from the comments on the original PR #137 .

The sample demonstrates using the `MuliConverter` in conjunction with the `NotEqualConverter` and the `TextCaseConverter` to check that an entered string is not the same as a given string, converting the entered string to upper case.

![2020-08-20 22 17 36](https://user-images.githubusercontent.com/29908924/90769127-15650280-e333-11ea-991a-691ebd8355b4.gif)

### Bugs Fixed ###

- Fixes #168 
- Adds sample for #137 
- Tests already added in #156

### API Changes ###

None

Added: 
- MultiConverterPage
- MultiConverterViewModel
- MultiConverterDescription in resx
- MultiConverterShortDescription in resx

Changed:

 - `Items` in ConverterGalleryViewModel to include new sample

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation