### PR TITLE
Fixes "Expander - System.ArgumentException: 'NaN is not a valid value"

### DIFF
--- a/XamarinCommunityToolkit/Views/Expander/Expander.shared.cs
+++ b/XamarinCommunityToolkit/Views/Expander/Expander.shared.cs
@@ -434,7 +434,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 
 			if (lastVisibleSize > 0)
-				length = Max((uint)(length * (Abs(endSize - startSize) / lastVisibleSize)), 1);
+				length = (uint)(length * (Abs(endSize - startSize) / lastVisibleSize));
+
+			length = Max(length, 1);
 
 			new Animation(v => ContentSizeRequest = v, startSize, endSize)
 				.Commit(contentHolder, expandAnimationName, 16, length, easing, (value, isInterrupted) =>


### PR DESCRIPTION
### Description of Change ###

Expander's animation length cannot be set to zero (it causes a crash on Animation level)
That's why we always should coerce the animation length value to be non-zero (1 millisecond is pretty fast and from users perspective is not noticeable)

For testing go to ExpanderPage, set Expand/Collapse animation length to 0, then run the sample app and make sure crash does not happen anymore)

### Bugs Fixed ###
- Fixes #329 

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
