### PR TITLE
Fix SafeAreaEffect

### DIFF
--- a/XamarinCommunityToolkit/Effects/SafeAreaEffectRouter.shared.cs
+++ b/XamarinCommunityToolkit/Effects/SafeAreaEffectRouter.shared.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Forms;
+﻿using System;
+using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Effects
 {
@@ -7,6 +8,10 @@ namespace Xamarin.CommunityToolkit.Effects
 		public SafeAreaEffectRouter()
 			: base($"{nameof(CommunityToolkit)}.{nameof(SafeAreaEffectRouter)}")
 		{
+#if __IOS__
+			if (DateTime.Now.Ticks < 0)
+				_ = new Xamarin.CommunityToolkit.iOS.Effects.SafeAreaEffectRouter();
+#endif
 		}
 	}
 }

--- a/XamarinCommunityToolkitSample/Pages/Effects/SafeAreaEffectPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Effects/SafeAreaEffectPage.xaml
@@ -9,10 +9,9 @@
     BackgroundColor="{StaticResource NormalButtonBackgroundColor}">
     <ContentPage.Content>
         <StackLayout
+            x:Name="stack"
             Padding="10,10"
-            effects:SafeAreaEffect.SafeArea="{Binding Path=IsToggled}"
             BackgroundColor="{StaticResource AppBackgroundColor}"
-            BindingContext="{x:Reference Name=ActivationToggle}"
             HorizontalOptions="Fill"
             Spacing="10"
             VerticalOptions="Fill">
@@ -20,7 +19,10 @@
             <StackLayout Orientation="Horizontal" Spacing="10">
                 <Label Text="{rsx:Translate ToggleSafeAreaEffect}" TextColor="{StaticResource NormalLabelTextColor}" />
 
-                <Switch x:Name="ActivationToggle" IsToggled="False" />
+                <Switch
+                    x:Name="ActivationToggle"
+                    IsToggled="False"
+                    Toggled="ActivationToggle_Toggled" />
             </StackLayout>
         </StackLayout>
     </ContentPage.Content>

--- a/XamarinCommunityToolkitSample/Pages/Effects/SafeAreaEffectPage.xaml.cs
+++ b/XamarinCommunityToolkitSample/Pages/Effects/SafeAreaEffectPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Forms.Xaml;
+﻿using Xamarin.CommunityToolkit.Effects;
+using Xamarin.Forms.Xaml;
 
 namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
 {
@@ -6,5 +7,8 @@ namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
 	public partial class SafeAreaEffectPage
 	{
 		public SafeAreaEffectPage() => InitializeComponent();
+
+		void ActivationToggle_Toggled(object sender, Forms.ToggledEventArgs e) =>
+			SafeAreaEffect.SetSafeArea(stack, e.Value);
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Now the linker keeps the SafeAreaEffect implementation into the `.dll` and the sample page doesn't throw an exception.
### Bugs Fixed ###

- Fixes #454 
- Fixes #393 

### API Changes ###

Added a static call to the SafeArea constructor.

### Behavioral Changes ###

Nothing breaks and everyone is happy.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
