### PR TITLE
CameraView: Implemented returning of path of saved file

### DIFF
--- a/XamarinCommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
+++ b/XamarinCommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
@@ -303,13 +303,13 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 		}
 
-		void OnPhoto(object sender, byte[] data) =>
+		void OnPhoto(object sender, Tuple<string, byte[]> tuple) =>
 			Device.BeginInvokeOnMainThread(() =>
-				Element?.RaiseMediaCaptured(new MediaCapturedEventArgs(data, ImageSource.FromStream(() => new MemoryStream(data)))));
+				Element?.RaiseMediaCaptured(new MediaCapturedEventArgs(tuple.Item1, tuple.Item2)));
 
-		void OnVideo(object sender, string data) =>
+		void OnVideo(object sender, string path) =>
 			Device.BeginInvokeOnMainThread(() =>
-				Element?.RaiseMediaCaptured(new MediaCapturedEventArgs(video: MediaSource.FromFile(data))));
+				Element?.RaiseMediaCaptured(new MediaCapturedEventArgs(path)));
 
 		void SetupImageReader()
 		{
@@ -320,10 +320,14 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			var readerListener = new ImageAvailableListener();
 			readerListener.Photo += (_, bytes) =>
 			{
+				string filePath = null;
 				if (Element.SavePhotoToFile)
-					File.WriteAllBytes(ConstructMediaFilename(null, "jpg"), bytes);
+				{
+					filePath = ConstructMediaFilename(null, "jpg");
+					File.WriteAllBytes(filePath, bytes);
+				}
 				Sound(MediaActionSoundType.ShutterClick);
-				OnPhoto(this, bytes);
+				OnPhoto(this, new Tuple<string, byte[]>(filePath, Element.SavePhotoToFile ? null : bytes));
 			};
 
 			photoReader.SetOnImageAvailableListener(readerListener, backgroundHandler);

--- a/XamarinCommunityToolkit/Views/CameraView/MediaCapturedEventArgs.shared.cs
+++ b/XamarinCommunityToolkit/Views/CameraView/MediaCapturedEventArgs.shared.cs
@@ -1,25 +1,44 @@
 ﻿using System;
+using System.IO;
 using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.UI.Views
 {
 	public class MediaCapturedEventArgs : EventArgs
 	{
+		private readonly Lazy<ImageSource> imageSource;
+		private readonly Lazy<MediaSource> mediaSource;
+
 		internal MediaCapturedEventArgs(
-			object data = null,
-			ImageSource image = null,
-			MediaSource video = null)
+			string path = null,
+			byte[] imageData = null)
 		{
-			Data = data;
-			Image = image;
-			Video = video;
+			Path = path;
+			ImageData = imageData;
+			imageSource = new Lazy<ImageSource>(GetImageSource);
+			mediaSource = new Lazy<MediaSource>(GetMediaSource);
 		}
 
 		/// <summary>
-		/// Raw image data, only filled when taking a picture
+		/// Path of the saved file, only filled when taking a video or a picture and SavePhotoToFile is true
 		/// </summary>
-		public object Data { get; }
-		public ImageSource Image { get; }
-		public MediaSource Video { get; }
+		public string Path { get; }
+		/// <summary>
+		/// Raw image data, only filled when taking a picture and SavePhotoToFile is false
+		/// </summary>
+		public byte[] ImageData { get; }
+
+		public ImageSource Image => imageSource.Value;
+
+		public MediaSource Video => mediaSource.Value;
+
+		private ImageSource GetImageSource()
+		{
+			if (ImageData != null)
+				return ImageSource.FromStream(() => new MemoryStream(ImageData));
+			return !string.IsNullOrEmpty(Path) ? Path : null;
+		}
+
+		private MediaSource GetMediaSource() => !string.IsNullOrEmpty(Path) ? Path : null;
 	}
 }

--- a/XamarinCommunityToolkit/Views/CameraView/iOS/CameraViewRenderer.ios.cs
+++ b/XamarinCommunityToolkit/Views/CameraView/iOS/CameraViewRenderer.ios.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-using System.IO;
+using System.Diagnostics;
+using AVFoundation;
 using Foundation;
 using Photos;
 using UIKit;
@@ -51,15 +52,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			Element.IsAvailable = available;
 		}
 
