### PR TITLE
[Bug] [CameraView] [Android] Fixed SetVideoStabilization of CameraFragment

### DIFF
--- a/XamarinCommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
+++ b/XamarinCommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
@@ -620,10 +620,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		public void SetVideoStabilization()
 		{
 			if (sessionBuilder == null || !stabilizationSupported)
-			{
-				sessionBuilder.Set(CaptureRequest.ControlVideoStabilizationMode,
-					(int)(Element.VideoStabilization ? ControlVideoStabilizationMode.On : ControlVideoStabilizationMode.Off));
-			}
+				return;
+			sessionBuilder.Set(CaptureRequest.ControlVideoStabilizationMode,
+				(int)(Element.VideoStabilization ? ControlVideoStabilizationMode.On : ControlVideoStabilizationMode.Off));
 		}
 
 		public void ApplyZoom()


### PR DESCRIPTION
### Description of Change ###

Fixed the method SetVideoStabilization of CameraFragment on Android.
The condition was invalid and should have been reversed.

### Bugs Fixed ###

- Fixes #303


### API Changes ###

None

### Behavioral Changes ###

VideoStabilization on Android should now be set.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
