### PR TITLE
Set Default Language in UWP to fix blank text resources

### DIFF
--- a/XamarinCommunityToolkitSample/AssemblyInfo.cs
+++ b/XamarinCommunityToolkitSample/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+using System.Resources;
 using Xamarin.Forms.Xaml;
 
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
+
+[assembly: NeutralResourcesLanguage("en")]


### PR DESCRIPTION
Added default language in sample app. Without this UWP has Null for all resources until a language is set.

### Description of Change ###

Set NeutralResourcesLanguage to `en`

### Bugs Fixed ###

Fixes #230 

### API Changes ###
None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated documentation