### PR TITLE
use decimal separator from current culture

### DIFF
--- a/XamarinCommunityToolkit.UnitTests/Behaviors/NumericValidationBehavior_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/Behaviors/NumericValidationBehavior_Tests.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.CommunityToolkit.Behaviors;
+﻿using System.Globalization;
+using Xamarin.CommunityToolkit.Behaviors;
 using Xamarin.CommunityToolkit.UnitTests.Mocks;
 using Xamarin.Forms;
 using Xunit;
@@ -12,39 +13,62 @@ namespace Xamarin.CommunityToolkit.UnitTests.Behaviors
 
 		[Theory]
 		// Positive
-		[InlineData("15.2", 1.0, 16.0, 0, 16, true)]
-		[InlineData("15.", 1.0, 16.0, 0, 1, true)]
-		[InlineData("15.88", 1.0, 16.0, 2, 2, true)]
-		[InlineData("0.99", 0.9, 2.0, 0, 16, true)]
-		[InlineData(".99", 0.9, 2.0, 0, 16, true)]
+		[InlineData("en-US", "15.2", 1.0, 16.0, 0, 16, true)]
+		[InlineData("en-US", "15.", 1.0, 16.0, 0, 1, true)]
+		[InlineData("en-US", "15.88", 1.0, 16.0, 2, 2, true)]
+		[InlineData("en-US", "0.99", 0.9, 2.0, 0, 16, true)]
+		[InlineData("en-US", ".99", 0.9, 2.0, 0, 16, true)]
+		[InlineData("de-DE", "15,2", 1.0, 16.0, 0, 16, true)]
+		[InlineData("de-DE", "15,", 1.0, 16.0, 0, 1, true)]
+		[InlineData("de-DE", "15,88", 1.0, 16.0, 2, 2, true)]
+		[InlineData("de-DE", "0,99", 0.9, 2.0, 0, 16, true)]
+		[InlineData("de-DE", ",99", 0.9, 2.0, 0, 16, true)]
 		// Negative
-		[InlineData("15.3", 16.0, 20.0, 0, 16, false)]
-		[InlineData("15.3", 0.0, 15.0, 0, 16, false)]
-		[InlineData("15.", 1.0, 16.0, 0, 0, false)]
-		[InlineData(".7", 0.0, 16.0, 0, 0, false)]
-		[InlineData("15", 1.0, 16.0, 1, 16, false)]
-		[InlineData("", 0.0, 16.0, 0, 16, false)]
-		[InlineData(" ", 0.0, 16.0, 0, 16, false)]
-		[InlineData(null, 0.0, 16.0, 0, 16, false)]
-		public void IsValid(string value, double minValue, double maxValue, int minDecimalPlaces, int maxDecimalPlaces, bool expectedValue)
+		[InlineData("en-US", "15.3", 16.0, 20.0, 0, 16, false)]
+		[InlineData("en-US", "15.3", 0.0, 15.0, 0, 16, false)]
+		[InlineData("en-US", "15.", 1.0, 16.0, 0, 0, false)]
+		[InlineData("en-US", ".7", 0.0, 16.0, 0, 0, false)]
+		[InlineData("en-US", "15", 1.0, 16.0, 1, 16, false)]
+		[InlineData("en-US", "", 0.0, 16.0, 0, 16, false)]
+		[InlineData("en-US", " ", 0.0, 16.0, 0, 16, false)]
+		[InlineData("en-US", null, 0.0, 16.0, 0, 16, false)]
+		[InlineData("de-DE", "15,3", 16.0, 20.0, 0, 16, false)]
+		[InlineData("de-DE", "15,3", 0.0, 15.0, 0, 16, false)]
+		[InlineData("de-DE", "15,", 1.0, 16.0, 0, 0, false)]
+		[InlineData("de-DE", ",7", 0.0, 16.0, 0, 0, false)]
+		[InlineData("de-DE", "15", 1.0, 16.0, 1, 16, false)]
+		[InlineData("de-DE", "", 0.0, 16.0, 0, 16, false)]
+		[InlineData("de-DE", " ", 0.0, 16.0, 0, 16, false)]
+		[InlineData("de-DE", null, 0.0, 16.0, 0, 16, false)]
+		public void IsValid(string culture, string value, double minValue, double maxValue, int minDecimalPlaces, int maxDecimalPlaces, bool expectedValue)
 		{
-			var behavior = new NumericValidationBehavior
+			var origCulture = CultureInfo.CurrentCulture;
+			CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+
+			try
 			{
-				MinimumValue = minValue,
-				MaximumValue = maxValue,
-				MinimumDecimalPlaces = minDecimalPlaces,
-				MaximumDecimalPlaces = maxDecimalPlaces
-			};
-			new Entry
-			{
-				Text = value,
-				Behaviors =
+				var behavior = new NumericValidationBehavior
+				{
+					MinimumValue = minValue,
+					MaximumValue = maxValue,
+					MinimumDecimalPlaces = minDecimalPlaces,
+					MaximumDecimalPlaces = maxDecimalPlaces
+				};
+				new Entry
+				{
+					Text = value,
+					Behaviors =
 				{
 					behavior
 				}
-			};
-			behavior.ForceValidate();
-			Assert.Equal(expectedValue, behavior.IsValid);
+				};
+				behavior.ForceValidate();
+				Assert.Equal(expectedValue, behavior.IsValid);
+			}
+			finally
+			{
+				CultureInfo.CurrentCulture = origCulture;
+			}
 		}
 	}
 }

