### PR TITLE
Adding Default XmlnsDefinition

### DIFF
--- a/XamarinCommunityToolkit/AssemblyInfo/AssemblyInfo.shared.cs
+++ b/XamarinCommunityToolkit/AssemblyInfo/AssemblyInfo.shared.cs
@@ -1,3 +1,12 @@
 ﻿using System.Runtime.CompilerServices;
+using Xamarin.Forms;
 
 [assembly: InternalsVisibleTo("Xamarin.CommunityToolkit.UnitTests")]
+
+#if !NETSTANDARD1_0
+[assembly: XmlnsDefinition("http://xamarin.com/schemas/2020/toolkit", "Xamarin.CommunityToolkit.Behaviors")]
+[assembly: XmlnsDefinition("http://xamarin.com/schemas/2020/toolkit", "Xamarin.CommunityToolkit.Converters")]
+[assembly: XmlnsDefinition("http://xamarin.com/schemas/2020/toolkit", "Xamarin.CommunityToolkit.Effects")]
+[assembly: XmlnsDefinition("http://xamarin.com/schemas/2020/toolkit", "Xamarin.CommunityToolkit.Extensions")]
+[assembly: XmlnsDefinition("http://xamarin.com/schemas/2020/toolkit", "Xamarin.CommunityToolkit.UI.Views")]
+#endif

--- a/XamarinCommunityToolkit/Helpers/PreserveToolkitAttribute.shared.cs
+++ b/XamarinCommunityToolkit/Helpers/PreserveToolkitAttribute.shared.cs
@@ -1,0 +1,11 @@
+using System;
+using System.ComponentModel;
+
+namespace Xamarin.CommunityToolkit.Helpers
+{
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	[AttributeUsage(AttributeTargets.Assembly)]
+	public sealed class PreserveToolkitAttribute : Attribute
+	{
+	}
+}

--- a/XamarinCommunityToolkit/Xamarin.CommunityToolkit.csproj
+++ b/XamarinCommunityToolkit/Xamarin.CommunityToolkit.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
+<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;netstandard2.1;Xamarin.iOS10;MonoAndroid90;MonoAndroid10.0;Xamarin.TVOS10;Xamarin.WatchOS10;Xamarin.Mac20;tizen40</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.17763;netcoreapp3.1;net472;net471</TargetFrameworks>
@@ -22,21 +22,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <RepositoryUrl>https://github.com/xamarin/XamarinCommunityToolkit</RepositoryUrl>
     <PackageReleaseNotes>
-      
-      
-      
-      
-      
-      
-      
       <!-- See if we can host these on MS docs? -->
-    
-    
-    
-    
-    
-    
-    
     </PackageReleaseNotes>
     <DefineConstants>$(DefineConstants);</DefineConstants>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
@@ -120,7 +106,7 @@
     <AndroidResource Include="Resources\**\*.xml" />
     <AndroidResource Include="Resources\**\*.png" />
   </ItemGroup>
-  
+
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid9.0')) ">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
@@ -142,12 +128,12 @@
     <Compile Include="**\*.macos.cs" />
     <Compile Include="**\*.macos.*.cs" />
   </ItemGroup>
-  
+
   <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.WatchOS')) ">
     <Compile Include="**\*.watchos.cs" />
     <Compile Include="**\*.watchos.*.cs" />
   </ItemGroup>
-  
+
   <ItemGroup Condition=" $(TargetFramework.StartsWith('tizen')) ">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <Compile Include="**\*.tizen.cs" />
@@ -213,5 +199,10 @@
       <HintPath>..\Libs\gtk-sharp\gtk-sharp-2.0\pango-sharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="build\*.cs" />
+    <None Include="build\**\*.cs;build\**\*.targets" Pack="true" PackagePath="build" />
   </ItemGroup>
 </Project>

--- a/XamarinCommunityToolkit/build/PreserveXamarinCommunityToolkit.cs
+++ b/XamarinCommunityToolkit/build/PreserveXamarinCommunityToolkit.cs
@@ -1,0 +1,3 @@
+using Xamarin.CommunityToolkit.Helpers;
+
+[assembly: PreserveToolkit]

--- a/XamarinCommunityToolkit/build/Xamarin.CommunityToolkit.targets
+++ b/XamarinCommunityToolkit/build/Xamarin.CommunityToolkit.targets
@@ -1,5 +1,6 @@
 <Project>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)PreserveXamarinCommunityToolkit.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PreserveXamarinCommunityToolkit.cs"
+             Visible="false" />
   </ItemGroup>
 </Project>

--- a/XamarinCommunityToolkit/build/Xamarin.CommunityToolkit.targets
+++ b/XamarinCommunityToolkit/build/Xamarin.CommunityToolkit.targets
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)PreserveXamarinCommunityToolkit.cs" />
+  </ItemGroup>
+</Project>

--- a/XamarinCommunityToolkitSample/Pages/AboutPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/AboutPage.xaml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:views="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
-                xmlns:viewmodels="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                xmlns:viewmodels="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels"
                 x:Class="Xamarin.CommunityToolkit.Sample.Pages.AboutPage"
-                xmlns:rsx="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit"
                 Title="About...">
 
     <pages:BasePage.ToolbarItems>
@@ -40,7 +39,7 @@
                                 <RowDefinition Height="65" />
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
-                            <views:AvatarView Size="60"
+                            <xct:AvatarView Size="60"
                                               Source="{Binding AvatarUrl}"
                                               HorizontalOptions="Center" VerticalOptions="Center" />
 

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/AnimationBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/AnimationBehaviorPage.xaml
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.AnimationBehaviorPage"
-             xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
-             xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-             xmlns:rsx="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit">
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.AnimationBehaviorPage">
       <ScrollView>
         <StackLayout Padding="{StaticResource ContentPadding}"
                      Spacing="10">
@@ -15,12 +14,12 @@
             <Button Text="Testing Fade Animation"
                    TextColor="HotPink">
                  <Button.Behaviors>
-                      <behaviors:AnimationBehavior EventName="Clicked">
-                            <behaviors:AnimationBehavior.AnimationType>
-                                <behaviors:FadeAnimation Easing="{x:Static Easing.Linear}"
-                                                         Duration="100"/>
-                            </behaviors:AnimationBehavior.AnimationType>
-                        </behaviors:AnimationBehavior>
+                      <xct:AnimationBehavior EventName="Clicked">
+                            <xct:AnimationBehavior.AnimationType>
+                                <xct:FadeAnimation Easing="{x:Static Easing.Linear}"
+                                                   Duration="100"/>
+                            </xct:AnimationBehavior.AnimationType>
+                        </xct:AnimationBehavior>
                 </Button.Behaviors>
             </Button>
 
@@ -28,11 +27,11 @@
                      HeightRequest="40"
                      HorizontalOptions="Fill">
                 <BoxView.Behaviors>
-                    <behaviors:AnimationBehavior Command="{Binding MyCommand}">
-                        <behaviors:AnimationBehavior.AnimationType>
-                            <behaviors:RotateAnimation/>
-                        </behaviors:AnimationBehavior.AnimationType>
-                    </behaviors:AnimationBehavior>
+                    <xct:AnimationBehavior Command="{Binding MyCommand}">
+                        <xct:AnimationBehavior.AnimationType>
+                            <xct:RotateAnimation/>
+                        </xct:AnimationBehavior.AnimationType>
+                    </xct:AnimationBehavior>
                 </BoxView.Behaviors>
             </BoxView>
 
@@ -40,55 +39,55 @@
                           BackgroundColor="Transparent"
                           HeightRequest="50">
                 <ImageButton.Behaviors>
-                    <behaviors:AnimationBehavior EventName="Clicked">
-                        <behaviors:AnimationBehavior.AnimationType>
-                            <behaviors:FlipVerticalAnimation/>
-                        </behaviors:AnimationBehavior.AnimationType>
-                    </behaviors:AnimationBehavior>
+                    <xct:AnimationBehavior EventName="Clicked">
+                        <xct:AnimationBehavior.AnimationType>
+                            <xct:FlipVerticalAnimation/>
+                        </xct:AnimationBehavior.AnimationType>
+                    </xct:AnimationBehavior>
                 </ImageButton.Behaviors>
             </ImageButton>
             
  
-             <Label Text="{rsx:Translate Shake}">
+             <Label Text="{xct:Translate Shake}">
                 <Label.Behaviors>
-                    <behaviors:AnimationBehavior Command="{Binding MyCommand}">
-                        <behaviors:AnimationBehavior.AnimationType>
-                            <behaviors:ShakeAnimation/>
-                        </behaviors:AnimationBehavior.AnimationType>
-                    </behaviors:AnimationBehavior>
+                    <xct:AnimationBehavior Command="{Binding MyCommand}">
+                        <xct:AnimationBehavior.AnimationType>
+                            <xct:ShakeAnimation/>
+                        </xct:AnimationBehavior.AnimationType>
+                    </xct:AnimationBehavior>
                 </Label.Behaviors>
             </Label>
 
             <Entry>
                 <Entry.Behaviors>
-                    <behaviors:AnimationBehavior Command="{Binding MyCommand}"
-                                                  EventName="Focused">
-                        <behaviors:AnimationBehavior.AnimationType>
-                            <behaviors:ShakeAnimation/>
-                        </behaviors:AnimationBehavior.AnimationType>
-                    </behaviors:AnimationBehavior>
+                    <xct:AnimationBehavior Command="{Binding MyCommand}"
+                                           EventName="Focused">
+                        <xct:AnimationBehavior.AnimationType>
+                            <xct:ShakeAnimation/>
+                        </xct:AnimationBehavior.AnimationType>
+                    </xct:AnimationBehavior>
                 </Entry.Behaviors>
             </Entry>
            
              <Switch>
                 <Switch.Behaviors>
-                    <behaviors:AnimationBehavior EventName="Toggled"
-                                                  Command="{Binding MyCommand}">
-                        <behaviors:AnimationBehavior.AnimationType>
-                            <behaviors:FadeAnimation/>
-                        </behaviors:AnimationBehavior.AnimationType>
-                    </behaviors:AnimationBehavior>
+                    <xct:AnimationBehavior EventName="Toggled"
+                                           Command="{Binding MyCommand}">
+                        <xct:AnimationBehavior.AnimationType>
+                            <xct:FadeAnimation/>
+                        </xct:AnimationBehavior.AnimationType>
+                    </xct:AnimationBehavior>
                 </Switch.Behaviors>
             </Switch>
 
             <CheckBox>
                 <CheckBox.Behaviors>
-                    <behaviors:AnimationBehavior EventName="CheckedChanged"
-                                                  Command="{Binding MyCommand}">
-                        <behaviors:AnimationBehavior.AnimationType>
-                            <behaviors:FadeAnimation/>
-                        </behaviors:AnimationBehavior.AnimationType>
-                    </behaviors:AnimationBehavior>
+                    <xct:AnimationBehavior EventName="CheckedChanged"
+                                           Command="{Binding MyCommand}">
+                        <xct:AnimationBehavior.AnimationType>
+                            <xct:FadeAnimation/>
+                        </xct:AnimationBehavior.AnimationType>
+                    </xct:AnimationBehavior>
                 </CheckBox.Behaviors>
             </CheckBox>
         </StackLayout>

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/CharactersValidationBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/CharactersValidationBehaviorPage.xaml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<pages:BasePage x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.CharactersValidationBehaviorPage"
-                xmlns="http://xamarin.com/schemas/2014/forms"
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-                xmlns:rsx="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit"
-                x:Name="Page">
+                x:Name="Page"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.CharactersValidationBehaviorPage">
 
     <pages:BasePage.Resources>
         <Style x:Key="InvalidEntryStyle"
@@ -57,13 +56,13 @@
         <Label Text="Type characters for validation behavior according to the settings you set upon." />
         <Entry Placeholder="Type characters...">
             <Entry.Behaviors>
-                <behaviors:CharactersValidationBehavior CharacterType="{Binding SelectedItem,
-                                                                                Source={x:Reference CharacterTypePicker}}"
-                                                        InvalidStyle="{StaticResource InvalidEntryStyle}"
-                                                        MaximumCharacterCount="{Binding Text,
-                                                                                        Source={x:Reference MaximumCharacterCountEntry}}"
-                                                        MinimumCharacterCount="{Binding Text,
-                                                                                        Source={x:Reference MinimumCharacterCountEntry}}" />
+                <xct:CharactersValidationBehavior CharacterType="{Binding SelectedItem,
+                                                                          Source={x:Reference CharacterTypePicker}}"
+                                                  InvalidStyle="{StaticResource InvalidEntryStyle}"
+                                                  MaximumCharacterCount="{Binding Text,
+                                                                                  Source={x:Reference MaximumCharacterCountEntry}}"
+                                                  MinimumCharacterCount="{Binding Text,
+                                                                                  Source={x:Reference MinimumCharacterCountEntry}}" />
             </Entry.Behaviors>
         </Entry>
     </StackLayout>

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/EmailValidationBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/EmailValidationBehaviorPage.xaml
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.EmailValidationBehaviorPage"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-                xmlns:rsx="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit">
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.EmailValidationBehaviorPage">
 
     <pages:BasePage.Resources>
         <Style x:Key="InvalidEntryStyle" TargetType="Entry">
@@ -18,7 +17,7 @@
         <Label Text="Text color will change accordingly to the style that is configured when a invalid value (email address) is entered." />
         <Entry Placeholder="Email">
             <Entry.Behaviors>
-                <behaviors:EmailValidationBehavior DecorationFlags="Trim" InvalidStyle="{StaticResource InvalidEntryStyle}"/>
+                <xct:EmailValidationBehavior DecorationFlags="Trim" InvalidStyle="{StaticResource InvalidEntryStyle}"/>
             </Entry.Behaviors>
         </Entry>
     </StackLayout>

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/EventToCommandBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/EventToCommandBehaviorPage.xaml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors"
-                xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.EventToCommandBehaviorPage"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-                xmlns:rsx="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit">
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.EventToCommandBehaviorPage">
 
     <pages:BasePage.BindingContext>
         <vm:EventToCommandBehaviorViewModel />
@@ -20,7 +19,7 @@
                     TextColor="White"
                     BackgroundColor="{StaticResource NormalButtonBackgroundColor}">
                 <Button.Behaviors>
-                    <behaviors:EventToCommandBehavior
+                    <xct:EventToCommandBehavior
                         EventName="Clicked"
                         Command="{Binding IncrementCommand}" />
                 </Button.Behaviors>

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/ImpliedOrderGridBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/ImpliedOrderGridBehaviorPage.xaml
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
-          xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-          xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages;assembly=Xamarin.CommunityToolkit.Sample"
-          xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
-          xmlns:behaviors1="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages.Behaviors;assembly=Xamarin.CommunityToolkit.Sample"
-          x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.ImpliedOrderGridBehaviorPage">
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages.Behaviors;assembly=Xamarin.CommunityToolkit.Sample"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages;assembly=Xamarin.CommunityToolkit.Sample"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.ImpliedOrderGridBehaviorPage">
     <StackLayout>
         <StackLayout Orientation="Horizontal" Spacing="5" Margin="10">
             <Button Text="Add Row" Clicked="ButtonAddRow_OnClicked"></Button>
@@ -27,7 +27,7 @@ If the user manually assigns a row or column on a view, it will be honored.
 
         <Grid x:Name="TestGrid" Margin="30" BackgroundColor="Gray">
             <Grid.Behaviors>
-                <behaviors:ImpliedOrderGridBehavior/>
+                <xct:ImpliedOrderGridBehavior/>
             </Grid.Behaviors>
             <Grid.RowDefinitions>
                 <RowDefinition Height="*"></RowDefinition>
@@ -42,20 +42,20 @@ If the user manually assigns a row or column on a view, it will be honored.
                 <ColumnDefinition Width="*"></ColumnDefinition>
             </Grid.ColumnDefinitions>
 
-            <behaviors1:ImpliedOrderGridBehaviorLabel Grid.RowSpan="2"/>
-            <behaviors1:ImpliedOrderGridBehaviorLabel />
-            <behaviors1:ImpliedOrderGridBehaviorLabel />
+            <behaviors:ImpliedOrderGridBehaviorLabel Grid.RowSpan="2"/>
+            <behaviors:ImpliedOrderGridBehaviorLabel />
+            <behaviors:ImpliedOrderGridBehaviorLabel />
 
-            <behaviors1:ImpliedOrderGridBehaviorLabel Grid.ColumnSpan="2"/>
-            <behaviors1:ImpliedOrderGridBehaviorLabel/>
+            <behaviors:ImpliedOrderGridBehaviorLabel Grid.ColumnSpan="2"/>
+            <behaviors:ImpliedOrderGridBehaviorLabel/>
 
-            <behaviors1:ImpliedOrderGridBehaviorLabel />
-            <behaviors1:ImpliedOrderGridBehaviorLabel Grid.ColumnSpan="2" Grid.RowSpan="2" />
-            <behaviors1:ImpliedOrderGridBehaviorLabel />
+            <behaviors:ImpliedOrderGridBehaviorLabel />
+            <behaviors:ImpliedOrderGridBehaviorLabel Grid.ColumnSpan="2" Grid.RowSpan="2" />
+            <behaviors:ImpliedOrderGridBehaviorLabel />
 
-            <behaviors1:ImpliedOrderGridBehaviorLabel />
-            <behaviors1:ImpliedOrderGridBehaviorLabel />
-            <behaviors1:ImpliedOrderGridBehaviorLabel />
+            <behaviors:ImpliedOrderGridBehaviorLabel />
+            <behaviors:ImpliedOrderGridBehaviorLabel />
+            <behaviors:ImpliedOrderGridBehaviorLabel />
 
         </Grid>
 

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/MaskedBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/MaskedBehaviorPage.xaml
@@ -2,7 +2,7 @@
 <pages:BasePage x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.MaskedBehaviorPage"
                 xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages;assembly=Xamarin.CommunityToolkit.Sample">
     <ScrollView>
         <StackLayout Padding="{StaticResource ContentPadding}" Spacing="5">
@@ -11,21 +11,21 @@
 
             <Entry Keyboard="Numeric">
                 <Entry.Behaviors>
-                    <behaviors:MaskedBehavior Mask="XX-XX-XX" />
+                    <xct:MaskedBehavior Mask="XX-XX-XX" />
                 </Entry.Behaviors>
             </Entry>
             <Label Padding="10,0,10,50" FontSize="Small" Text="e.g. Sort code 'XX-XX-XX'" />
 
             <Entry Keyboard="Numeric">
                 <Entry.Behaviors>
-                    <behaviors:MaskedBehavior Mask="AA-AA-AA" UnMaskedCharacter="A" />
+                    <xct:MaskedBehavior Mask="AA-AA-AA" UnMaskedCharacter="A" />
                 </Entry.Behaviors>
             </Entry>
             <Label Padding="10,0,10,50" FontSize="Small" Text="e.g. Sort code 'AA-AA-AA'" />
 
             <Entry Keyboard="Numeric">
                 <Entry.Behaviors>
-                    <behaviors:MaskedBehavior Mask="XXXX XXXX XXXX XXXX" />
+                    <xct:MaskedBehavior Mask="XXXX XXXX XXXX XXXX" />
                 </Entry.Behaviors>
             </Entry>
             <Label Padding="10,0,10,50" FontSize="Small">
@@ -39,14 +39,14 @@
 
             <Entry Keyboard="Numeric" Placeholder="dd/mm/yyyy">
                 <Entry.Behaviors>
-                    <behaviors:MaskedBehavior Mask="XX/XX/XXXX" />
+                    <xct:MaskedBehavior Mask="XX/XX/XXXX" />
                 </Entry.Behaviors>
             </Entry>
             <Label Padding="10,0,10,50" FontSize="Small" Text="e.g. Date 'XX/XX/XXXX'" />
 
             <Entry Keyboard="Numeric" Placeholder="hh:mm">
                 <Entry.Behaviors>
-                    <behaviors:MaskedBehavior Mask="XX:XX" />
+                    <xct:MaskedBehavior Mask="XX:XX" />
                 </Entry.Behaviors>
             </Entry>
             <Label Padding="10,0,10,50" FontSize="Small">
@@ -60,14 +60,14 @@
 
             <Entry Keyboard="Numeric">
                 <Entry.Behaviors>
-                    <behaviors:MaskedBehavior Mask="XXX-XX-XXXX" />
+                    <xct:MaskedBehavior Mask="XXX-XX-XXXX" />
                 </Entry.Behaviors>
             </Entry>
             <Label Padding="10,0,10,50" FontSize="Small" Text="e.g. Social Security Number 'XXX-XX-XXXX'" />
 
             <Entry Keyboard="Numeric">
                 <Entry.Behaviors>
-                    <behaviors:MaskedBehavior Mask="(XXX) XXX-XXXX" />
+                    <xct:MaskedBehavior Mask="(XXX) XXX-XXXX" />
                 </Entry.Behaviors>
             </Entry>
             <Label Padding="10,0,10,50" FontSize="Small" Text="e.g. Phone Number '(XXX) XXX-XXXX'" />

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/MaxLengthReachedBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/MaxLengthReachedBehaviorPage.xaml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-                xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors"
                 x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.MaxLengthReachedBehaviorPage">
 
     <pages:BasePage.BindingContext>
@@ -46,8 +46,8 @@
                        MaxLength="{Binding Path=Text, Source={x:Reference MaxLengthSetting}}"
                        Margin="{StaticResource ContentPadding}">
                     <Entry.Behaviors>
-                        <behaviors:MaxLengthReachedBehavior MaxLengthReached="MaxLengthReachedBehavior_MaxLengthReached"
-                                                            ShouldDismissKeyboardAutomatically="{Binding Path=IsToggled, Source={x:Reference AutoDismissKeyboardSetting}}" />
+                        <xct:MaxLengthReachedBehavior MaxLengthReached="MaxLengthReachedBehavior_MaxLengthReached"
+                                                      ShouldDismissKeyboardAutomatically="{Binding Path=IsToggled, Source={x:Reference AutoDismissKeyboardSetting}}" />
                     </Entry.Behaviors>
                 </Entry>
 
@@ -64,8 +64,8 @@
                        MaxLength="{Binding Path=Text, Source={x:Reference MaxLengthSetting}}"
                        Margin="{StaticResource ContentPadding}">
                     <Entry.Behaviors>
-                        <behaviors:MaxLengthReachedBehavior Command="{Binding MaxLengthReachedCommand}"
-                                                            ShouldDismissKeyboardAutomatically="{Binding Path=IsToggled, Source={x:Reference AutoDismissKeyboardSetting}}" />
+                        <xct:MaxLengthReachedBehavior Command="{Binding MaxLengthReachedCommand}"
+                                                      ShouldDismissKeyboardAutomatically="{Binding Path=IsToggled, Source={x:Reference AutoDismissKeyboardSetting}}" />
                     </Entry.Behaviors>
                 </Entry>
 

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/MultiValidationBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/MultiValidationBehaviorPage.xaml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.MultiValidationBehaviorPage"
-                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.MultiValidationBehaviorPage">
 
     <pages:BasePage.Resources>
         <Style x:Key="InvalidEntryStyle" TargetType="Entry">
@@ -17,14 +17,14 @@
         <Label Text="Start typing until MaxLength is reached..." />
         <Entry Placeholder="Number">
             <Entry.Behaviors>
-                <behaviors:MultiValidationBehavior x:Name="MultiValidation"
-                                                   InvalidStyle="{StaticResource InvalidEntryStyle}">
-                    <behaviors:NumericValidationBehavior behaviors:MultiValidationBehavior.Error="NaN" />
-                    <behaviors:NumericValidationBehavior MinimumValue="-10"
-                                                         behaviors:MultiValidationBehavior.Error="Min: -10" />
-                    <behaviors:NumericValidationBehavior MaximumValue="5"
-                                                         behaviors:MultiValidationBehavior.Error="Max: 5" />
-                </behaviors:MultiValidationBehavior>
+                <xct:MultiValidationBehavior x:Name="MultiValidation"
+                                             InvalidStyle="{StaticResource InvalidEntryStyle}">
+                    <xct:NumericValidationBehavior xct:MultiValidationBehavior.Error="NaN" />
+                    <xct:NumericValidationBehavior MinimumValue="-10"
+                                                   xct:MultiValidationBehavior.Error="Min: -10" />
+                    <xct:NumericValidationBehavior MaximumValue="5"
+                                                   xct:MultiValidationBehavior.Error="Max: 5" />
+                </xct:MultiValidationBehavior>
             </Entry.Behaviors>
         </Entry>
         <Label

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/NumericValidationBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/NumericValidationBehaviorPage.xaml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.NumericValidationBehaviorPage"
-                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.NumericValidationBehaviorPage">
 
     <pages:BasePage.Resources>
         <Style x:Key="InvalidEntryStyle" TargetType="Entry">
@@ -17,10 +17,10 @@
         <Label Text="Text color will be changed according to the configured style in case of an invalid numeric format or when the numeric value is outside of the configured boundaries (min: 1.0, max: 100.0). Maximum decimal places value equals 2." />
         <Entry Placeholder="Number">
             <Entry.Behaviors>
-                <behaviors:NumericValidationBehavior InvalidStyle="{StaticResource InvalidEntryStyle}"
-                                                     MinimumValue="1.0"
-                                                     MaximumValue="100.0"
-                                                     MaximumDecimalPlaces="2"/>
+                <xct:NumericValidationBehavior InvalidStyle="{StaticResource InvalidEntryStyle}"
+                                               MinimumValue="1.0"
+                                               MaximumValue="100.0"
+                                               MaximumDecimalPlaces="2"/>
             </Entry.Behaviors>
         </Entry>
     </StackLayout>

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/RequiredStringValidationBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/RequiredStringValidationBehaviorPage.xaml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages;assembly=Xamarin.CommunityToolkit.Sample"
-             xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
-             x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.RequiredStringValidationBehaviorPage">
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages;assembly=Xamarin.CommunityToolkit.Sample"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.RequiredStringValidationBehaviorPage">
     <pages:BasePage.Resources>
         <Style x:Key="InvalidEntryStyle" TargetType="Entry"> 
             <Setter Property="TextColor" Value="Red" />
@@ -17,9 +16,9 @@
         <Entry x:Name="passwordEntry" Placeholder="Password" />
             <Entry Placeholder="Confirm Password">
                 <Entry.Behaviors>
-                    <behaviors:RequiredStringValidationBehavior InvalidStyle="{StaticResource InvalidEntryStyle}"
-                                                       Flags="ValidateOnValueChanging"
-                                                       RequiredString="{Binding Source={x:Reference passwordEntry},Path=Text}" />
+                    <xct:RequiredStringValidationBehavior InvalidStyle="{StaticResource InvalidEntryStyle}"
+                                                          Flags="ValidateOnValueChanging"
+                                                          RequiredString="{Binding Source={x:Reference passwordEntry},Path=Text}" />
                 </Entry.Behaviors>
             </Entry>
         </StackLayout>

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/UriValidationBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/UriValidationBehaviorPage.xaml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.UriValidationBehaviorPage"
-                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.UriValidationBehaviorPage">
 
     <pages:BasePage.Resources>
         <Style x:Key="InvalidEntryStyle" TargetType="Entry">
@@ -18,17 +18,17 @@
         <StackLayout>
             <Entry Placeholder="UriKind: Absolute">
                 <Entry.Behaviors>
-                    <behaviors:UriValidationBehavior UriKind="Absolute" InvalidStyle="{StaticResource InvalidEntryStyle}"/>
+                    <xct:UriValidationBehavior UriKind="Absolute" InvalidStyle="{StaticResource InvalidEntryStyle}"/>
                 </Entry.Behaviors>
             </Entry>
             <Entry Placeholder="UriKind: Relative">
                 <Entry.Behaviors>
-                    <behaviors:UriValidationBehavior UriKind="Relative" InvalidStyle="{StaticResource InvalidEntryStyle}"/>
+                    <xct:UriValidationBehavior UriKind="Relative" InvalidStyle="{StaticResource InvalidEntryStyle}"/>
                 </Entry.Behaviors>
             </Entry>
             <Entry Placeholder="UriKind: RelativeOrAbsolute">
                 <Entry.Behaviors>
-                    <behaviors:UriValidationBehavior UriKind="RelativeOrAbsolute" InvalidStyle="{StaticResource InvalidEntryStyle}"/>
+                    <xct:UriValidationBehavior UriKind="RelativeOrAbsolute" InvalidStyle="{StaticResource InvalidEntryStyle}"/>
                 </Entry.Behaviors>
             </Entry>
         </StackLayout>

--- a/XamarinCommunityToolkitSample/Pages/Behaviors/UserStoppedTypingBehaviorPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Behaviors/UserStoppedTypingBehaviorPage.xaml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-                xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors"
                 x:Class="Xamarin.CommunityToolkit.Sample.Pages.Behaviors.UserStoppedTypingBehaviorPage">
 
     <pages:BasePage.BindingContext>
@@ -48,10 +48,10 @@
 
             <SearchBar Placeholder="Start searching..." Margin="{StaticResource ContentPadding}">
                 <SearchBar.Behaviors>
-                    <behaviors:UserStoppedTypingBehavior Command="{Binding SearchCommand}"
-                                                         StoppedTypingTimeThreshold="{Binding Path=Text, Source={x:Reference TimeThresholdSetting}}"
-                                                         MinimumLengthThreshold="{Binding Path=Text, Source={x:Reference MinimumLengthThresholdSetting}}"
-                                                         ShouldDismissKeyboardAutomatically="{Binding Path=IsToggled, Source={x:Reference AutoDismissKeyboardSetting}}" />
+                    <xct:UserStoppedTypingBehavior Command="{Binding SearchCommand}"
+                                                   StoppedTypingTimeThreshold="{Binding Path=Text, Source={x:Reference TimeThresholdSetting}}"
+                                                   MinimumLengthThreshold="{Binding Path=Text, Source={x:Reference MinimumLengthThresholdSetting}}"
+                                                   ShouldDismissKeyboardAutomatically="{Binding Path=IsToggled, Source={x:Reference AutoDismissKeyboardSetting}}" />
                 </SearchBar.Behaviors>
             </SearchBar>
 

--- a/XamarinCommunityToolkitSample/Pages/Converters/ByteArrayToImageSourcePage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Converters/ByteArrayToImageSourcePage.xaml
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Converters.ByteArrayToImageSourcePage"
-                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Converters"
-                xmlns:converters="clr-namespace:Xamarin.CommunityToolkit.Converters;assembly=Xamarin.CommunityToolkit"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-                xmlns:views="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
-                >
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Converters"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Converters.ByteArrayToImageSourcePage">
 
     <pages:BasePage.BindingContext>
         <vm:ByteArrayToImageSourceViewModel />
@@ -14,7 +12,7 @@
 
     <ContentPage.Resources>
          <ResourceDictionary>
-             <converters:ByteArrayToImageSourceConverter x:Key="ByteArrayToImageSourceConverter" />
+             <xct:ByteArrayToImageSourceConverter x:Key="ByteArrayToImageSourceConverter" />
          </ResourceDictionary>
     </ContentPage.Resources>
 
@@ -27,9 +25,9 @@
                    HorizontalOptions="Center"
                    Text="Image below uses byte array from ViewModel which is converted to ImageSource using ByteArrayToImageSource converter." />
 
-            <views:AvatarView Size="300"
-                              Source="{Binding Avatar, Converter={StaticResource ByteArrayToImageSourceConverter}}"
-                              HorizontalOptions="Center" VerticalOptions="Center" />
+            <xct:AvatarView Size="300"
+                            Source="{Binding Avatar, Converter={StaticResource ByteArrayToImageSourceConverter}}"
+                            HorizontalOptions="Center" VerticalOptions="Center" />
 
             <Label Text="Please wait..."
                    Margin="16"

--- a/XamarinCommunityToolkitSample/Pages/Converters/ConvertersGalleryPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Converters/ConvertersGalleryPage.xaml
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
                 xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Converters"
                 x:Class="Xamarin.CommunityToolkit.Sample.Pages.Converters.ConvertersGalleryPage"
-                ControlTemplate="{StaticResource GalleryPageTemplate}"
-                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+                ControlTemplate="{StaticResource GalleryPageTemplate}">
 
     <pages:BasePage.BindingContext>
         <vm:ConvertersGalleryViewModel />

--- a/XamarinCommunityToolkitSample/Pages/Converters/DateTimeOffsetConverterPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Converters/DateTimeOffsetConverterPage.xaml
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Xamarin.CommunityToolkit.Sample.Pages.Converters.DateTimeOffsetConverterPage"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
                 xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Converters"
-                xmlns:converters="clr-namespace:Xamarin.CommunityToolkit.Converters;assembly=Xamarin.CommunityToolkit"
-                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Converters.DateTimeOffsetConverterPage">
     <pages:BasePage.BindingContext>
         <vm:DateTimeOffsetConverterViewModel />
     </pages:BasePage.BindingContext>
 
     <ContentPage.Resources>
          <ResourceDictionary>
-             <converters:DateTimeOffsetConverter x:Key="DateTimeOffsetConverter" />
+             <xct:DateTimeOffsetConverter x:Key="DateTimeOffsetConverter" />
          </ResourceDictionary>
     </ContentPage.Resources>
 

--- a/XamarinCommunityToolkitSample/Pages/Converters/ItemSelectedEventArgsPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Converters/ItemSelectedEventArgsPage.xaml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Converters"
-             xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
-             xmlns:converters="clr-namespace:Xamarin.CommunityToolkit.Converters;assembly=Xamarin.CommunityToolkit"
-             x:Class="Xamarin.CommunityToolkit.Sample.Pages.Converters.ItemSelectedEventArgsPage"
-             xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Converters"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Converters.ItemSelectedEventArgsPage">
 
     <pages:BasePage.BindingContext>
         <vm:ItemSelectedEventArgsViewModel />
@@ -13,7 +12,7 @@
 
     <ContentPage.Resources>
          <ResourceDictionary>
-             <converters:ItemSelectedEventArgsConverter x:Key="ItemSelectedEventArgsConverter" />
+             <xct:ItemSelectedEventArgsConverter x:Key="ItemSelectedEventArgsConverter" />
          </ResourceDictionary>
     </ContentPage.Resources>
 
@@ -53,7 +52,7 @@
         </ListView.ItemTemplate>
 
         <ListView.Behaviors>
-            <behaviors:EventToCommandBehavior EventName="ItemSelected"
+            <xct:EventToCommandBehavior EventName="ItemSelected"
                                               Command="{Binding ItemSelectedCommand}"
                                               EventArgsConverter="{StaticResource ItemSelectedEventArgsConverter}" />
         </ListView.Behaviors>

--- a/XamarinCommunityToolkitSample/Pages/Converters/ItemTappedEventArgsPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Converters/ItemTappedEventArgsPage.xaml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
                 xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Converters"
-                xmlns:behaviors="clr-namespace:Xamarin.CommunityToolkit.Behaviors;assembly=Xamarin.CommunityToolkit"
-                xmlns:converters="clr-namespace:Xamarin.CommunityToolkit.Converters;assembly=Xamarin.CommunityToolkit"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Converters.ItemTappedEventArgsPage"
-                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Converters.ItemTappedEventArgsPage">
 
     <pages:BasePage.BindingContext>
         <vm:ItemTappedEventArgsViewModel />
