### PR TITLE
Added ObservableObject from MVVM Helpers

### DIFF
--- a/XamarinCommunityToolkit.UnitTests/ObjectModel/ObservableObject_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/ObjectModel/ObservableObject_Tests.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xunit;
+
+namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
+{
+	public sealed class ObservableObject_Tests
+	{
+		Person person;
+
+		public ObservableObject_Tests()
+		{
+			person = new Person
+			{
+				FirstName = "James",
+				LastName = "Montemagno"
+			};
+		}
+
+		[Fact]
+		public void OnPropertyChanged()
+		{
+			PropertyChangedEventArgs updated = null;
+			person.PropertyChanged += (sender, args) =>
+			{
+				updated = args;
+			};
+
+			person.FirstName = "Motz";
+
+			Assert.NotNull(updated);
+			Assert.Equal(nameof(person.FirstName), updated.PropertyName);
+		}
+
+		[Fact]
+		public void OnDidntChange()
+		{
+			PropertyChangedEventArgs updated = null;
+			person.PropertyChanged += (sender, args) =>
+			{
+				updated = args;
+			};
+
+			person.FirstName = "James";
+
+			Assert.Null(updated);
+		}
+
+		[Fact]
+		public void OnChangedEvent()
+		{
+			var triggered = false;
+			person.Changed = () =>
+			{
+				triggered = true;
+			};
+
+			person.FirstName = "Motz";
+
+			Assert.True(triggered, "OnChanged didn't raise");
+		}
+
+		[Fact]
+		public void OnChangingEvent()
+		{
+			var triggered = false;
+			person.Changing = () =>
+			{
+				triggered = true;
+			};
+
+			person.FirstName = "Motz";
+
+			Assert.True(triggered, "OnChanging didn't raise");
+		}
+
+		[Fact]
+		public void ValidateEvent()
+		{
+			var contol = "Motz";
+			var triggered = false;
+			person.Validate = (oldValue, newValue) =>
+			{
+				triggered = true;
+				return oldValue != newValue;
+			};
+
+			person.FirstName = contol;
+
+			Assert.True(triggered, "ValidateValue didn't raise");
+			Assert.Equal(person.FirstName, contol);
+		}
+
+		[Fact]
+		public void NotValidateEvent()
+		{
+			var contol = person.FirstName;
+			var triggered = false;
+			person.Validate = (oldValue, newValue) =>
+			{
+				triggered = true;
+				return false;
+			};
+
+			person.FirstName = "Motz";
+
+			Assert.True(triggered, "ValidateValue didn't raise");
+			Assert.Equal(person.FirstName, contol);
+		}
+
+		[Fact]
+		public async Task ValidateEventException()
+		{
+			person.Validate = (oldValue, newValue) =>
+			{
+				throw new ArgumentOutOfRangeException();
+			};
+
+			var result = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+			{
+				person.FirstName = "Motz";
+				return Task.CompletedTask;
+			});
+
+			Assert.NotNull(result);
+		}
+
+		public class Person : ObservableObject
+		{
+			string firstName;
+			string lastName;
+
+			public Action Changed { get; set; }
+
+			public Action Changing { get; set; }
+
+			public Func<string, string, bool> Validate { get; set; }
+
+			public string FirstName
+			{
+				get => firstName;
+				set => SetProperty(ref firstName, value, onChanged: Changed, onChanging: Changing, validateValue: Validate);
+			}
+
+			public string LastName
+			{
+				get => lastName;
+				set => SetProperty(ref lastName, value, onChanged: Changed, onChanging: Changing, validateValue: Validate);
+			}
+		}
+	}
+}