--- a/XamarinCommunityToolkit.UnitTests/Behaviors/NumericValidationBehavior_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/Behaviors/NumericValidationBehavior_Tests.cs
@@ -58,9 +58,9 @@ namespace Xamarin.CommunityToolkit.UnitTests.Behaviors
 				{
 					Text = value,
 					Behaviors =
-				{
-					behavior
-				}
+					{
+						behavior
+					}
 				};
 				behavior.ForceValidate();
 				Assert.Equal(expectedValue, behavior.IsValid);

--- a/XamarinCommunityToolkit.UnitTests/Behaviors/NumericValidationBehavior_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/Behaviors/NumericValidationBehavior_Tests.cs
@@ -18,11 +18,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.Behaviors
 		[InlineData("en-US", "15.88", 1.0, 16.0, 2, 2, true)]
 		[InlineData("en-US", "0.99", 0.9, 2.0, 0, 16, true)]
 		[InlineData("en-US", ".99", 0.9, 2.0, 0, 16, true)]
+		[InlineData("en-US", "1,115.2", 1.0, 2000.0, 0, 16, true)]
 		[InlineData("de-DE", "15,2", 1.0, 16.0, 0, 16, true)]
 		[InlineData("de-DE", "15,", 1.0, 16.0, 0, 1, true)]
 		[InlineData("de-DE", "15,88", 1.0, 16.0, 2, 2, true)]
 		[InlineData("de-DE", "0,99", 0.9, 2.0, 0, 16, true)]
 		[InlineData("de-DE", ",99", 0.9, 2.0, 0, 16, true)]
+		[InlineData("de-DE", "1.115,2", 1.0, 2000.0, 0, 16, true)]
 		// Negative
 		[InlineData("en-US", "15.3", 16.0, 20.0, 0, 16, false)]
 		[InlineData("en-US", "15.3", 0.0, 15.0, 0, 16, false)]
@@ -32,6 +34,8 @@ namespace Xamarin.CommunityToolkit.UnitTests.Behaviors
 		[InlineData("en-US", "", 0.0, 16.0, 0, 16, false)]
 		[InlineData("en-US", " ", 0.0, 16.0, 0, 16, false)]
 		[InlineData("en-US", null, 0.0, 16.0, 0, 16, false)]
+		[InlineData("en-US", "15,2", 1.0, 16.0, 0, 16, false)]
+		[InlineData("en-US", "1.115,2", 1.0, 2000.0, 0, 16, false)]
 		[InlineData("de-DE", "15,3", 16.0, 20.0, 0, 16, false)]
 		[InlineData("de-DE", "15,3", 0.0, 15.0, 0, 16, false)]
 		[InlineData("de-DE", "15,", 1.0, 16.0, 0, 0, false)]
@@ -40,6 +44,8 @@ namespace Xamarin.CommunityToolkit.UnitTests.Behaviors
 		[InlineData("de-DE", "", 0.0, 16.0, 0, 16, false)]
 		[InlineData("de-DE", " ", 0.0, 16.0, 0, 16, false)]
 		[InlineData("de-DE", null, 0.0, 16.0, 0, 16, false)]
+		[InlineData("de-DE", "15.2", 1.0, 16.0, 0, 16, false)]
+		[InlineData("de-DE", "1,115.2", 1.0, 2000.0, 0, 16, false)]
 		public void IsValid(string culture, string value, double minValue, double maxValue, int minDecimalPlaces, int maxDecimalPlaces, bool expectedValue)
 		{
 			var origCulture = CultureInfo.CurrentCulture;

--- a/XamarinCommunityToolkit/Behaviors/Validators/NumericValidationBehavior.shared.cs
+++ b/XamarinCommunityToolkit/Behaviors/Validators/NumericValidationBehavior.shared.cs
@@ -1,11 +1,10 @@
-﻿using Xamarin.Forms;
+﻿using System.Globalization;
+using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Behaviors
 {
 	public class NumericValidationBehavior : ValidationBehavior
 	{
-		const char decimalPartDelimeter = '.';
-
 		public static readonly BindableProperty MinimumValueProperty =
 			BindableProperty.Create(nameof(MinimumValue), typeof(double), typeof(NumericValidationBehavior), double.NegativeInfinity, propertyChanged: OnValidationPropertyChanged);
 
@@ -53,7 +52,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 				&& numeric <= MaximumValue))
 				return false;
 
-			var decimalDelimeterIndex = valueString.IndexOf(decimalPartDelimeter);
+			var decimalDelimeterIndex = valueString.IndexOf(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
 			var hasDecimalDelimeter = decimalDelimeterIndex >= 0;
 
 			// If MaximumDecimalPlaces equals zero, ".5" or "14." should be considered as invalid inputs.


### PR DESCRIPTION
### Description of Change ###

Use `CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator` in `NumericValidationBehavior`.
Not sure about the tests. Is this the way to go to test multiple cultures?
I didn't add additional samples and additional documentation.

### Bugs Fixed ###

- Related to issue #247 

### API Changes ###

No API changes

### Behavioral Changes ###

The `NumericValidationBehavior` takes now the current culture into account.
Previously, the '.' sign was hardcoded. Now the `CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator` is used.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation