### PR TITLE
Added some unit tests to check namespaces

### DIFF
--- a/XamarinCommunityToolkit.UnitTests/ConvertersNamespace_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/ConvertersNamespace_Tests.cs
@@ -1,0 +1,61 @@
+﻿using System.Linq;
+using System.Reflection;
+using Xamarin.CommunityToolkit.Behaviors;
+using Xamarin.Forms;
+using Xunit;
+
+namespace Xamarin.CommunityToolkit.UnitTests
+{
+	public class Namespace_Tests
+	{
+		[Fact]
+		public void MakeSureConvertersAreInTheRightNamespace()
+		{
+			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
+			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Converter") && t.GetInterface("IValueConverter") != null))
+			{
+				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Converters"), $"{type.FullName} not in Xamarin.CommunityToolkit.Converters namespace");
+			}
+		}
+
+		[Fact]
+		public void MakeSureEffectsAreInTheRightNamespace()
+		{
+			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
+			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Effect") && t.IsClass && t.IsSealed && t.IsAbstract))
+			{
+				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Effects"), $"{type.FullName} not in Xamarin.CommunityToolkit.Effects namespace");
+			}
+		}
+
+		[Fact]
+		public void MakeSureMarkupExtensionsAreInTheRightNamespace()
+		{
+			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
+			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Extension") && t.GetInterface("IMarkupExtension") != null))
+			{
+				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Extensions"), $"{type.FullName} not in Xamarin.CommunityToolkit.Extensions namespace");
+			}
+		}
+
+		[Fact]
+		public void MakeSureBehaviorsAreInTheRightNamespace()
+		{
+			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
+			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Behavior") && t.IsSubclassOf(typeof(BaseBehavior))))
+			{
+				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Behaviors"), $"{type.FullName} not in Xamarin.CommunityToolkit.Behaviors namespace");
+			}
+		}
+
+		[Fact]
+		public void MakeSureViewsAreInTheRightNamespace()
+		{
+			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
+			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("View") && t.IsSubclassOf(typeof(View))))
+			{
+				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.UI.Views"), $"{type.FullName} not in Xamarin.CommunityToolkit.UI.Views namespace");
+			}
+		}
+	}
+}

--- a/XamarinCommunityToolkit.UnitTests/ConvertersNamespace_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/ConvertersNamespace_Tests.cs
@@ -1,6 +1,9 @@
 ﻿using System.Linq;
 using System.Reflection;
 using Xamarin.CommunityToolkit.Behaviors;
+using Xamarin.CommunityToolkit.Converters;
+using Xamarin.CommunityToolkit.Effects;
+using Xamarin.CommunityToolkit.Extensions;
 using Xamarin.Forms;
 using Xunit;
 
@@ -11,7 +14,7 @@ namespace Xamarin.CommunityToolkit.UnitTests
 		[Fact]
 		public void MakeSureConvertersAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(InvertedBoolConverter)).GetTypes();
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Converter") && t.GetInterface("IValueConverter") != null))
 			{
 				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Converters"), $"{type.FullName} not in Xamarin.CommunityToolkit.Converters namespace");
@@ -21,7 +24,7 @@ namespace Xamarin.CommunityToolkit.UnitTests
 		[Fact]
 		public void MakeSureEffectsAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(SafeAreaEffect)).GetTypes();
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Effect") && t.IsClass && t.IsSealed && t.IsAbstract))
 			{
 				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Effects"), $"{type.FullName} not in Xamarin.CommunityToolkit.Effects namespace");
@@ -31,7 +34,7 @@ namespace Xamarin.CommunityToolkit.UnitTests
 		[Fact]
 		public void MakeSureMarkupExtensionsAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(TranslateExtension)).GetTypes();
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Extension") && t.GetInterface("IMarkupExtension") != null))
 			{
 				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Extensions"), $"{type.FullName} not in Xamarin.CommunityToolkit.Extensions namespace");
@@ -52,7 +55,7 @@ namespace Xamarin.CommunityToolkit.UnitTests
 		public void MakeSureViewsAreInTheRightNamespace()
 		{
 			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
-			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("View") && t.IsSubclassOf(typeof(View))))
+			foreach (var type in allTheTypes.Where(t => t.IsSubclassOf(typeof(View))))
 			{
 				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.UI.Views"), $"{type.FullName} not in Xamarin.CommunityToolkit.UI.Views namespace");
 			}

--- a/XamarinCommunityToolkit.UnitTests/ConvertersNamespace_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/ConvertersNamespace_Tests.cs
@@ -16,8 +16,9 @@ namespace Xamarin.CommunityToolkit.UnitTests
 		{
 			var allTheTypes = Assembly.GetAssembly(typeof(InvertedBoolConverter)).GetTypes();
 
-			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Converter") && t.GetInterface("IValueConverter") != null))
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Converters"), $"{type.FullName} not in Xamarin.CommunityToolkit.Converters namespace");
+			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Converter") && t.GetInterface(nameof(IValueConverter)) != null))
+				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Converters"),
+					$"{type.FullName} not in Xamarin.CommunityToolkit.Converters namespace");
 		}
 
 		[Fact]
