### PR TITLE
Fix unit tests

### DIFF
--- a/XamarinCommunityToolkit.UnitTests/Mocks/MockPlatformServices.cs
+++ b/XamarinCommunityToolkit.UnitTests/Mocks/MockPlatformServices.cs
@@ -29,7 +29,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Mocks
 		public bool IsInvokeRequired
 			=> false;
 
-		public OSAppTheme RequestedTheme => OSAppTheme.Unspecified;
+		//public OSAppTheme RequestedTheme => OSAppTheme.Unspecified;
 
 		public string RuntimePlatform { get; set; }
 

--- a/XamarinCommunityToolkit.UnitTests/Xamarin.CommunityToolkit.UnitTests.csproj
+++ b/XamarinCommunityToolkit.UnitTests/Xamarin.CommunityToolkit.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
### Description of Change ###

Removes the net461 target and an API in the mock that is not available in the installed Forms version in order to restore the unit test project to build and run successfully
