### PR TITLE
[Bug] SideMenu: MenuGestureEnabled = False doesn't work

### DIFF
--- a/XamarinCommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
+++ b/XamarinCommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
@@ -493,11 +493,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void OnChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			HandleChild(e.OldItems, RemoveChild);
-			HandleChild(e.NewItems, AddChild);
+			HandleChildren(e.OldItems, RemoveChild);
+			HandleChildren(e.NewItems, AddChild);
 		}
 
-		void HandleChild(IList items, Action<View> action)
+		void HandleChildren(IList items, Action<View> action)
 		{
 			if (items != null)
 				foreach (var item in items)

--- a/XamarinCommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
+++ b/XamarinCommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Xamarin.Forms;
 using static System.Math;
 using static Xamarin.Forms.AbsoluteLayout;
+using IList = System.Collections.IList;
 
 namespace Xamarin.CommunityToolkit.UI.Views
 {
@@ -276,7 +277,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			mainView.AbortAnimation(animationName);
 			var totalShift = previousShift + shift;
-			if (!TryUpdateShift(totalShift - zeroShift, false))
+			if (!TryUpdateShift(totalShift - zeroShift, false, true))
 				zeroShift = totalShift - Shift;
 		}
 
@@ -314,7 +315,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				SetOverlayViewInputTransparent(state);
 				return;
 			}
-			var animation = new Animation(v => TryUpdateShift(v, true), Shift, end);
+			var animation = new Animation(v => TryUpdateShift(v, true, false), Shift, end);
 			mainView.Animate(animationName, animation, animationRate, animationLength, animationEasing, (v, isCanceled) =>
 			{
 				if (isCanceled)
@@ -345,10 +346,13 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			return isRightSwipe ? left : right;
 		}
 
-		bool TryUpdateShift(double sift, bool shouldUpdatePreviousShift)
+		bool TryUpdateShift(double sift, bool shouldUpdatePreviousShift, bool shouldCheckMenuGestureEnabled)
 		{
 			SetActiveView(sift >= 0);
-			if (activeMenu == null || !GetMenuGestureEnabled(activeMenu))
+			if (activeMenu == null)
+				return false;
+
+			if (shouldCheckMenuGestureEnabled && !GetMenuGestureEnabled(activeMenu))
 				return false;
 
 			sift = Sign(sift) * Min(Abs(sift), activeMenu.Width);
@@ -390,6 +394,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void UpdateState(SideMenuState state, bool isSwipe)
 		{
+			if (!CheckMenuGestureEnabled(state))
+				return;
+
 			this.isSwipe = isSwipe;
 			if (State == state)
 			{
@@ -419,6 +426,21 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				return;
 
 			LowerChild(inactiveMenu);
+		}
+
+		bool CheckMenuGestureEnabled(SideMenuState state)
+		{
+			var view = state switch
+			{
+				SideMenuState.LeftMenuShown => leftMenu,
+				SideMenuState.RightMenuShown => rightMenu,
+				_ => activeMenu
+			};
+
+			if (view == null)
+				return false;
+
+			return GetMenuGestureEnabled(view);
 		}
 
 		bool TryResolveFlingGesture(ref SideMenuState state)
@@ -471,13 +493,15 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void OnChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			if (e.OldItems != null)
-				foreach (var item in e.OldItems)
-					RemoveChild((View)item);
+			HandleChild(e.OldItems, RemoveChild);
+			HandleChild(e.NewItems, AddChild);
+		}
 
-			if (e.NewItems != null)
-				foreach (var item in e.NewItems)
-					AddChild((View)item);
+		void HandleChild(IList items, Action<View> action)
+		{
+			if (items != null)
+				foreach (var item in items)
+					action?.Invoke((View)item);
 		}
 
 		void AddChild(View view)

--- a/XamarinCommunityToolkitSample/Pages/Views/SideMenuViewPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/SideMenuViewPage.xaml
@@ -3,17 +3,30 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:views="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
              xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-             x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.SideMenuViewPage"
-             xmlns:rsx="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit">
+             x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.SideMenuViewPage">
 
     <pages:BasePage.Resources>
+        <Style x:Key="BaseMenuButtonStyle" TargetType="Button">
+            <Setter Property="HeightRequest" Value="40" />
+            <Setter Property="WidthRequest" Value="40" />
+            <Setter Property="VerticalOptions" Value="Start" />
+            <Setter Property="Text" Value="||" />
+        </Style>
     </pages:BasePage.Resources>
 
-    <views:SideMenuView>
+    <views:SideMenuView x:Name="SideMenuView">
         <!-- MainView -->
-        <Frame
-            Padding="0"
-            BackgroundColor="Gold" />
+        <StackLayout
+            Orientation="Horizontal"
+            BackgroundColor="Gold">
+
+            <Button Style="{StaticResource BaseMenuButtonStyle}"
+                    Clicked="OnLeftButtonClicked" />
+
+            <Button Style="{StaticResource BaseMenuButtonStyle}"
+                    HorizontalOptions="EndAndExpand"
+                    Clicked="OnRightButtonClicked" />
+        </StackLayout>
 
         <!-- LeftMenu -->
         <BoxView

--- a/XamarinCommunityToolkitSample/Pages/Views/SideMenuViewPage.xaml.cs
+++ b/XamarinCommunityToolkitSample/Pages/Views/SideMenuViewPage.xaml.cs
@@ -1,9 +1,17 @@
-﻿
+﻿using System;
+using Xamarin.CommunityToolkit.UI.Views;
+
 namespace Xamarin.CommunityToolkit.Sample.Pages.Views
 {
 	public partial class SideMenuViewPage
 	{
 		public SideMenuViewPage()
 			=> InitializeComponent();
+
+		void OnLeftButtonClicked(object sender, EventArgs e)
+			=> SideMenuView.State = SideMenuState.LeftMenuShown;
+
+		void OnRightButtonClicked(object sender, EventArgs e)
+			=> SideMenuView.State = SideMenuState.RightMenuShown;
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Setting MenuGestureEnabled to False broke the possibility to set "State" manually.

**How to test:"
1) Run the sample app and navigate to SideMenuPage
2) Make sure you can open the right/left menu by dragging.
3) Set ```views:SideMenuView.MenuGestureEnabled="False"``` to any menu view
4) Restart the app and navigate to SideMenuPage again (Or probably HotReload will reload XAML for you)
5) Make sure you cannot open the menu by dragging anymore, but still can open the menu by clicking the button (||).


### Bugs Fixed ###

- Fixes #263

Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR.

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###

- [] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated documentation