--- a/XamarinCommunityToolkit/ObjectModel/ObservableObject.shared.cs
+++ b/XamarinCommunityToolkit/ObjectModel/ObservableObject.shared.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Xamarin.CommunityToolkit.Helpers;
+
+#nullable enable
+
+namespace Xamarin.CommunityToolkit.ObjectModel
+{
+	/// <summary>
+	/// Observable object with INotifyPropertyChanged implemented
+	/// </summary>
+	public abstract class ObservableObject : INotifyPropertyChanged
+	{
+		readonly WeakEventManager weakEventManager = new WeakEventManager();
+
+		/// <summary>
+		/// Occurs when property changed.
+		/// </summary>
+		public event PropertyChangedEventHandler? PropertyChanged
+		{
+			add => weakEventManager.AddEventHandler(value);
+			remove => weakEventManager.RemoveEventHandler(value);
+		}
+
+		/// <summary>
+		/// Sets the property.
+		/// </summary>
+		/// <returns><c>true</c>, if property was set, <c>false</c> otherwise.</returns>
+		/// <param name="backingStore">Backing store.</param>
+		/// <param name="value">Value.</param>
+		/// <param name="validateValue">Validates value.</param>
+		/// <param name="propertyName">Property name.</param>
+		/// <param name="onChanged">On changed.</param>
+		/// <typeparam name="T">The 1st type parameter.</typeparam>
+		protected virtual bool SetProperty<T>(
+			ref T backingStore,
+			T value,
+			[CallerMemberName] string propertyName = "",
+			Action? onChanging = null,
+			Action? onChanged = null,
+			Func<T, T, bool>? validateValue = null)
+		{
+			// if value didn't change
+			if (EqualityComparer<T>.Default.Equals(backingStore, value))
+				return false;
+
+			// if value changed but didn't validate
+			if (validateValue != null && !validateValue(backingStore, value))
+				return false;
+
+			onChanging?.Invoke();
+			backingStore = value;
+			onChanged?.Invoke();
+			OnPropertyChanged(propertyName);
+			return true;
+		}
+
+		/// <summary>
+		/// Raises the property changed event.
+		/// </summary>
+		/// <param name="propertyName">Property name.</param>
+		protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = "") =>
+			weakEventManager.RaiseEvent(this, new PropertyChangedEventArgs(propertyName), nameof(PropertyChanged));
+	}
+}

--- a/XamarinCommunityToolkitSample/ViewModels/AboutViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/AboutViewModel.cs
@@ -25,19 +25,19 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 		public RepositoryContributor[] Contributors
 		{
 			get => contributors;
-			set => Set(ref contributors, value);
+			set => SetProperty(ref contributors, value);
 		}
 
 		public RepositoryContributor SelectedContributor
 		{
 			get => selectedContributor;
-			set => Set(ref selectedContributor, value);
+			set => SetProperty(ref selectedContributor, value);
 		}
 
 		public string EmptyViewText
 		{
 			get => emptyViewText;
-			set => Set(ref emptyViewText, value);
+			set => SetProperty(ref emptyViewText, value);
 		}
 
 		public ICommand SelectedContributorCommand => selectedContributorCommand ??= new AsyncCommand(async () =>

--- a/XamarinCommunityToolkitSample/ViewModels/Base/BaseViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Base/BaseViewModel.cs
@@ -1,31 +1,8 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using Xamarin.CommunityToolkit.Helpers;
+﻿using Xamarin.CommunityToolkit.ObjectModel;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels
 {
-	public class BaseViewModel : INotifyPropertyChanged
+	public abstract class BaseViewModel : ObservableObject
 	{
-		readonly WeakEventManager propertyChangedEventManager = new WeakEventManager();
-
-		event PropertyChangedEventHandler INotifyPropertyChanged.PropertyChanged
-		{
-			add => propertyChangedEventManager.AddEventHandler(value);
-			remove => propertyChangedEventManager.RemoveEventHandler(value);
-		}
-
-		protected bool Set<T>(ref T backingStore, T value, [CallerMemberName] string name = null)
-		{
-			if (EqualityComparer<T>.Default.Equals(backingStore, value))
-				return false;
-
-			backingStore = value;
-			OnPropertyChanged(name);
-			return true;
-		}
-
-		protected virtual void OnPropertyChanged([CallerMemberName] string name = "")
-			=> propertyChangedEventManager.RaiseEvent(this, new PropertyChangedEventArgs(name), nameof(INotifyPropertyChanged.PropertyChanged));
 	}
 }

--- a/XamarinCommunityToolkitSample/ViewModels/Behaviors/EventToCommandBehaviorViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Behaviors/EventToCommandBehaviorViewModel.cs
@@ -14,7 +14,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 		public int ClickCount
 		{
 			get => clickCount;
-			set => Set(ref clickCount, value);
+			set => SetProperty(ref clickCount, value);
 		}
 	}
 }

--- a/XamarinCommunityToolkitSample/ViewModels/Behaviors/UserStoppedTypingBehaviorViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Behaviors/UserStoppedTypingBehaviorViewModel.cs
@@ -14,7 +14,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 		public string PerformedSearches
 		{
 			get => performedSearches;
-			set => Set(ref performedSearches, value);
+			set => SetProperty(ref performedSearches, value);
 		}
 
 		public ICommand SearchCommand { get; }

--- a/XamarinCommunityToolkitSample/ViewModels/Converters/ByteArrayToImageSourceViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Converters/ByteArrayToImageSourceViewModel.cs
@@ -14,7 +14,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 		public byte[] Avatar
 		{
 			get => avatar;
-			set => Set(ref avatar, value);
+			set => SetProperty(ref avatar, value);
 		}
 
 		bool isBusy;
@@ -22,7 +22,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 		public bool IsBusy
 		{
 			get => isBusy;
-			set => Set(ref isBusy, value);
+			set => SetProperty(ref isBusy, value);
 		}
 
 		public async Task OnAppearing()

--- a/XamarinCommunityToolkitSample/ViewModels/Converters/DateTimeOffsetConverterViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Converters/DateTimeOffsetConverterViewModel.cs
@@ -9,7 +9,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 		public DateTimeOffset TheDate
 		{
 			get => theDate;
-			set => Set(ref theDate, value);
+			set => SetProperty(ref theDate, value);
 		}
 	}
 }

--- a/XamarinCommunityToolkitSample/ViewModels/Converters/MultiConverterViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Converters/MultiConverterViewModel.cs
@@ -9,7 +9,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 		public string EnteredName
 		{
 			get => enteredName;
-			set => Set(ref enteredName, value);
+			set => SetProperty(ref enteredName, value);
 		}
 	}
 }

--- a/XamarinCommunityToolkitSample/ViewModels/SettingViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/SettingViewModel.cs
@@ -19,7 +19,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 		public IList<Language> SupportedLanguages
 		{
 			get => supportedLanguages;
-			private set => Set(ref supportedLanguages, value);
+			private set => SetProperty(ref supportedLanguages, value);
 		}
 
 		Language selectedLanguage;
@@ -27,7 +27,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 		public Language SelectedLanguage
 		{
 			get => selectedLanguage;
-			set => Set(ref selectedLanguage, value);
+			set => SetProperty(ref selectedLanguage, value);
 		}
 
 		ICommand changeLanguageCommand;

--- a/XamarinCommunityToolkitSample/ViewModels/Views/ExpanderViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Views/ExpanderViewModel.cs
@@ -51,19 +51,19 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 			public string Name
 			{
 				get => name;
-				set => Set(ref name, value);
+				set => SetProperty(ref name, value);
 			}
 
 			public bool IsExpanded
 			{
 				get => isExpanded;
-				set => Set(ref isExpanded, value);
+				set => SetProperty(ref isExpanded, value);
 			}
 
 			public bool IsEnabled
 			{
 				get => isEnabled;
-				set => Set(ref isEnabled, value);
+				set => SetProperty(ref isEnabled, value);
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Ive added the ObservableObject from MVVM Helpers

### Bugs Fixed ###
- Partial fixes
#190 

### API Changes ###
Added: 

```csharp
public abstract class ObservableObject
{
    public event PropertyChangedEventHandler? PropertyChanged;

    protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = "");

    protected virtual bool SetProperty<T>(ref T backingStore,
			T value,
			[CallerMemberName] string propertyName = "",
			Action? onChanging = null,
			Action? onChanged = null,
			Func<T, T, bool>? validateValue = null);
}
```

### Behavioral Changes ###

Simple implementation of INotifyPropertyChanged that any class can inherit from.

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- TODO: - [ ] Updated documentation -->