-		void RaiseImageCapture(NSData photoData)
-		{
-			var data = UIImage.LoadFromData(photoData).AsJPEG().ToArray();
-			Device.BeginInvokeOnMainThread(() =>
-			{
-				Element.RaiseMediaCaptured(new MediaCapturedEventArgs(data, ImageSource.FromStream(() => new MemoryStream(data))));
-			});
-		}
-
 		void FinishCapture(object sender, Tuple<NSObject, NSError> e)
 		{
 			if (Element == null || Control == null)
@@ -74,10 +66,15 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			var photoData = e.Item1 as NSData;
 			if (!Element.SavePhotoToFile && photoData != null)
 			{
-				RaiseImageCapture(photoData);
+				var data = UIImage.LoadFromData(photoData).AsJPEG().ToArray();
+				Device.BeginInvokeOnMainThread(() =>
+				{
+					Element.RaiseMediaCaptured(new MediaCapturedEventArgs(imageData: data));
+				});
 				return;
 			}
 
+			PHObjectPlaceholder placeholder = null;
 			PHPhotoLibrary.RequestAuthorization(status =>
 			{
 				if (status != PHAuthorizationStatus.Authorized)
@@ -90,7 +87,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 					if (photoData != null)
 					{
 						creationRequest.AddResource(PHAssetResourceType.Photo, photoData, null);
-						RaiseImageCapture(photoData);
+						placeholder = creationRequest.PlaceholderForCreatedAsset;
 					}
 					else if (e.Item1 is NSUrl outputFileUrl)
 					{
@@ -101,15 +98,58 @@ namespace Xamarin.CommunityToolkit.UI.Views
 							{
 								ShouldMoveFile = true
 							});
-						Device.BeginInvokeOnMainThread(() =>
-						{
-							Element.RaiseMediaCaptured(new MediaCapturedEventArgs(video: MediaSource.FromFile(outputFileUrl.Path)));
-						});
+						placeholder = creationRequest.PlaceholderForCreatedAsset;
 					}
 				}, (success2, error2) =>
 				{
 					if (!success2)
-						Console.WriteLine($"Could not save movie to photo library: {error2}");
+					{
+						Debug.WriteLine($"Could not save media to photo library: {error2}");
+						if (error2 != null)
+						{
+							Element.RaiseMediaCaptureFailed(error2.LocalizedDescription);
+							return;
+						}
+						Element.RaiseMediaCaptureFailed($"Could not save media to photo library");
+						return;
+					}
+
+					if (!(PHAsset.FetchAssetsUsingLocalIdentifiers(new []{ placeholder.LocalIdentifier }, null).firstObject is PHAsset asset))
+					{
+						Element.RaiseMediaCaptureFailed($"Could not save media to photo library");
+						return;
+					}
+					if (asset.MediaType == PHAssetMediaType.Image)
+					{
+						asset.RequestContentEditingInput(new PHContentEditingInputRequestOptions
+						{
+							CanHandleAdjustmentData = p => true
+						}, (input, info) =>
+						{
+							Device.BeginInvokeOnMainThread(() =>
+							{
+								Element.RaiseMediaCaptured(new MediaCapturedEventArgs(input.FullSizeImageUrl.Path));
+							});
+						});
+					}
+					else if (asset.MediaType == PHAssetMediaType.Video)
+					{
+						PHImageManager.DefaultManager.RequestAvAsset(asset, new PHVideoRequestOptions
+						{
+							Version = PHVideoRequestOptionsVersion.Original
+						}, ((avAsset, mix, info) =>
+						{
+							if (!(avAsset is AVUrlAsset urlAsset))
+							{
+								Element.RaiseMediaCaptureFailed($"Could not save media to photo library");
+								return;
+							}
+							Device.BeginInvokeOnMainThread(() =>
+							{
+								Element.RaiseMediaCaptured(new MediaCapturedEventArgs(urlAsset.Url.Path));
+							});
+						}));
+					}
 				});
 			});
 		}
@@ -158,7 +198,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			{
 				case CameraCaptureOptions.Default:
 				case CameraCaptureOptions.Photo:
-					await Control?.TakePhoto();
+					if (Control != null)
+						await Control.TakePhoto();
 					break;
 				case CameraCaptureOptions.Video:
 					if (Control == null)

--- a/XamarinCommunityToolkit/Xamarin.CommunityToolkit.csproj
+++ b/XamarinCommunityToolkit/Xamarin.CommunityToolkit.csproj
@@ -32,6 +32,7 @@
     <PackageProjectUrl>https://github.com/xamarin/XamarinCommunityToolkit</PackageProjectUrl>
     <DebugType>portable</DebugType>
     <Configurations>Debug;Release</Configurations>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <!-- Manage TargetFrameworks for development (Debug Mode) -->
@@ -60,7 +61,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
-    <None Include="**\*.cs;**\*.xml;**\*.axml;**\*.png" Exclude="obj\**\*.*;bin\**\*.*;bin;obj" />
     <Compile Include="**/*.shared.cs" />
     <Compile Include="**/*.shared.*.cs" />
     <None Include="..\LICENSE" PackagePath="" Pack="true" />


### PR DESCRIPTION
### Description of Change ###

As stated in https://github.com/xamarin/XamarinCommunityToolkit/issues/287 it is sometimes necessary to access the path of the saved file.
Currently it's also impossible to access the video file because it has been moved and the path given to the MediaSource is invalid.
Furthermore I added a lazy creation of ImageSource/MediaSource since they are not always needed.

### API Changes ###

List all API changes here (or just put None), example:

Added in MediaCapturedEventArgs: 
 
- `string Path { get; }`

Changed in MediaCapturedEventArgs:

 - `object Data { get; }` => `byte[] ImageData { get; }`
 - `ImageSource Image` is now lazily created
 - `MediaSource Video` is now lazily created
 - `internal MediaCapturedEventArgs(object data = null, ImageSource image = null, MediaSource video = null)` => `internal MediaCapturedEventArgs(string path = null, byte[] imageData = null)`

### Behavioral Changes ###

 - ImageSource and MediaSource in MediaCapturedEventArgs are now lazily created and not provided in the constructor
 - MediaCapturedEventArgs returns now the path of the saved file for videos and for photos if SavePhotoToFile is true

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
