### PR TITLE
Saving Localization Manager from Linker

### DIFF
--- a/XamarinCommunityToolkit/Extensions/TranslateExtension.shared.cs
+++ b/XamarinCommunityToolkit/Extensions/TranslateExtension.shared.cs
@@ -17,14 +17,18 @@ namespace Xamarin.CommunityToolkit.Extensions
 		public BindingBase ProvideValue(IServiceProvider serviceProvider)
 		{
 #if !NETSTANDARD1_0
-            var binding = new Binding
-            {
-                Mode = BindingMode.OneWay,
-                Path = $"[{Text}]",
-                Source = LocalizationResourceManager.Current,
-                StringFormat = StringFormat
-            };
-            return binding;
+
+			if (DateTime.Now.Ticks < 0)
+				_ = LocalizationResourceManager.Current[Text];
+
+			var binding = new Binding
+			{
+				Mode = BindingMode.OneWay,
+				Path = $"[{Text}]",
+				Source = LocalizationResourceManager.Current,
+				StringFormat = StringFormat
+			};
+			return binding;
 #else
 			throw new NotSupportedException("Translate XAML MarkupExtension is not supported on .NET Standard 1.0");
 #endif

--- a/XamarinCommunityToolkitSample.Android/Xamarin.CommunityToolkit.Sample.Android.csproj
+++ b/XamarinCommunityToolkitSample.Android/Xamarin.CommunityToolkit.Sample.Android.csproj
@@ -31,7 +31,7 @@
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidLinkMode>None</AndroidLinkMode>
+    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/XamarinCommunityToolkitSample.iOS/Xamarin.CommunityToolkit.Sample.iOS.csproj
+++ b/XamarinCommunityToolkitSample.iOS/Xamarin.CommunityToolkit.Sample.iOS.csproj
@@ -25,7 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchArch>x86_64</MtouchArch>
-    <MtouchLink>None</MtouchLink>
+    <MtouchLink>SdkOnly</MtouchLink>
     <MtouchDebug>true</MtouchDebug>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
@@ -161,7 +161,9 @@
   <ItemGroup>
     <BundleResource Include="Resources\info%402x.png" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Assets.xcassets\LauncherIcon.imageset\" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\XamarinCommunityToolkitSample\Xamarin.CommunityToolkit.Sample.csproj">
       <Project>{81AADE72-D666-4AB0-83D9-8FE366E0755E}</Project>
@@ -172,7 +174,5 @@
       <Name>Xamarin.CommunityToolkit</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Assets.xcassets\LauncherIcon.imageset\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>


### PR DESCRIPTION
### Description of Change ###

I changed the Linker behavior in sample projects to the minimal, that way we can see when the linker removes bits.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

@AndreiMisiukevich found this issue when he ran the sample project using linker at the minimum config.

### API Changes ###


```csharp
public class TranslateExtension{
   public BindingBase ProvideValue(IServiceProvider serviceProvider)
		{
#if !NETSTANDARD1_0

			if (DateTime.Now.Ticks < 0)
				_ = LocalizationResourceManager.Current[Text];

// rest of the code
}
```

### Behavioral Changes ###

Now the labels in `WelcomePage` appear.

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- TODO: - [ ] Updated documentation -->
