### PR TITLE
DockLayout

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Pages/Views/DockLayoutPage.xaml
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Pages/Views/DockLayoutPage.xaml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+ <pages:BasePage
+     xmlns="http://xamarin.com/schemas/2014/forms"
+     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+     xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+     xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+     x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.DockLayoutPage">
+   <xct:DockLayout
+          LastChildFill="False">
+          <Button xct:DockLayout.Dock="Top" Text="Top" HeightRequest="50"/>
+          <Button xct:DockLayout.Dock="Bottom" Text="Bottom" HeightRequest="50"/>
+          <Button xct:DockLayout.Dock="Left" Text="Left" WidthRequest="60"/>
+          <Button xct:DockLayout.Dock="Left" Text="Left" WidthRequest="60"/>
+          <Button xct:DockLayout.Dock="Right" Text="Right" WidthRequest="80"/>
+          <Button xct:DockLayout.Dock="Right" Text="Right" WidthRequest="80"/>
+      </xct:DockLayout>
+ </pages:BasePage>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Pages/Views/DockLayoutPage.xaml.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Pages/Views/DockLayoutPage.xaml.cs
@@ -1,0 +1,8 @@
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Views
+{
+	public partial class DockLayoutPage
+	{
+		public DockLayoutPage()
+			=> InitializeComponent();
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/ViewModels/Views/ViewsGalleryViewModel.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/ViewModels/Views/ViewsGalleryViewModel.cs
@@ -17,6 +17,9 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 			new SectionModel(typeof(CameraViewPage), "CameraView",
 				"The CameraView allows you to show a live preview from the camera. You can take pictures, record videos and much more!"),
 
+			new SectionModel(typeof(DockLayoutPage), "DockLayout",
+ 				"Makes it easy to dock content in all four directions (top, bottom, left and right)"),
+
 			new SectionModel(typeof(GravatarImagePage), "GravatarImageSource",
 				"The GravatarImageSource allows you to easily utilize a users Gravatar image from Gravatar.com using nothing but their email address"),
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout.shared.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace Xamarin.CommunityToolkit.UI.Views
+{
+    public enum Dock
+    {
+        Left,
+        Top,
+        Right,
+        Bottom
+    }
+
+    /// <summary>
+    /// The DockLayout makes it easy to dock content in all four directions (top, bottom, left and right).
+    /// This makes it a great choice in many situations, where you want to divide the screen into specific areas,
+    /// especially because by default, the last element inside the DockLayout, unless this feature is specifically disabled,
+    /// will automatically fill the rest of the space (center).
+    /// Inspired by WPF DockPanel: https://docs.microsoft.com/en-us/dotnet/api/system.windows.controls.dockpanel?view=netframework-4.8
+    /// </summary>
+    public class DockLayout : Layout<View>
+    {
+        public static readonly BindableProperty DockProperty =
+            BindableProperty.Create(nameof(Dock), typeof(Dock), typeof(DockLayout), Dock.Left,
+                BindingMode.TwoWay, null);
+
+        public Dock Dock
+        {
+            get => (Dock)GetValue(DockProperty);
+            set => SetValue(DockProperty, value);
+        }
+
+        Dock GetDock(BindableObject bindable) => (Dock)bindable.GetValue(DockProperty);
+
+        public static readonly BindableProperty LastChildFillProperty =
+           BindableProperty.Create(nameof(LastChildFill), typeof(bool), typeof(DockLayout), true,
+               BindingMode.TwoWay, null);
+
+        /// <summary>
+        /// The default behavior is that the last child of the DockLayout takes up the rest of the space,
+        /// but this can be disabled using the LastChildFill.
+        /// </summary>
+        public bool LastChildFill
+        {
+            get => (bool)GetValue(LastChildFillProperty);
+            set => SetValue(LastChildFillProperty, value);
+        }
+
+        protected override void LayoutChildren(double x, double y, double width, double height)
+        {
+            var i = 0;
+
+            foreach (var child in Children)
+            {
+                if (child.IsVisible)
+                {
+                    i++;
+
+                    var sizeRequest = child.Measure(width, height, MeasureFlags.IncludeMargins);
+
+                    double childX = 0;
+                    double childY = 0;
+                    var request = sizeRequest.Request;
+                    var childWidth = Math.Min(width, request.Width);
+                    var childHeight = Math.Min(height, request.Height);
+
+                    var lastItem = i == Children.Count;
+                    if (lastItem & LastChildFill)
+                    {
+                        LayoutChildIntoBoundingRegion(child, new Rectangle(x, y, width, height));
+                        return;
+                    }
+
+                    switch (GetDock(child))
+                    {
+                        case Dock.Left:
+                            {
+                                childX = x;
+                                childY = y;
+                                childHeight = height;
+                                x += childWidth;
+                                width -= childWidth;
+                                break;
+                            }
+                        case Dock.Top:
+                            {
+                                childX = x;
+                                childY = y;
+                                childWidth = width;
+                                y += childHeight;
+                                height -= childHeight;
+                                break;
+                            }
+                        case Dock.Right:
+                            {
+                                childX = x + width - childWidth;
+                                childY = y;
+                                childHeight = height;
+                                width -= childWidth;
+                                break;
+                            }
+                        case Dock.Bottom:
+                            {
+                                childX = x;
+                                childY = y + height - childHeight;
+                                childWidth = width;
+                                height -= childHeight;
+                                break;
+                            }
+                        default:
+                            {
+                                goto case Dock.Left;
+                            }
+                    }
+
+                    LayoutChildIntoBoundingRegion(child, new Rectangle(childX, childY, childWidth, childHeight));
+                }
+            }
+        }
+
+        protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
+        {
+            double height = 0;
+            double width = 0;
+            double finalWidth = 0;
+            double finalHeight = 0;
+
+            foreach (var child in Children)
+            {
+                if (child.IsVisible)
+                {
+                    var sizeRequest = child.Measure(widthConstraint, heightConstraint, MeasureFlags.IncludeMargins);
+                    var request = sizeRequest.Request;
+
+                    switch (GetDock(child))
+                    {
+                        case Dock.Left:
+                        case Dock.Right:
+                            {
+                                width += request.Width;
+                                finalWidth = Math.Max(finalWidth, width);
+                                finalHeight = Math.Max(finalHeight, height + request.Height);
+                                break;
+                            }
+                        case Dock.Top:
+                        case Dock.Bottom:
+                            {
+                                height += request.Height;
+                                finalWidth = Math.Max(finalWidth, width + request.Width);
+                                finalHeight = Math.Max(finalHeight, height);
+                                break;
+                            }
+                        default:
+                            {
+                                goto case Dock.Right;
+                            }
+                    }
+                }
+            }
+
+            return new SizeRequest(new Size(finalWidth, finalHeight));
+        }
+    }
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout/Dock.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout/Dock.shared.cs
@@ -1,0 +1,10 @@
+﻿namespace Xamarin.CommunityToolkit.UI.Views
+{
+    public enum Dock
+    {
+        Left,
+        Top,
+        Right,
+        Bottom
+    }
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout/DockLayout.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout/DockLayout.shared.cs
@@ -3,14 +3,6 @@ using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.UI.Views
 {
-    public enum Dock
-    {
-        Left,
-        Top,
-        Right,
-        Bottom
-    }
-
     /// <summary>
     /// The DockLayout makes it easy to dock content in all four directions (top, bottom, left and right).
     /// This makes it a great choice in many situations, where you want to divide the screen into specific areas,

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout/DockLayout.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout/DockLayout.shared.cs
@@ -68,6 +68,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
                     switch (GetDock(child))
                     {
+                        default:
                         case Dock.Left:
                             {
                                 childX = x;
@@ -101,10 +102,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
                                 childWidth = width;
                                 height -= childHeight;
                                 break;
-                            }
-                        default:
-                            {
-                                goto case Dock.Left;
                             }
                     }
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout/DockLayout.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout/DockLayout.shared.cs
@@ -126,6 +126,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
                     switch (GetDock(child))
                     {
+                        default:
                         case Dock.Left:
                         case Dock.Right:
                             {

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout/DockLayout.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout/DockLayout.shared.cs
@@ -142,10 +142,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
                                 finalHeight = Math.Max(finalHeight, height);
                                 break;
                             }
-                        default:
-                            {
-                                goto case Dock.Right;
-                            }
                     }
                 }
             }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout/DockLayout.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DockLayout/DockLayout.shared.cs
@@ -13,8 +13,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
     public class DockLayout : Layout<View>
     {
         public static readonly BindableProperty DockProperty =
-            BindableProperty.Create(nameof(Dock), typeof(Dock), typeof(DockLayout), Dock.Left,
-                BindingMode.TwoWay, null);
+            BindableProperty.CreateAttached(nameof(Dock), typeof(Dock), typeof(DockLayout), Dock.Left);
 
         public Dock Dock
         {
@@ -22,7 +21,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
             set => SetValue(DockProperty, value);
         }
 
-        Dock GetDock(BindableObject bindable) => (Dock)bindable.GetValue(DockProperty);
+        public static Dock GetDock(BindableObject bindable)
+            => (Dock)bindable.GetValue(DockProperty);
+
+        public static void SetDock(BindableObject bindable, Dock value)
+            => bindable.SetValue(DockProperty, value);
 
         public static readonly BindableProperty LastChildFillProperty =
            BindableProperty.Create(nameof(LastChildFill), typeof(bool), typeof(DockLayout), true,


### PR DESCRIPTION
### Description of Change ###

The DockLayout makes it easy to dock content in all four directions (top, bottom, left and right). 
This makes it a great choice in many situations, where you want to divide the screen into specific areas, 
especially because by default, the last element inside the DockLayout, unless this feature is specifically disabled, 
will automatically fill the rest of the space (center).

![xct-docklayout](https://user-images.githubusercontent.com/6755973/95685496-8967ac80-0bf8-11eb-825d-352a84c32d75.gif)

### API Changes ###


Added: 
 
- DockLayout

```
<layout:DockLayout
    LastChildFill="False">
    <Button layout:DockLayout.Dock="Top" Text="Top" HeightRequest="50"/>
    <Button layout:DockLayout.Dock="Bottom" Text="Bottom" HeightRequest="50"/>
    <Button layout:DockLayout.Dock="Left" Text="Left" WidthRequest="60"/>
    <Button layout:DockLayout.Dock="Left" Text="Left" WidthRequest="60"/>
    <Button layout:DockLayout.Dock="Right" Text="Right" WidthRequest="80"/>
    <Button layout:DockLayout.Dock="Right" Text="Right" WidthRequest="80"/>
</layout:DockLayout>
```

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard