### PR TITLE
[Android] Adds EntryFormattedText Effect

### DIFF
--- a/XamarinCommunityToolkit.UnitTests/Xamarin - Backup.CommunityToolkit.UnitTests.csproj
+++ b/XamarinCommunityToolkit.UnitTests/Xamarin - Backup.CommunityToolkit.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/XamarinCommunityToolkit.UnitTests/Xamarin.CommunityToolkit.UnitTests.csproj
+++ b/XamarinCommunityToolkit.UnitTests/Xamarin.CommunityToolkit.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/XamarinCommunityToolkit/Effects/EntryFormattedTextEffect.android.cs
+++ b/XamarinCommunityToolkit/Effects/EntryFormattedTextEffect.android.cs
@@ -54,9 +54,7 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			base.OnElementPropertyChanged(args);
 
 			if (args.PropertyName == FormattedTextEffect.FormattedTextProperty.PropertyName)
-			{
 				UpdateFormattedText();
-			}
 		}
 
 		void OnTextChanged(object sender, global::Android.Text.TextChangedEventArgs args)

--- a/XamarinCommunityToolkit/Effects/EntryFormattedTextEffect.android.cs
+++ b/XamarinCommunityToolkit/Effects/EntryFormattedTextEffect.android.cs
@@ -2,6 +2,7 @@
 using Android.Text;
 using Android.Text.Style;
 using Android.Widget;
+using Xamarin.CommunityToolkit.Android.Effects;
 using Xamarin.CommunityToolkit.Effects;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
@@ -9,7 +10,7 @@ using Xamarin.Forms.Platform.Android;
 [assembly: ResolutionGroupName(nameof(Xamarin.CommunityToolkit))]
 [assembly: ExportEffect(typeof(EntryFormattedTextEffect), nameof(EntryFormattedTextEffect))]
 
-namespace Xamarin.CommunityToolkit.Effects
+namespace Xamarin.CommunityToolkit.Android.Effects
 {
 	/// <summary>
 	/// The FormattedText <see cref="PlatformEffect"/> specific

--- a/XamarinCommunityToolkit/Effects/EntryFormattedTextEffect.android.cs
+++ b/XamarinCommunityToolkit/Effects/EntryFormattedTextEffect.android.cs
@@ -1,0 +1,109 @@
+﻿using System.ComponentModel;
+using Android.Text;
+using Android.Text.Style;
+using Android.Widget;
+using Xamarin.CommunityToolkit.Effects;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ResolutionGroupName(nameof(Xamarin.CommunityToolkit))]
+[assembly: ExportEffect(typeof(EntryFormattedTextEffect), nameof(EntryFormattedTextEffect))]
+
+namespace Xamarin.CommunityToolkit.Effects
+{
+	/// <summary>
+	/// The FormattedText <see cref="PlatformEffect"/> specific
+	/// to <see cref="Entry"/> controls.
+	/// </summary>
+	public class EntryFormattedTextEffect : PlatformEffect
+	{
+		/// <summary>
+		/// Gets the native <see cref="FormsEditText"/> control.
+		/// </summary>
+		public new FormsEditText Control => (FormsEditText)base.Control;
+
+		/// <summary>
+		/// Gets the Xamarin.Forms <see cref="Entry"/> element.
+		/// </summary>
+		public new Entry Element => (Entry)base.Element;
+
+		/// <inheritdoc />
+		protected override void OnAttached()
+		{
+			UpdateFormattedText();
+		}
+
+		/// <inheritdoc />
+		protected override void OnDetached()
+		{
+		}
+
+		/// <inheritdoc />
+		protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)
+		{
+			base.OnElementPropertyChanged(args);
+
+			if (args.PropertyName == FormattedTextEffect.FormattedTextProperty.PropertyName)
+			{
+				UpdateFormattedText();
+			}
+		}
+
+		/// <summary>
+		/// Updates the native <see cref="FormsEditText"/> with the
+		/// Text or FormattedText. If the FormattedText is null the
+		/// Control defaults to using Text property. Otherwise it uses
+		/// the custom Spans in FormattedText.
+		/// </summary>
+		void UpdateFormattedText()
+		{
+			var selectionStart = Control.SelectionStart;
+			var selectionEnd = Control.SelectionEnd;
+			var formattedText = FormattedTextEffect.GetFormattedText(Element);
+
+			if (formattedText == null)
+			{
+				Control.Text = Element.Text;
+			}
+			else
+			{
+				var text = new SpannableStringBuilder();
+				var position = 0;
+				for (var index = 0; index < formattedText.Spans.Count; index++)
+				{
+					var currentSpan = formattedText.Spans[index];
+					text.Append(currentSpan.Text);
+
+					var nativeSpan = CreateNativeSpan(currentSpan);
+					text.SetSpan(nativeSpan, position, position + currentSpan.Text.Length, SpanTypes.ExclusiveExclusive);
+
+					position += currentSpan.Text.Length;
+				}
+
+				Control.SetText(text, TextView.BufferType.Spannable);
+			}
+
+			Control.SetSelection(selectionStart, selectionEnd);
+		}
+
+		/// <summary>
+		/// Create a native Android Span that is used
+		/// with the <see cref="Spannable"/> object.
+		/// </summary>
+		/// <param name="span">
+		/// The Xamarin.Forms <see cref="Span"/> to convert to a native span.
+		/// </param>
+		/// <returns>
+		/// The native Android Span.
+		/// </returns>
+		/// <remarks>
+		/// The native Android <see cref="Spannable"/> accepts <see cref="Java.Lang.Object"/>
+		/// which allows several different types. Please refer to the Android Documentation
+		/// on usage. https://developer.android.com/reference/android/text/Spannable.
+		/// </remarks>
+		protected virtual Java.Lang.Object CreateNativeSpan(Span span)
+		{
+			return new ForegroundColorSpan(span.TextColor.ToAndroid());
+		}
+	}
+}

