### PR TITLE
Implement ShouldNotDismissKeyboardWhenMinimumLengthThreholdHasNotBeenReached unit test

### DIFF
--- a/XamarinCommunityToolkit.UnitTests/Behaviors/UserStoppedTypingBehavior_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/Behaviors/UserStoppedTypingBehavior_Tests.cs
@@ -109,26 +109,24 @@ namespace Xamarin.CommunityToolkit.UnitTests.Behaviors
 			Assert.False(commandHasBeenExecuted);
 		}
 
-		/// <summary>
-		/// Due to Focus() not setting the Entry to IsFocused = true, we cannot test if the entry still got focus or not
-		/// See for more information: https://forums.xamarin.com/discussion/181096/how-to-focus-an-entry-control-in-a-unit-test
-		/// </summary>
-		/// <returns></returns>
-		//[Fact]
-		//public async Task ShouldNotDismissKeyboardWhenMinimumLengthThreholdHasNotBeenReached()
-		//{
-		//	// arrange
-		//	var entry = CreateEntryWithBehavior(lengthThreshold: 3,
-		//										shouldDismissKeyboardAutomatically: true);
+		[Fact]
+		public async Task ShouldNotDismissKeyboardWhenMinimumLengthThreholdHasNotBeenReached()
+		{
+			// arrange
+			var entry = CreateEntryWithBehavior(lengthThreshold: 3,
+												shouldDismissKeyboardAutomatically: true);
 
-		//	// act
-		//	entry.Focus();
-		//	entry.Text = "1";
-		//	await Task.Delay(defaultTimeThreshold + 100);
+			// act
+			// "Focus" doesn't change IsFocused property in Unit Tests
+			// So we simulate this behavior ourselves
+			entry.SetValue(VisualElement.IsFocusedPropertyKey, true);
 
-		//	// assert
-		//	Assert.True(entry.IsFocused);
-		//}
+			entry.Text = "1";
+			await Task.Delay(defaultTimeThreshold + 100);
+
+			// assert
+			Assert.True(entry.IsFocused);
+		}
 
 		[Fact]
 		public async Task ShouldExecuteCommandImmediatelyWhenMinimumLengthThreholdHasNotBeenSet()


### PR DESCRIPTION
### Description of Change ###
Worked around "Focus does not change IsFocused property"

### Bugs Fixed ###
- Fixes https://github.com/xamarin/XamarinCommunityToolkit/pull/389#issuecomment-706099734

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [X] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
