### PR TITLE
Fix #286 Prevent extra iOS camera inits

### DIFF
--- a/XamarinCommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
+++ b/XamarinCommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
@@ -52,7 +52,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			};
 
 			mainView.Layer.AddSublayer(previewLayer);
-			RetrieveCameraDevice(CameraOptions.Default);
+			//RetrieveCameraDevice(CameraOptions.Default);
 
 			Add(mainView);
 

--- a/XamarinCommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
+++ b/XamarinCommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
@@ -21,6 +21,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		AVCaptureMovieFileOutput videoOutput;
 		AVCaptureConnection captureConnection;
 		AVCaptureDevice device;
+		AVCaptureDevicePosition? lastPosition;
 		bool isBusy;
 		bool isAvailable;
 		CameraFlashMode flashMode;
@@ -413,6 +414,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				case CameraOptions.External:
 					position = AVCaptureDevicePosition.Unspecified; break;
 			}
+
+			// Cache the last position requested, so we only initialize the camera if it's changed
+			if (position == lastPosition)
+				return;
+			lastPosition = position;
 
 			device = null;
 			var devs = AVCaptureDevice.DevicesWithMediaType(AVMediaType.Video);

--- a/XamarinCommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
+++ b/XamarinCommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
@@ -52,7 +52,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			};
 
 			mainView.Layer.AddSublayer(previewLayer);
-			//RetrieveCameraDevice(CameraOptions.Default);
 
 			Add(mainView);
 

--- a/XamarinCommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
+++ b/XamarinCommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
@@ -394,8 +394,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 					cameraAccess = true;
 					break;
 				case AVAuthorizationStatus.NotDetermined:
-					AVCaptureDevice.RequestAccessForMediaType(AVMediaType.Video, granted => cameraAccess = granted);
-					break;
+					AVCaptureDevice.RequestAccessForMediaType(AVMediaType.Video, granted => 
+						InvokeOnMainThread(() => RetrieveCameraDevice(cameraOptions)));
+					return;
 			}
 
 			if (!cameraAccess)


### PR DESCRIPTION
### Description of Change ###

Caches the last camera position initialed and only reinitialize if the position changes.
Removes un-need init from FormsCamera ctor.
If camera permission must be asked for, after a successful granting of permission it retries camera init.

I tested in the sample app and now I only get 1 camera init to the default (back) using the sample.  If in the camera sample page xaml I set the camera option to "Front", I only get 1 camera init to the front camera.

As long as the camera option is set before the renderer is created, it should only result in 1 init.

Testing Procedure
* Set a breakpoint in FormsCameraView.RetrieveCameraDevice 
* Make sure it is only called once at startup. (previous behavior was called twice)
* Delete sample app from a device, redeploy and then make sure the camera preview shows up after asking for camera permissions. (previous behavior was a blank screen).

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #286 

### API Changes ###
None

### Behavioral Changes ###
None to user

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
