### PR TITLE
Don't overwrite margin when detaching safe area effect if the effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Browsing the [sample app](./XamarinCommunityToolkitSample) is the best place to 
 
 The toolkit is available via NuGet, and should be installed into all your projects:
 
-* NuGet Official Releases: [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.CommunityToolkit.svg?label=NuGet)](https://www.nuget.org/packages/Microsoft.Toolkit.Xamarin.Forms)
+* NuGet Official Releases: [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.CommunityToolkit.svg?label=NuGet)](https://www.nuget.org/packages/Xamarin.CommunityToolkit)
 * NuGet Nightly Releases: [![NuGet Nightly](https://img.shields.io/badge/NuGet-Nightly-yellow)](https://pkgs.dev.azure.com/xamarin/public/_packaging/XamarinCommunityToolkitNightly/nuget/v3/index.json)
 
 Now all you need to do is use it! 

--- a/XamarinCommunityToolkit/Effects/SafeAreaEffectRouter.ios.cs
+++ b/XamarinCommunityToolkit/Effects/SafeAreaEffectRouter.ios.cs
@@ -12,7 +12,7 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 {
 	public class SafeAreaEffectRouter : PlatformEffect
 	{
-		Thickness initialMargin;
+		Thickness? initialMargin;
 
 		protected override void OnAttached()
 		{
@@ -24,24 +24,27 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 
 			var insets = UIApplication.SharedApplication.Windows[0].SafeAreaInsets;
 
-			initialMargin = element.Margin;
-
 			if (insets.Top <= 0)
 				return;
+
+			initialMargin = element.Margin;
 
 			var safeArea = SafeAreaEffect.GetSafeArea(element);
 
 			element.Margin = new Thickness(
-				initialMargin.Left + (safeArea.Left ? insets.Left : 0),
-				initialMargin.Top + (safeArea.Top ? insets.Top : 0),
-				initialMargin.Right + (safeArea.Right ? insets.Right : 0),
-				initialMargin.Bottom + (safeArea.Bottom ? insets.Bottom : 0));
+				element.Margin.Left + (safeArea.Left ? insets.Left : 0),
+				element.Margin.Top + (safeArea.Top ? insets.Top : 0),
+				element.Margin.Right + (safeArea.Right ? insets.Right : 0),
+				element.Margin.Bottom + (safeArea.Bottom ? insets.Bottom : 0));
 		}
 
 		protected override void OnDetached()
 		{
-			if (Element is Layout element)
-				element.Margin = initialMargin;
+			if (Element is Layout element && initialMargin.HasValue)
+			{
+				element.Margin = initialMargin.Value;
+				initialMargin = null;
+			}
 		}
 	}
 }


### PR DESCRIPTION
was never applied.

### Description of Change ###

### Bugs Fixed ###

- Fixes https://github.com/xamarin/XamarinCommunityToolkit/issues/323

### API Changes ###