### PR TITLE
Set android Toolbar item color

### DIFF
--- a/XamarinCommunityToolkitSample.Android/Resources/values/styles.xml
+++ b/XamarinCommunityToolkitSample.Android/Resources/values/styles.xml
@@ -21,6 +21,7 @@
     <item name="windowActionModeOverlay">true</item>
 
     <item name="android:datePickerDialogTheme">@style/AppCompatDialogStyle</item>
+    <item name="android:actionMenuTextColor"> #5D5D5D </item>
   </style>
 
   <style name="AppCompatDialogStyle" parent="Theme.AppCompat.Light.Dialog">


### PR DESCRIPTION
Updated toolbar item color to #5D5D5D which matches `NavigationBarTextColor` from App.xaml.

Old color was white text on white background

@jfversluis once commented on a question about this that I encountered while fixing this, I gave it an upvote.

![Screen Shot 2020-08-25 at 8 20 16 pm](https://user-images.githubusercontent.com/29908924/91164854-19b66480-e713-11ea-9772-69d4c485b638.png)

### Description of Change ###

Changed the Toolbar background color.

### Bugs Fixed ###

Fixed #231 

### API Changes ###

None, sample code only

### Behavioral Changes ###

Users can now use Settings and About page without being psychic

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation