### PR TITLE
[Bug] [CameraView] [Android] Removed unnecessary mirroring code

### DIFF
--- a/XamarinCommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
+++ b/XamarinCommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
@@ -844,43 +844,10 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			var centerY = viewRect.CenterY();
 			bufferRect.Offset(centerX - bufferRect.CenterX(), centerY - bufferRect.CenterY());
 
-			// return to this when we dicided how to handle with platform specifics
-			var mirror = Element.CameraOptions == CameraOptions.Front;//&& Element.OnThisPlatform().GetMirrorFrontPreview();
 			matrix.SetRectToRect(viewRect, bufferRect, Matrix.ScaleToFit.Fill);
-			float sx, sy;
 
-			//switch (Element.PreviewAspect)
-			//{
-			//	default:
-			//	case Aspect.AspectFit:
-			//		sx = sy = System.Math.Min(scaleHH(), scaleHW());
-			//		break;
-			//	case Aspect.AspectFill:
-			//		sx = sy = System.Math.Max(scaleHH(), scaleHW());
-			//		break;
-			//	case Aspect.Fill:
-			if (Resources.Configuration.Orientation == AOrientation.Landscape)
-			{
-				sx = scaleWW();
-				sy = scaleHH();
-			}
-			else
-			{
-				sx = scaleWH();
-				sy = scaleHW();
-			}
-			//		break;
-			//}
-
-			matrix.PostScale(mirror ? -sx : sx, sy, centerX, centerY);
 			matrix.PostRotate(GetCaptureOrientation(), centerX, centerY);
 			texture.SetTransform(matrix);
-
-
-			float scaleHH() => (float)viewHeight / previewSize.Height;
-			float scaleHW() => (float)viewHeight / previewSize.Width;
-			float scaleWW() => (float)viewWidth / previewSize.Width;
-			float scaleWH() => (float)viewWidth / previewSize.Height;
 		}
 
 		int GetCaptureOrientation()


### PR DESCRIPTION
### Description of Change ###

The previous logic was mirroring twice if the CameraView got initialized with CameraOptions.Front.
This made the Android implementation work like the iOS implementation in this aspect.

### Bugs Fixed ###

- Fixes #295


### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated documentation