--- a/XamarinCommunityToolkit/Effects/EntryFormattedTextEffect.android.cs
+++ b/XamarinCommunityToolkit/Effects/EntryFormattedTextEffect.android.cs
@@ -61,7 +61,7 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 
 		void OnTextChanged(object sender, global::Android.Text.TextChangedEventArgs args)
 		{
-			var spannable = (SpannableStringBuilder)args.Text;
+			var spannable = args.Text as SpannableStringBuilder;
 			if (spannable == null || Segments.Count == 0)
 			{
 				return;

--- a/XamarinCommunityToolkit/Effects/EntryFormattedTextEffect.android.cs
+++ b/XamarinCommunityToolkit/Effects/EntryFormattedTextEffect.android.cs
@@ -63,16 +63,19 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			}
 
 			var characterStyleClass = Java.Lang.Class.FromType(typeof(CharacterStyle));
+			var findSpans = spannable.GetSpans(args.Start, args.Start + args.AfterCount, characterStyleClass);
 
-			var findSpans = spannable.GetSpans(args.Start, args.AfterCount, characterStyleClass);
-			if (findSpans != null && findSpans.Length > 0)
+			if (HasSpan())
 			{
-				var spanStartPosition = spannable.GetSpanStart(findSpans[0]);
-				var spanEndPosition = spannable.GetSpanEnd(findSpans[0]);
+				var startPosition = spannable.GetSpanStart(findSpans[0]);
+				var endPosition = spannable.GetSpanEnd(findSpans[0]);
 
-				spannable.SetSpan(findSpans[0], spanStartPosition, spanEndPosition, SpanTypes.ExclusiveExclusive);
+				spannable.SetSpan(findSpans[0], startPosition, endPosition, SpanTypes.ExclusiveExclusive);
 			}
+
+			bool HasSpan() => findSpans != null & findSpans.Length > 0;
 		}
+
 
 		/// <summary>
 		/// Updates the native <see cref="FormsEditText"/> with the