@@ -13,7 +12,7 @@
 
     <pages:BasePage.Resources>
         <ResourceDictionary>
-            <converters:ItemTappedEventArgsConverter x:Key="ItemTappedEventArgsConverter" />
+            <xct:ItemTappedEventArgsConverter x:Key="ItemTappedEventArgsConverter" />
         </ResourceDictionary>
     </pages:BasePage.Resources>
 
@@ -53,7 +52,7 @@
         </ListView.ItemTemplate>
 
         <ListView.Behaviors>
-            <behaviors:EventToCommandBehavior EventName="ItemTapped"
+            <xct:EventToCommandBehavior EventName="ItemTapped"
                                               Command="{Binding ItemTappedCommand}"
                                               EventArgsConverter="{StaticResource ItemTappedEventArgsConverter}" />
         </ListView.Behaviors>

--- a/XamarinCommunityToolkitSample/Pages/Converters/MultiConverterPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Converters/MultiConverterPage.xaml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pages:BasePage
-    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:xct="clr-namespace:Xamarin.CommunityToolkit.Converters;assembly=Xamarin.CommunityToolkit"
-    xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Converters"
-    x:Class="Xamarin.CommunityToolkit.Sample.Pages.Converters.MultiConverterPage">
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Converters"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Converters.MultiConverterPage">
     <pages:BasePage.Resources>
         <ResourceDictionary>
             <xct:MultiConverter

--- a/XamarinCommunityToolkitSample/Pages/Effects/EffectsGalleryPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Effects/EffectsGalleryPage.xaml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<pages:BasePage
-    x:Class="Xamarin.CommunityToolkit.Sample.Pages.Effects.EffectsGalleryPage"
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-    xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Effects"
-    ControlTemplate="{StaticResource GalleryPageTemplate}">
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Effects"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Effects.EffectsGalleryPage"
+                ControlTemplate="{StaticResource GalleryPageTemplate}">
     <pages:BasePage.BindingContext>
         <vm:EffectsGalleryViewModel />
     </pages:BasePage.BindingContext>

--- a/XamarinCommunityToolkitSample/Pages/Effects/IconTintColorEffectPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Effects/IconTintColorEffectPage.xaml
@@ -2,7 +2,7 @@
 <pages:BasePage
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:effects="clr-namespace:Xamarin.CommunityToolkit.Effects;assembly=Xamarin.CommunityToolkit"
+    xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
     xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
     x:Class="Xamarin.CommunityToolkit.Sample.Pages.Effects.IconTintColorEffectPage">
 
@@ -20,7 +20,7 @@
         <ScrollView>
             <StackLayout
                 Padding="20">
-                
+
                 <Label
                     Text="With the IconTintColorEffect you set the tint color of an image. This effects works on the Image and ImageButton controls and is implemented for the Android and iOS platform."
                     Margin="0,0,0,20"/>
@@ -39,17 +39,17 @@
                     <Image
                         Source="https://image.flaticon.com/icons/png/512/48/48639.png"
                         Grid.Row="1" />
-                    
+
                     <Image
                         Source="https://image.flaticon.com/icons/png/512/48/48639.png"
-                        effects:IconTintColorEffect.TintColor="Red"
+                        xct:IconTintColorEffect.TintColor="Red"
                         Grid.Row="2" />
-                    
+
                     <Image
                         Source="https://image.flaticon.com/icons/png/512/48/48639.png"
-                        effects:IconTintColorEffect.TintColor="Green"
+                        xct:IconTintColorEffect.TintColor="Green"
                         Grid.Row="3" />
-                    
+
 
                     <Label
                         Text="ImageButton control"
@@ -65,13 +65,13 @@
 
                     <ImageButton
                         Source="https://image.flaticon.com/icons/png/512/48/48639.png"
-                        effects:IconTintColorEffect.TintColor="Red"
+                        xct:IconTintColorEffect.TintColor="Red"
                         Grid.Row="2"
                         Grid.Column="1" />
 
                     <ImageButton
                         Source="https://image.flaticon.com/icons/png/512/48/48639.png"
-                        effects:IconTintColorEffect.TintColor="Green"
+                        xct:IconTintColorEffect.TintColor="Green"
                         Grid.Row="3"
                         Grid.Column="1" />
 

--- a/XamarinCommunityToolkitSample/Pages/Effects/RemoveBorderEffectPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Effects/RemoveBorderEffectPage.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-                xmlns:effects="clr-namespace:Xamarin.CommunityToolkit.Effects;assembly=Xamarin.CommunityToolkit"
                 x:Class="Xamarin.CommunityToolkit.Sample.Pages.Effects.RemoveBorderEffectPage"
                 Title="RemoveBorderEffect">
     <ContentPage.Content>
@@ -26,7 +26,7 @@
                 <Frame BackgroundColor="{StaticResource SoftFrameBackgroundColor}" HasShadow="False">
                     <Entry Placeholder="I don't have a border" TextColor="{StaticResource DarkLabelTextColor}" PlaceholderColor="{StaticResource DarkLabelPlaceholderColor}">
                         <Entry.Effects>
-                            <effects:RemoveBorderEffect/>
+                            <xct:RemoveBorderEffect/>
                         </Entry.Effects>
                     </Entry>
                 </Frame>

--- a/XamarinCommunityToolkitSample/Pages/Effects/SafeAreaEffectPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Effects/SafeAreaEffectPage.xaml
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<pages:BasePage
-    x:Class="Xamarin.CommunityToolkit.Sample.Pages.Effects.SafeAreaEffectPage"
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-    BackgroundColor="{StaticResource NormalButtonBackgroundColor}">
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Effects.SafeAreaEffectPage"
+                BackgroundColor="{StaticResource NormalButtonBackgroundColor}">
     <ContentPage.Content>
         <StackLayout
             x:Name="stack"

--- a/XamarinCommunityToolkitSample/Pages/Effects/SelectAllTextEffectPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Effects/SelectAllTextEffectPage.xaml
@@ -1,9 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-                xmlns:effects="clr-namespace:Xamarin.CommunityToolkit.Effects;assembly=Xamarin.CommunityToolkit"
-                xmlns:rsx="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit"
                 x:Class="Xamarin.CommunityToolkit.Sample.Pages.Effects.SelectAllTextEffectPage">
     <ContentPage.Content>
         <ScrollView>
@@ -23,13 +22,13 @@
                         <Entry Text="https://github.com/xamarin/XamarinCommunityToolkit" TextColor="{StaticResource DarkLabelTextColor}" PlaceholderColor="{StaticResource DarkLabelPlaceholderColor}"/>
                     </Frame>
                 </StackLayout>
-                
+
                 <StackLayout>
                     <Label Text="Entry with the effect, when focussed all text will be selected" FontAttributes="Italic"/>
                     <Frame BackgroundColor="{StaticResource SoftFrameBackgroundColor}" HasShadow="False">
                         <Entry Text="https://github.com/xamarin/XamarinCommunityToolkit" TextColor="{StaticResource DarkLabelTextColor}" PlaceholderColor="{StaticResource DarkLabelPlaceholderColor}">
                             <Entry.Effects>
-                                <effects:SelectAllTextEffect/>
+                                <xct:SelectAllTextEffect/>
                             </Entry.Effects>
                         </Entry>
                     </Frame>
@@ -55,7 +54,7 @@ Just my luck, no ice. I gave it a cold? I gave it a virus. A computer virus. Mus
                     <Frame BackgroundColor="{StaticResource SoftFrameBackgroundColor}" HasShadow="False">
                         <Editor TextColor="{StaticResource DarkLabelTextColor}" PlaceholderColor="{StaticResource DarkLabelPlaceholderColor}">
                             <Editor.Effects>
-                                <effects:SelectAllTextEffect/>
+                                <xct:SelectAllTextEffect/>
                             </Editor.Effects>
                             <Editor.Text>
                                 Yeah, but your scientists were so preoccupied with whether or not they could, they didn't stop to think if they should. Must go faster... go, go, go, go, go! You know what? It is beets. I've crashed into a beet truck. Is this my espresso machine? Wh-what is-h-how did you get my espresso machine?

--- a/XamarinCommunityToolkitSample/Pages/Extensions/ExtensionsGalleryPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Extensions/ExtensionsGalleryPage.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Extensions.ExtensionsGalleryPage"
-                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Extensions.ExtensionsGalleryPage">
     <pages:BasePage.Content>
     </pages:BasePage.Content>
 </pages:BasePage>

--- a/XamarinCommunityToolkitSample/Pages/SettingPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/SettingPage.xaml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Xamarin.CommunityToolkit.Sample.Pages.SettingPage"
-             xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-             xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels"
-             xmlns:rsx="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit"
-             x:DataType="vm:SettingViewModel">
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.SettingPage"
+                x:DataType="vm:SettingViewModel">
 
     <pages:BasePage.ToolbarItems>
         <ToolbarItem Text="X" Order="Primary" Clicked="OnCloseClicked" />
@@ -18,13 +18,13 @@
     <StackLayout Padding="{StaticResource ContentPadding}"
                  VerticalOptions="Center"
                  Spacing="10">
-        <Label Text="{rsx:Translate ChangeLanguage}"/>
+        <Label Text="{xct:Translate ChangeLanguage}"/>
 
         <Picker ItemsSource="{Binding SupportedLanguages}"
                 ItemDisplayBinding="{Binding Name}"
                 SelectedItem="{Binding SelectedLanguage}"/>
 
-        <Button Text="{rsx:Translate Save}"
+        <Button Text="{xct:Translate Save}"
                 Command="{Binding ChangeLanguageCommand, Mode=OneTime}"/>
     </StackLayout>
 </pages:BasePage>

--- a/XamarinCommunityToolkitSample/Pages/TestCases/TestCasesGalleryPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/TestCases/TestCasesGalleryPage.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.TestCases.TestCasesGalleryPage"
-                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.TestCases.TestCasesGalleryPage">
     <pages:BasePage.Content>
     </pages:BasePage.Content>
 </pages:BasePage>

--- a/XamarinCommunityToolkitSample/Pages/Views/AvatarViewPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/AvatarViewPage.xaml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<pages:BasePage x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.AvatarViewPage"
-                xmlns="http://xamarin.com/schemas/2014/forms"
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-                xmlns:rsx="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit"
                 xmlns:viewmodels="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Views"
-                xmlns:views="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit">
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.AvatarViewPage">
 
     <pages:BasePage.BindingContext>
         <viewmodels:AvatarViewViewModel />
@@ -22,7 +21,7 @@
                                      Orientation="Horizontal"
                                      Spacing="10">
 
-                            <views:AvatarView ColorTheme="{x:Static views:ColorTheme.Jungle}"
+                            <xct:AvatarView ColorTheme="{x:Static xct:ColorTheme.Jungle}"
                                               FontSize="Medium"
                                               Size="{Binding Value,
                                               Source={x:Reference Slider}}"
@@ -45,7 +44,7 @@
             </CollectionView.ItemTemplate>
         </CollectionView>
         <StackLayout Padding="{StaticResource ContentPadding}">
-            <Label Text="{rsx:Translate AvatarViewSizeText}" />
+            <Label Text="{xct:Translate AvatarViewSizeText}" />
             <Slider x:Name="Slider"
                     Maximum="80"
                     Minimum="40"

--- a/XamarinCommunityToolkitSample/Pages/Views/AvatarViewPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/AvatarViewPage.xaml
@@ -27,10 +27,10 @@
                                               Source={x:Reference Slider}}"
                                               Text="{Binding Initials}">
 
-                                <views:AvatarView.Source>
+                                <xct:AvatarView.Source>
                                     <UriImageSource Uri="{Binding Source}" />
-                                </views:AvatarView.Source>
-                            </views:AvatarView>
+                                </xct:AvatarView.Source>
+                            </xct:AvatarView>
 
                             <Label FontSize="20"
                                    Text="{Binding Name}"

--- a/XamarinCommunityToolkitSample/Pages/Views/BadgeViewPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/BadgeViewPage.xaml
@@ -1,12 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<pages:BasePage
-    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:controls="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
-    xmlns:viewmodels="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Views"
-    x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.BadgeViewPage"
-    Title="BadgeView">
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                xmlns:viewmodels="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Views"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.BadgeViewPage"
+                Title="BadgeView">
     <pages:BasePage.Resources>
         <ResourceDictionary>
 
@@ -28,24 +27,24 @@
                 <Label
                     Text="Getting started"
                     Style="{StaticResource SectionStyle}"/>
-                <controls:BadgeView
+                <xct:BadgeView
                     BackgroundColor="Red"
                     TextColor="White"
                     Text="1">
                     <Label
                         Text="BadgeView"/>
-                </controls:BadgeView>
+                </xct:BadgeView>
                 <Label
                     Text="Customization options"
                     Style="{StaticResource SectionStyle}"/>
-                <controls:BadgeView
+                <xct:BadgeView
                     BackgroundColor="Blue"
                     TextColor="White"
                     Text="1003">
                     <Label
                         Text="Long Text"/>
-                </controls:BadgeView>
-                <controls:BadgeView
+                </xct:BadgeView>
+                <xct:BadgeView
                     BackgroundColor="Red"
                     FontAttributes="Bold"
                     FontSize="8"
@@ -53,8 +52,8 @@
                     Text="1">
                     <Label
                         Text="Font Customization"/>
-                </controls:BadgeView>
-                <controls:BadgeView
+                </xct:BadgeView>
+                <xct:BadgeView
                     BackgroundColor="Red"
                     FontAttributes="Bold"
                     FontSize="Medium"
@@ -62,16 +61,16 @@
                     Text="1">
                     <Label
                         Text="Named Font Size"/>
-                </controls:BadgeView>
-                <controls:BadgeView
+                </xct:BadgeView>
+                <xct:BadgeView
                     BackgroundColor="Red"
                     BorderColor="Orange"
                     TextColor="White"
                     Text="1">
                     <Label
                         Text="Border Customization"/>
-                </controls:BadgeView>
-                <controls:BadgeView
+                </xct:BadgeView>
+                <xct:BadgeView
                     BackgroundColor="Red"
                     BorderColor="Orange"
                     HasShadow="True"
@@ -79,8 +78,8 @@
                     Text="1">
                     <Label
                         Text="Shadow Customization"/>
-                </controls:BadgeView>
-                <controls:BadgeView
+                </xct:BadgeView>
+                <xct:BadgeView
                     HorizontalOptions="Center"
                     BadgePosition="TopRight"
                     BackgroundColor="Red"
@@ -96,11 +95,11 @@
                             VerticalOptions="Center"
                             Text="TopRight"/>
                     </Grid>
-                </controls:BadgeView>
+                </xct:BadgeView>
                 <Label
                     Text="Badge animations"
                     Style="{StaticResource SectionStyle}"/>
-                <controls:BadgeView
+                <xct:BadgeView
                     BackgroundColor="Red"
                     Text="{Binding Counter}"
                     TextColor="White">
@@ -115,7 +114,7 @@
                             Command="{Binding DecreaseCommand}"
                             Text="Decrease"/>
                     </StackLayout>
-                </controls:BadgeView>
+                </xct:BadgeView>
             </StackLayout>
         </ScrollView>
     </ContentPage.Content>

--- a/XamarinCommunityToolkitSample/Pages/Views/CameraViewPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/CameraViewPage.xaml
@@ -1,12 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<pages:BasePage
-    x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.CameraViewPage"
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-    xmlns:views="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit">
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.CameraViewPage">
     <StackLayout>
-        <views:CameraView
+        <xct:CameraView
             x:Name="cameraView"
             CaptureOptions="Video"
             FlashMode="On"

--- a/XamarinCommunityToolkitSample/Pages/Views/ExpanderPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/ExpanderPage.xaml
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:views="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
                 xmlns:viewmodels="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Views"
                 x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.ExpanderPage"
-                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
                 x:Name="page">
 
     <pages:BasePage.BindingContext>
@@ -15,23 +15,23 @@
         <StackLayout BindableLayout.ItemsSource="{Binding Items}">
             <BindableLayout.ItemTemplate>
                 <DataTemplate>
-                    <views:Expander ExpandAnimationEasing="{x:Static Easing.CubicIn}"
+                    <xct:Expander ExpandAnimationEasing="{x:Static Easing.CubicIn}"
                                 CollapseAnimationEasing="{x:Static Easing.CubicOut}"
                                 IsExpanded="{Binding IsExpanded}"
                                 Command="{Binding BindingContext.Command, Source={x:Reference page}}"
                                 CommandParameter="{Binding .}">
-                        <views:Expander.Header>
+                        <xct:Expander.Header>
                             <StackLayout Orientation="Horizontal" Spacing="0">
                                 <Label Text="{Binding Name}" HorizontalOptions="FillAndExpand" FontSize="32" FontAttributes="Bold"/>
                                 <Label Text="Enable nested:" FontSize="13" VerticalOptions="CenterAndExpand" />
                                 <Switch IsToggled="{Binding IsEnabled}" />
                             </StackLayout>
-                        </views:Expander.Header>
-                        <views:Expander IsEnabled="{Binding IsEnabled}">
-                            <views:Expander.Header>
+                        </xct:Expander.Header>
+                        <xct:Expander IsEnabled="{Binding IsEnabled}">
+                            <xct:Expander.Header>
                                 <Label Text="Nested expander" FontSize="30" FontAttributes="Bold"/>
-                            </views:Expander.Header>
-                            <views:Expander.ContentTemplate>
+                            </xct:Expander.Header>
+                            <xct:Expander.ContentTemplate>
                                 <DataTemplate>
                                     <StackLayout Spacing="0" Margin="10" Padding="1" BackgroundColor="Black">
                                         <BoxView HeightRequest="50" Color="White" />
@@ -39,9 +39,9 @@
                                         <BoxView HeightRequest="50" Color="White" />
                                     </StackLayout>
                                 </DataTemplate>
-                            </views:Expander.ContentTemplate>
-                        </views:Expander>
-                    </views:Expander>
+                            </xct:Expander.ContentTemplate>
+                        </xct:Expander>
+                    </xct:Expander>
                 </DataTemplate>
             </BindableLayout.ItemTemplate>
         </StackLayout>

--- a/XamarinCommunityToolkitSample/Pages/Views/GravatarImagePage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/GravatarImagePage.xaml
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
                 xmlns:viewmodels="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Views"
-                xmlns:toolkit="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
-                xmlns:xaml="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit"
                 x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.GravatarImagePage">
     <pages:BasePage.BindingContext>
         <viewmodels:GravatarImageViewModel />
@@ -16,17 +15,17 @@
                 <Label Text="Full Image Source" />
                 <Image>
                     <Image.Source>
-                        <toolkit:GravatarImageSource Email="{Binding Email}"
-                                                     Size="{Binding Size}"
-                                                     CachingEnabled="{Binding EnableCache}" />
+                        <xct:GravatarImageSource Email="{Binding Email}"
+                                                 Size="{Binding Size}"
+                                                 CachingEnabled="{Binding EnableCache}" />
                     </Image.Source>
                 </Image>
 
                 <Label Text="XAML Extension" />
-                <Image Source="{xaml:GravatarImage {Binding Email}, Size=65, CachingEnabled={Binding EnableCache}}" />
+                <Image Source="{xct:GravatarImage {Binding Email}, Size=65, CachingEnabled={Binding EnableCache}}" />
 
                 <Label Text="Default Gravatar" />
-                <Image Source="{xaml:GravatarImage '', Default={Binding DefaultGravatar}, Size={Binding Size}, CachingEnabled={Binding EnableCache}}" />
+                <Image Source="{xct:GravatarImage '', Default={Binding DefaultGravatar}, Size={Binding Size}, CachingEnabled={Binding EnableCache}}" />
             </StackLayout>
         </Frame>
 

--- a/XamarinCommunityToolkitSample/Pages/Views/MediaElementPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/MediaElementPage.xaml
@@ -1,20 +1,18 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<pages:BasePage
-    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:converters="clr-namespace:Xamarin.CommunityToolkit.Converters;assembly=Xamarin.CommunityToolkit"
-    xmlns:views="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
-    x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.MediaElementPage">
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.MediaElementPage">
     <pages:BasePage.Resources>
-        <converters:TimeSpanToDoubleConverter x:Key="TimeSpanConverter"/>
+        <xct:TimeSpanToDoubleConverter x:Key="TimeSpanConverter"/>
     </pages:BasePage.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <views:MediaElement
+        <xct:MediaElement
             x:Name="mediaElement"
             Source="https://sec.ch9.ms/ch9/5d93/a1eab4bf-3288-4faf-81c4-294402a85d93/XamarinShow_mid.mp4"
             ShowsPlaybackControls="True"

--- a/XamarinCommunityToolkitSample/Pages/Views/RangeSliderPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/RangeSliderPage.xaml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:views="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
-             xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-             x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.RangeSliderPage">
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.RangeSliderPage">
 
     <pages:BasePage.Resources>
         <x:String x:Key="CustomValueLabeStringFormat">{0:0.#}</x:String>
@@ -31,7 +31,7 @@
     <StackLayout>
 
         <Frame Padding="15, 20">
-            <views:RangeSlider
+            <xct:RangeSlider
                 x:Name="RangeSlider"
                 MaximumValue="10"
                 MinimumValue="-10"
@@ -56,13 +56,13 @@
                 IsEnabled="{Binding IsToggled, Source={x:Reference IsEnabledSwitch}}"
                 ValueLabelSpacing="{Binding Value, Source={x:Reference ValueLabelSpacingSlider}}">
 
-                <views:RangeSlider.LowerThumbView>
+                <xct:RangeSlider.LowerThumbView>
                     <Label Text="L" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" IsVisible="{Binding IsToggled, Source={x:Reference LowerThumbViewSwitch}}" />
-                </views:RangeSlider.LowerThumbView>
-                <views:RangeSlider.UpperThumbView>
+                </xct:RangeSlider.LowerThumbView>
+                <xct:RangeSlider.UpperThumbView>
                     <Label Text="U" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" IsVisible="{Binding IsToggled, Source={x:Reference UpperThumbViewSwitch}}" />
-                </views:RangeSlider.UpperThumbView>
-            </views:RangeSlider>
+                </xct:RangeSlider.UpperThumbView>
+            </xct:RangeSlider>
         </Frame>
 
         <ScrollView Padding="15, 20">

--- a/XamarinCommunityToolkitSample/Pages/Views/ShieldPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/ShieldPage.xaml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<pages:BasePage
-    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:controls="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
-    x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.ShieldPage"
-    Title="Shield">
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.ShieldPage"
+                Title="Shield">
 
     <StackLayout
         Spacing="10">
@@ -13,7 +12,7 @@
         <StackLayout
             Orientation="Horizontal">
 
-            <controls:Shield
+            <xct:Shield
                 Subject="C#"
                 Status=">=4.5"
                 Color="DodgerBlue"
@@ -21,14 +20,14 @@
                 Margin="2,0"
                 Tapped="OnShieldTapped" />
 
-            <controls:Shield
+            <xct:Shield
                 Subject="IDE"
                 Status="2019"
                 Color="DodgerBlue"
                 TextColor="White"
                 Margin="2,0" />
 
-            <controls:Shield
+            <xct:Shield
                 Subject="chat"
                 Status="on discord"
                 Color="SeaGreen"
@@ -39,7 +38,7 @@
         <StackLayout
             Orientation="Horizontal">
 
-            <controls:Shield
+            <xct:Shield
                 Subject="IDE"
                 Status="2019"
                 Color="DodgerBlue"
@@ -47,7 +46,7 @@
                 FontSize="20"
                 Margin="2,0" />
 
-            <controls:Shield
+            <xct:Shield
                 Subject="IDE"
                 Status="2019"
                 Color="DodgerBlue"
@@ -55,7 +54,7 @@
                 FontSize="Title"
                 Margin="2,0" />
 
-            <controls:Shield
+            <xct:Shield
                 Subject="IDE"
                 Status="2019"
                 Color="DodgerBlue"
@@ -63,7 +62,7 @@
                 FontAttributes="Bold"
                 Margin="2,0" />
 
-            <controls:Shield
+            <xct:Shield
                 Subject="IDE"
                 Status="2019"
                 Color="DodgerBlue"

--- a/XamarinCommunityToolkitSample/Pages/Views/SideMenuViewPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/SideMenuViewPage.xaml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:views="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
-             xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-             x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.SideMenuViewPage">
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.SideMenuViewPage">
 
     <pages:BasePage.Resources>
         <Style x:Key="BaseMenuButtonStyle" TargetType="Button">
@@ -14,7 +14,7 @@
         </Style>
     </pages:BasePage.Resources>
 
-    <views:SideMenuView x:Name="SideMenuView">
+    <xct:SideMenuView x:Name="SideMenuView">
         <!-- MainView -->
         <StackLayout
             Orientation="Horizontal"
@@ -31,15 +31,15 @@
         <!-- LeftMenu -->
         <BoxView
             BackgroundColor="Orange"
-            views:SideMenuView.Position="LeftMenu"
-            views:SideMenuView.MenuWidthPercentage=".5" />
+            xct:SideMenuView.Position="LeftMenu"
+            xct:SideMenuView.MenuWidthPercentage=".5" />
 
         <!-- RightMenu -->
         <BoxView
             BackgroundColor="LightGreen"
-            views:SideMenuView.Position="RightMenu"
-            views:SideMenuView.MenuWidthPercentage=".3" />
+            xct:SideMenuView.Position="RightMenu"
+            xct:SideMenuView.MenuWidthPercentage=".3" />
 
-    </views:SideMenuView>
+    </xct:SideMenuView>
 
 </pages:BasePage>

--- a/XamarinCommunityToolkitSample/Pages/Views/StateLayoutPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/StateLayoutPage.xaml
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:state="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
-             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"                
+             xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
              xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
              xmlns:viewmodels="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Views"
-             xmlns:converters="clr-namespace:Xamarin.CommunityToolkit.Converters;assembly=Xamarin.CommunityToolkit"
              x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.StateLayoutPage"
              ios:Page.UseSafeArea="true">
 
@@ -14,18 +13,18 @@
     </pages:BasePage.BindingContext>
 
     <pages:BasePage.Resources>
-        <converters:StateToBooleanConverter x:Key="StateToBooleanConverter" />
+        <xct:StateToBooleanConverter x:Key="StateToBooleanConverter" />
     </pages:BasePage.Resources>
     <pages:BasePage.Content>
-        <Grid state:StateLayout.CurrentState="{Binding MainState}" state:StateLayout.AnimateStateChanges="False">
-            <state:StateLayout.StateViews>
-                <state:StateView StateKey="Loading" BackgroundColor="White" VerticalOptions="FillAndExpand">
+        <Grid xct:StateLayout.CurrentState="{Binding MainState}" xct:StateLayout.AnimateStateChanges="False">
+            <xct:StateLayout.StateViews>
+                <xct:StateView StateKey="Loading" BackgroundColor="White" VerticalOptions="FillAndExpand">
                     <StackLayout VerticalOptions="Center" HorizontalOptions="Center">
-                        <ActivityIndicator Color="#1abc9c" IsRunning="{Binding MainState, Converter={StaticResource StateToBooleanConverter}, ConverterParameter={x:Static state:LayoutState.Loading}}" />
+                        <ActivityIndicator Color="#1abc9c" IsRunning="{Binding MainState, Converter={StaticResource StateToBooleanConverter}, ConverterParameter={x:Static xct:LayoutState.Loading}}" />
                         <Label Text="Loading..." HorizontalOptions="Center" />
                     </StackLayout>
-                </state:StateView>
-            </state:StateLayout.StateViews>
+                </xct:StateView>
+            </xct:StateLayout.StateViews>
             <ScrollView>
                 <StackLayout Spacing="0" Padding="40,30,40,40">
 
@@ -38,51 +37,51 @@
                     <Label Text="This will show all states at an interval of 3 seconds."
                            FontSize="14" Margin="0,8,0,16" HorizontalOptions="Center" HorizontalTextAlignment="Center" />
 
-                    <Button Command="{Binding CycleStatesCommand}" IsVisible="{Binding CurrentState, Converter={StaticResource StateToBooleanConverter}, ConverterParameter={x:Static state:LayoutState.None}}"
+                    <Button Command="{Binding CycleStatesCommand}" IsVisible="{Binding CurrentState, Converter={StaticResource StateToBooleanConverter}, ConverterParameter={x:Static xct:LayoutState.None}}"
                             Text="Cycle All States" Margin="0,0,0,16" />
 
-                    <StackLayout Padding="10" state:StateLayout.CurrentState="{Binding CurrentState}"
-                                 state:StateLayout.CurrentCustomStateKey="{Binding CustomState}" BackgroundColor="#f0f1f2">
-                        <state:StateLayout.StateViews>
-                            <state:StateView StateKey="Empty">
+                    <StackLayout Padding="10" xct:StateLayout.CurrentState="{Binding CurrentState}"
+                                 xct:StateLayout.CurrentCustomStateKey="{Binding CustomState}" BackgroundColor="#f0f1f2">
+                        <xct:StateLayout.StateViews>
+                            <xct:StateView StateKey="Empty">
                                 <Label Text="This is the empty state. Nothing in here!" VerticalOptions="Center"
                                        VerticalTextAlignment="Center" HorizontalOptions="Center" HorizontalTextAlignment="Center" />
-                            </state:StateView>
-                            <state:StateView StateKey="Saving">
+                            </xct:StateView>
+                            <xct:StateView StateKey="Saving">
                                 <StackLayout>
-                                    <ActivityIndicator IsRunning="{Binding CurrentState, Converter={StaticResource StateToBooleanConverter}, ConverterParameter={x:Static state:LayoutState.Saving}}" Color="Fuchsia" />
+                                    <ActivityIndicator IsRunning="{Binding CurrentState, Converter={StaticResource StateToBooleanConverter}, ConverterParameter={x:Static xct:LayoutState.Saving}}" Color="Fuchsia" />
                                     <Label Text="Saving the world!" VerticalOptions="Center" VerticalTextAlignment="Center"
                                            HorizontalOptions="Center" HorizontalTextAlignment="Center"  />
                                 </StackLayout>
-                            </state:StateView>
-                            <state:StateView StateKey="Loading">
+                            </xct:StateView>
+                            <xct:StateView StateKey="Loading">
                                 <StackLayout>
-                                    <ActivityIndicator IsRunning="{Binding CurrentState, Converter={StaticResource StateToBooleanConverter}, ConverterParameter={x:Static state:LayoutState.Loading}}" Color="Fuchsia" />
+                                    <ActivityIndicator IsRunning="{Binding CurrentState, Converter={StaticResource StateToBooleanConverter}, ConverterParameter={x:Static xct:LayoutState.Loading}}" Color="Fuchsia" />
                                     <Label Text="This is the loading state. So we have a loader!" VerticalOptions="Center"
                                            VerticalTextAlignment="Center" HorizontalOptions="Center" HorizontalTextAlignment="Center"  />
                                 </StackLayout>
-                            </state:StateView>
-                            <state:StateView StateKey="Error" RepeatCount="4">
-                                <state:StateView.RepeatTemplate>
+                            </xct:StateView>
+                            <xct:StateView StateKey="Error" RepeatCount="4">
+                                <xct:StateView.RepeatTemplate>
                                     <DataTemplate>
                                         <Label Text="Something went horribly wrong!" VerticalOptions="Center"
                                                VerticalTextAlignment="Center" HorizontalOptions="Center" HorizontalTextAlignment="Center"  />
                                     </DataTemplate>
-                                </state:StateView.RepeatTemplate>
-                            </state:StateView>
-                            <state:StateView StateKey="Custom" CustomStateKey="ThisIsCustomHi">
+                                </xct:StateView.RepeatTemplate>
+                            </xct:StateView>
+                            <xct:StateView StateKey="Custom" CustomStateKey="ThisIsCustomHi">
                                 <Label Text="Hi, I'm a custom state!" VerticalOptions="Center" VerticalTextAlignment="Center"
                                        HorizontalOptions="Center" HorizontalTextAlignment="Center"  />
-                            </state:StateView>
-                            <state:StateView StateKey="Custom" CustomStateKey="ThisIsCustomToo">
+                            </xct:StateView>
+                            <xct:StateView StateKey="Custom" CustomStateKey="ThisIsCustomToo">
                                 <Label Text="Hi, I'm a custom state too!" VerticalOptions="Center" VerticalTextAlignment="Center"
                                        HorizontalOptions="Center" HorizontalTextAlignment="Center"  />
-                            </state:StateView>
-                            <state:StateView StateKey="Success">
+                            </xct:StateView>
+                            <xct:StateView StateKey="Success">
                                 <Label Text="Hooray! Great success!" VerticalOptions="Center" VerticalTextAlignment="Center"
                                        HorizontalOptions="Center" HorizontalTextAlignment="Center"  />
-                            </state:StateView>
-                        </state:StateLayout.StateViews>
+                            </xct:StateView>
+                        </xct:StateLayout.StateViews>
                         <Label Text="This is the normal state." VerticalOptions="Center" VerticalTextAlignment="Center"
                                HorizontalOptions="Center" HorizontalTextAlignment="Center" />
                     </StackLayout>

--- a/XamarinCommunityToolkitSample/Pages/Views/ViewsGalleryPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/ViewsGalleryPage.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Views"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Views"
                 x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.ViewsGalleryPage"
                 ControlTemplate="{StaticResource GalleryPageTemplate}">
 

--- a/XamarinCommunityToolkitSample/Pages/WelcomePage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/WelcomePage.xaml
@@ -3,10 +3,9 @@
     x:Class="Xamarin.CommunityToolkit.Sample.Pages.WelcomePage"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:custom="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-    xmlns:rsx="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit"
     xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels"
+    xmlns:custom="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     x:Name="Page"
     Title="Welcome"
     NavigationPage.BackButtonTitle="">


### PR DESCRIPTION
### Description of Change ###

Adding XmlnsDefinitions for the Xamarin Community Toolkit. This utilizes a namespace based on what we see from Xamarin.Forms `http://xamarin.com/schemas/{year}/{product}`. The sample app has been updated to use the new `http://xamarin.com/schemas/2020/toolkit` namespace consistently using the `xct` prefix. 

**Q.** Why is the XmlnsDefinition Attribute excluded from .NET Standard 1.0?
**A.** Xamarin.Forms makes this API internal for netstandard1.0 due to an issue with Reflection methods that are not available. For those impacted, they can continue to use a traditional explicit xmlns for each clr namespace they require, or they can simply update to netstandard2.0
![image](https://user-images.githubusercontent.com/3860573/94939908-a4fbe600-0487-11eb-8938-642ff37f52ea.png)
*from the Xamarin.Forms source*

### Issue ###

- closes #345 

### API Changes ###

none

### Behavioral Changes ###

When consuming the Xamarin Community Toolkit you will no longer need to declare a unique xmlns for each CLR namespace you're consuming in XAML (unless you're oddly using netstandard1.0)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
