### PR TITLE
[Bug] [CameraView] [Android] Fixed unnecessary request of RecordAudio permission

### DIFF
--- a/XamarinCommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
+++ b/XamarinCommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
@@ -686,12 +686,20 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			if (permissionsRequested != null)
 				await permissionsRequested.Task;
 
+			var permissionsToRequest = new List<string>();
 			cameraPermissionsGranted = ContextCompat.CheckSelfPermission(Context, Manifest.Permission.Camera) == Permission.Granted;
-			audioPermissionsGranted = ContextCompat.CheckSelfPermission(Context, Manifest.Permission.RecordAudio) == Permission.Granted;
-			if (!cameraPermissionsGranted || !audioPermissionsGranted)
+			if (!cameraPermissionsGranted)
+				permissionsToRequest.Add(Manifest.Permission.Camera);
+			if (Element.CaptureOptions == CameraCaptureOptions.Video)
+			{
+				audioPermissionsGranted = ContextCompat.CheckSelfPermission(Context, Manifest.Permission.RecordAudio) == Permission.Granted;
+				if (!audioPermissionsGranted)
+					permissionsToRequest.Add(Manifest.Permission.RecordAudio);
+			}
+			if (permissionsToRequest.Count > 0)
 			{
 				permissionsRequested = new TaskCompletionSource<bool>();
-				RequestPermissions(new[] { Manifest.Permission.Camera, Manifest.Permission.RecordAudio }, requestCode: 1);
+				RequestPermissions(permissionsToRequest.ToArray(), requestCode: 1);
 				await permissionsRequested.Task;
 				permissionsRequested = null;
 			}


### PR DESCRIPTION
### Description of Change ###

Fixed the unnecessary request of RecordAudio permission when CaptureOptions is not CameraCaptureOptions.Video

### Bugs Fixed ###

- Fixes #296 

### API Changes ###

None.

### Behavioral Changes ###

Only asks for Microphone Access when CaptureOptions is CameraCaptureOptions.Video.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