--- a/XamarinCommunityToolkit/Effects/FormattedTextEffect.shared.cs
+++ b/XamarinCommunityToolkit/Effects/FormattedTextEffect.shared.cs
@@ -1,0 +1,69 @@
+﻿using System.Linq;
+using Xamarin.Forms;
+
+namespace Xamarin.CommunityToolkit.Effects
+{
+	/// <summary>
+	/// Manages adding a <see cref="FormattedString"/> to an existing
+	/// input control such as <see cref="Entry"/>.
+	/// </summary>
+	public static class FormattedTextEffect
+	{
+		public static readonly BindableProperty FormattedTextProperty = BindableProperty.CreateAttached(
+			"FormattedText", typeof(FormattedString), typeof(FormattedTextEffect), null, propertyChanged: OnPropertyChanged);
+
+		/// <summary>
+		/// Gets the value of the "FormattedText".
+		/// </summary>
+		/// <param name="view">
+		/// The element to retrieve the property from.
+		/// </param>
+		/// <returns>
+		/// The <see cref="FormattedString"/> property from the <see cref="BindableObject"/>.
+		/// </returns>
+		public static FormattedString GetFormattedText(BindableObject view) =>
+			(FormattedString)view.GetValue(FormattedTextProperty);
+
+		/// <summary>
+		/// Sets the value of the "FormattedText".
+		/// </summary>
+		/// <param name="view">
+		/// The element on which to set the "FormattedText".
+		/// </param>
+		/// <param name="value">
+		/// The new <see cref="FormattedString"/> value.
+		/// </param>
+		public static void SetFormattedText(BindableObject view, FormattedString value) =>
+			view.SetValue(FormattedTextProperty, value);
+
+		/// <summary>
+		/// Automates attaching the Xamarin.Forms Effect to the control. This
+		/// method automatically clears out any existing <see cref="EntryFormattedText"/>
+		/// as there should only ever be 1.
+		/// </summary>
+		/// <param name="bindable">The bindable object.</param>
+		/// <param name="oldValue">The old value.</param>
+		/// <param name="newValue">The new value.</param>
+		static void OnPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is View view && newValue != oldValue)
+			{
+				var effectsToRemove = view.Effects.OfType<EntryFormattedText>().ToArray();
+				for (var index = 0; index < effectsToRemove.Length; index++)
+				{
+					view.Effects.Remove(effectsToRemove[index]);
+				}
+
+				view.Effects.Add(new EntryFormattedText());
+			}
+		}
+
+		class EntryFormattedText : RoutingEffect
+		{
+			public EntryFormattedText()
+				: base($"{nameof(Xamarin.CommunityToolkit)}.{nameof(EntryFormattedText)}")
+			{
+			}
+		}
+	}
+}

--- a/XamarinCommunityToolkit/Effects/FormattedTextEffect.shared.cs
+++ b/XamarinCommunityToolkit/Effects/FormattedTextEffect.shared.cs
@@ -48,20 +48,20 @@ namespace Xamarin.CommunityToolkit.Effects
 		{
 			if (bindable is View view && newValue != oldValue)
 			{
-				var effectsToRemove = view.Effects.OfType<EntryFormattedText>().ToArray();
+				var effectsToRemove = view.Effects.OfType<EntryFormattedTextEffect>().ToArray();
 				for (var index = 0; index < effectsToRemove.Length; index++)
 				{
 					view.Effects.Remove(effectsToRemove[index]);
 				}
 
-				view.Effects.Add(new EntryFormattedText());
+				view.Effects.Add(new EntryFormattedTextEffect());
 			}
 		}
 
-		class EntryFormattedText : RoutingEffect
+		class EntryFormattedTextEffect : RoutingEffect
 		{
-			public EntryFormattedText()
-				: base($"{nameof(Xamarin.CommunityToolkit)}.{nameof(EntryFormattedText)}")
+			public EntryFormattedTextEffect()
+				: base($"{nameof(Xamarin.CommunityToolkit)}.{nameof(EntryFormattedTextEffect)}")
 			{
 			}
 		}

--- a/XamarinCommunityToolkit/Effects/FormattedTextSegment.shared.cs
+++ b/XamarinCommunityToolkit/Effects/FormattedTextSegment.shared.cs
@@ -1,0 +1,13 @@
+﻿using Xamarin.Forms;
+
+namespace Xamarin.CommunityToolkit.Effects
+{
+	public class FormattedTextSegment<T>
+	{
+		public int StartIndex { get; set; }
+
+		public Span Span { get; set; }
+
+		public T[] NativeSpans { get; set; }
+	}
+}

--- a/XamarinCommunityToolkitSample/Pages/Effects/EffectsGalleryPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Effects/EffectsGalleryPage.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Effects"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Effects.EffectsGalleryPage"
+                ControlTemplate="{StaticResource GalleryPageTemplate}"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+
+    <pages:BasePage.BindingContext>
+        <vm:EffectsGalleryViewModel />
+    </pages:BasePage.BindingContext>
+
+</pages:BasePage>

--- a/XamarinCommunityToolkitSample/Pages/Effects/EffectsGalleryPage.xaml.cs
+++ b/XamarinCommunityToolkitSample/Pages/Effects/EffectsGalleryPage.xaml.cs
@@ -1,0 +1,11 @@
+﻿using Xamarin.Forms.Xaml;
+
+namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class EffectsGalleryPage
+	{
+		public EffectsGalleryPage() =>
+			InitializeComponent();
+	}
+}

--- a/XamarinCommunityToolkitSample/Pages/Effects/FormattedTextEffectPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Effects/FormattedTextEffectPage.xaml
@@ -11,8 +11,9 @@
             <Entry>
                 <xct:FormattedTextEffect.FormattedText>
                     <FormattedString>
-                        <Span Text="Hello " TextColor="Red" />
+                        <Span Text="Hello" TextColor="Red" />
                         <Span Text="World" TextColor="Purple" />
+                        <Span Text="Testing" TextColor="White" BackgroundColor="Red" />
                     </FormattedString>
                 </xct:FormattedTextEffect.FormattedText>
             </Entry>

--- a/XamarinCommunityToolkitSample/Pages/Effects/FormattedTextEffectPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Effects/FormattedTextEffectPage.xaml
@@ -1,12 +1,21 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Xamarin.CommunityToolkit.Sample.Pages.Effects.FormattedTextEffectPage"
-             xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="clr-namespace:Xamarin.CommunityToolkit.Effects;assembly=Xamarin.CommunityToolkit"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Effects.FormattedTextEffectPage"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
 
     <ScrollView>
         <StackLayout>
-            <Entry Text="Hello World" />
+            <Label Text="Standard Usage - Formatted Text Defined in XAML" />
+            <Entry>
+                <xct:FormattedTextEffect.FormattedText>
+                    <FormattedString>
+                        <Span Text="Hello " TextColor="Red" />
+                        <Span Text="World" TextColor="Purple" />
+                    </FormattedString>
+                </xct:FormattedTextEffect.FormattedText>
+            </Entry>
         </StackLayout>
     </ScrollView>
     

--- a/XamarinCommunityToolkitSample/Pages/Effects/FormattedTextEffectPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Effects/FormattedTextEffectPage.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.CommunityToolkit.Sample.Pages.Effects.FormattedTextEffectPage"
+             xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+
+    <ScrollView>
+        <StackLayout>
+            <Entry Text="Hello World" />
+        </StackLayout>
+    </ScrollView>
+    
+</pages:BasePage>

--- a/XamarinCommunityToolkitSample/Pages/Effects/FormattedTextEffectPage.xaml.cs
+++ b/XamarinCommunityToolkitSample/Pages/Effects/FormattedTextEffectPage.xaml.cs
@@ -1,0 +1,11 @@
+﻿using Xamarin.Forms.Xaml;
+
+namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class FormattedTextEffectPage
+	{
+		public FormattedTextEffectPage() =>
+			InitializeComponent();
+	}
+}

--- a/XamarinCommunityToolkitSample/Resx/AppResources.Designer.cs
+++ b/XamarinCommunityToolkitSample/Resx/AppResources.Designer.cs
@@ -322,6 +322,24 @@ namespace Xamarin.CommunityToolkit.Sample.Resx {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Effects all you to add additional functionality to native controls without needing a custom renderer..
+        /// </summary>
+        internal static string EffectsDescription {
+            get {
+                return ResourceManager.GetString("EffectsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Effects.
+        /// </summary>
+        internal static string EffectsTitle {
+            get {
+                return ResourceManager.GetString("EffectsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to e.g..
         /// </summary>
         internal static string EG {
@@ -435,6 +453,15 @@ namespace Xamarin.CommunityToolkit.Sample.Resx {
         internal static string FullImageSource {
             get {
                 return ResourceManager.GetString("FullImageSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The FormattedTextEffect enables input controls to specify a FormattedString which customizes the string via Spans.
+        /// </summary>
+        internal static string FormattedTextEffectShortDescription {
+            get {
+                return ResourceManager.GetString("FormattedTextEffectShortDescription", resourceCulture);
             }
         }
         

--- a/XamarinCommunityToolkitSample/Resx/AppResources.resx
+++ b/XamarinCommunityToolkitSample/Resx/AppResources.resx
@@ -500,4 +500,13 @@ If the user manually assigns a row or column on a view, it will be honored.</val
   <data name="UserStoppedTypingBehaviorMinimumLengthThresholdOptionLabel" xml:space="preserve">
     <value>Minimum length threshold (number of characters)</value>
   </data>
+  <data name="EffectsDescription" xml:space="preserve">
+    <value>Effects all you to add additional functionality to native controls without needing a custom renderer.</value>
+  </data>
+  <data name="EffectsTitle" xml:space="preserve">
+    <value>Effects</value>
+  </data>
+  <data name="FormattedTextEffectShortDescription" xml:space="preserve">
+    <value>The FormattedTextEffect enables input controls to specify a FormattedString which customizes the string via Spans</value>
+  </data>
 </root>

--- a/XamarinCommunityToolkitSample/ViewModels/Effects/EffectsGalleryViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Effects/EffectsGalleryViewModel.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using Xamarin.CommunityToolkit.Effects;
+using Xamarin.CommunityToolkit.Sample.Models;
+using Xamarin.CommunityToolkit.Sample.Pages.Effects;
+using Xamarin.CommunityToolkit.Sample.Resx;
+
+namespace Xamarin.CommunityToolkit.Sample.ViewModels.Effects
+{
+	public class EffectsGalleryViewModel : BaseViewModel
+	{
+		public IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		{
+			new SectionModel(
+				typeof(FormattedTextEffectPage),
+				nameof(FormattedTextEffect),
+				AppResources.FormattedTextEffectShortDescription)
+		};
+	}
+}

--- a/XamarinCommunityToolkitSample/ViewModels/WelcomeViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/WelcomeViewModel.cs
@@ -2,6 +2,7 @@
 using Xamarin.CommunityToolkit.Sample.Models;
 using Xamarin.CommunityToolkit.Sample.Pages.Behaviors;
 using Xamarin.CommunityToolkit.Sample.Pages.Converters;
+using Xamarin.CommunityToolkit.Sample.Pages.Effects;
 using Xamarin.CommunityToolkit.Sample.Pages.Extensions;
 using Xamarin.CommunityToolkit.Sample.Pages.TestCases;
 using Xamarin.CommunityToolkit.Sample.Pages.Views;
@@ -15,6 +16,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 		public IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
 		{
 			new SectionModel(typeof(BehaviorsGalleryPage), AppResources.BehaviorsTitle, Color.FromHex("#8E8CD8"), AppResources.BehaviorsDescription),
+			new SectionModel(typeof(EffectsGalleryPage), AppResources.EffectsTitle, Color.Red, AppResources.EffectsDescription),
 			new SectionModel(typeof(ConvertersGalleryPage), AppResources.ConvertersTitle, Color.FromHex("#EA005E"), AppResources.ConvertersDescription),
 			new SectionModel(typeof(ExtensionsGalleryPage), AppResources.ExtensionsTitle, Color.FromHex("#00CC6A"), AppResources.ExtensionsDescription),
 			new SectionModel(typeof(TestCasesGalleryPage), AppResources.TestCasesTitle, Color.FromHex("#FF8C00"), AppResources.TestCasesDescription),

--- a/XamarinCommunityToolkitSample/Xamarin.CommunityToolkit.Sample.csproj
+++ b/XamarinCommunityToolkitSample/Xamarin.CommunityToolkit.Sample.csproj
@@ -12,6 +12,12 @@
     <EmbeddedResource Update="Pages\Behaviors\ImpliedOrderGridBehaviorPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="Pages\Effects\EffectsGalleryPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Pages\Effects\FormattedTextEffectPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Resx\AppResources.es.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>AppResources.es.Designer.cs</LastGenOutput>


### PR DESCRIPTION
### Description of Change ###
Adds a FormattedText Effect that can be applied as an attached property to `<Entry>` controls. This is the Android only implementation as I want to focus on getting the shared code correct prior to implementing it any further.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes: #348 - Android and shared code implementation

### API Changes ###
```csharp
public static class FormattedTextEffect
{
    public static FormattedString GetFormattedText(BindableObject view);
    public static void SetFormattedText(BindableObject view, FormattedString value);
}
```

The `FormattedTextEffect` is implemented as an attached property. This means it can be directly attached at the root level of the `<Entry>` control. 

```xaml
<Entry>
    <xct:FormattedTextEffect.FormattedText>
        <FormattedString>
            <Span Text="Hello " TextColor="Red" />
            <Span Text="World" TextColor="Purple" />
        </FormattedString>
    </xct:FormattedTextEffect.FormattedText>
</Entry>
```


### Behavioral Changes ###
This is a new feature to the Xamarin Community Toolkit

The EntryFormattedText Effect allows developers to add text formatting to the `<Entry>` control. For example a developer can have multiple text colors in a string and update them in place. See the gif under the **screenshots** section

### Screenshots ###
![entry-formatted-text](https://user-images.githubusercontent.com/17751436/94979207-7b76a500-04ef-11eb-9e51-1ecc35e39f33.gif)

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- TODO: - [ ] Updated documentation -->
