### PR TITLE
Change default value of ShowsPlaybackControls property

### DIFF
--- a/XamarinCommunityToolkit.UnitTests/Views/MediaElement_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/Views/MediaElement_Tests.cs
@@ -72,5 +72,21 @@ namespace Xamarin.CommunityToolkit.UnitTests.Views
 			Assert.IsType<UriMediaSource>(media.Source);
 			Assert.Equal(uri, ((UriMediaSource)media.Source).Uri);
 		}
+
+		[Fact]
+		public void TestDefaultValueForShowsPlaybackControls()
+		{
+			var media = new MediaElement();
+
+			Assert.True(media.ShowsPlaybackControls);
+		}
+
+		[Fact]
+		public void TestShowsPlaybackControlsSet()
+		{
+			var media = new MediaElement { ShowsPlaybackControls = false };
+
+			Assert.False(media.ShowsPlaybackControls);
+		}
 	}
 }

--- a/XamarinCommunityToolkit/Views/MediaElement/MediaElement.shared.cs
+++ b/XamarinCommunityToolkit/Views/MediaElement/MediaElement.shared.cs
@@ -31,7 +31,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		  BindableProperty.Create(nameof(Position), typeof(TimeSpan), typeof(MediaElement), TimeSpan.Zero);
 
 		public static readonly BindableProperty ShowsPlaybackControlsProperty =
-		  BindableProperty.Create(nameof(ShowsPlaybackControls), typeof(bool), typeof(MediaElement), false);
+		  BindableProperty.Create(nameof(ShowsPlaybackControls), typeof(bool), typeof(MediaElement), true);
 
 		public static readonly BindableProperty SourceProperty =
 		  BindableProperty.Create(nameof(Source), typeof(MediaSource), typeof(MediaElement),


### PR DESCRIPTION
### Description of Change ###

The default value of ShowsPlaybackControls property was changed to **true**.

### Bugs Fixed ###

- Fixes https://github.com/xamarin/XamarinCommunityToolkit/issues/331

### API Changes ###

None

### Behavioral Changes ###

The playback controls will appear by default when using the control.

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- TODO: - [ ] Updated documentation -->