@@ -26,7 +27,8 @@ namespace Xamarin.CommunityToolkit.UnitTests
 			var allTheTypes = Assembly.GetAssembly(typeof(SafeAreaEffect)).GetTypes();
 
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Effect") && t.IsClass && t.IsSealed && t.IsAbstract))
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Effects"), $"{type.FullName} not in Xamarin.CommunityToolkit.Effects namespace");
+				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Effects"),
+					$"{type.FullName} not in Xamarin.CommunityToolkit.Effects namespace");
 		}
 
 		[Fact]
@@ -35,7 +37,8 @@ namespace Xamarin.CommunityToolkit.UnitTests
 			var allTheTypes = Assembly.GetAssembly(typeof(TranslateExtension)).GetTypes();
 
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Extension") && t.GetInterface("IMarkupExtension") != null))
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Extensions"), $"{type.FullName} not in Xamarin.CommunityToolkit.Extensions namespace");
+				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Extensions"),
+					$"{type.FullName} not in nameof(Xamarin.CommunityToolkit.Extensions namespace");
 		}
 
 		[Fact]
@@ -44,7 +47,8 @@ namespace Xamarin.CommunityToolkit.UnitTests
 			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
 
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Behavior") && t.IsSubclassOf(typeof(BaseBehavior))))
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Behaviors"), $"{type.FullName} not in Xamarin.CommunityToolkit.Behaviors namespace");
+				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Behaviors"),
+					$"{type.FullName} not in Xamarin.CommunityToolkit.Behaviors namespace");
 		}
 
 		[Fact]
@@ -53,7 +57,8 @@ namespace Xamarin.CommunityToolkit.UnitTests
 			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
 
 			foreach (var type in allTheTypes.Where(t => t.IsSubclassOf(typeof(View))))
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.UI.Views"), $"{type.FullName} not in Xamarin.CommunityToolkit.UI.Views namespace");
+				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.UI.Views"),
+					$"{type.FullName} not in Xamarin.CommunityToolkit.UI.Views namespace");
 		}
 	}
 }

--- a/XamarinCommunityToolkit.UnitTests/ConvertersNamespace_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/ConvertersNamespace_Tests.cs
@@ -15,50 +15,45 @@ namespace Xamarin.CommunityToolkit.UnitTests
 		public void MakeSureConvertersAreInTheRightNamespace()
 		{
 			var allTheTypes = Assembly.GetAssembly(typeof(InvertedBoolConverter)).GetTypes();
+
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Converter") && t.GetInterface("IValueConverter") != null))
-			{
 				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Converters"), $"{type.FullName} not in Xamarin.CommunityToolkit.Converters namespace");
-			}
 		}
 
 		[Fact]
 		public void MakeSureEffectsAreInTheRightNamespace()
 		{
 			var allTheTypes = Assembly.GetAssembly(typeof(SafeAreaEffect)).GetTypes();
+
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Effect") && t.IsClass && t.IsSealed && t.IsAbstract))
-			{
 				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Effects"), $"{type.FullName} not in Xamarin.CommunityToolkit.Effects namespace");
-			}
 		}
 
 		[Fact]
 		public void MakeSureMarkupExtensionsAreInTheRightNamespace()
 		{
 			var allTheTypes = Assembly.GetAssembly(typeof(TranslateExtension)).GetTypes();
+
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Extension") && t.GetInterface("IMarkupExtension") != null))
-			{
 				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Extensions"), $"{type.FullName} not in Xamarin.CommunityToolkit.Extensions namespace");
-			}
 		}
 
 		[Fact]
 		public void MakeSureBehaviorsAreInTheRightNamespace()
 		{
 			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
+
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Behavior") && t.IsSubclassOf(typeof(BaseBehavior))))
-			{
 				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Behaviors"), $"{type.FullName} not in Xamarin.CommunityToolkit.Behaviors namespace");
-			}
 		}
 
 		[Fact]
 		public void MakeSureViewsAreInTheRightNamespace()
 		{
 			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior)).GetTypes();
+
 			foreach (var type in allTheTypes.Where(t => t.IsSubclassOf(typeof(View))))
-			{
 				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.UI.Views"), $"{type.FullName} not in Xamarin.CommunityToolkit.UI.Views namespace");
-			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Don't know if this makes any sense, but digging into the code the other day I noticed how easy it is to mix up namespaces. This will be especially true when working with extra subfolders like with `CameraView`.

Samples not added because... Tests.

If this does not make any sense to anyone, please tell me as well :D 
Or if you have ideas on how to add more checks like these.

### Bugs Fixed ###

N/A

### Behavioral Changes ###

N/A

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description) doh
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation