### PR TITLE
[iOS] Fix NullReferenceException when MediaElement methods are called before setting Source

### DIFF
--- a/XamarinCommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
+++ b/XamarinCommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
@@ -307,6 +307,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void MediaElementStateRequested(object sender, StateRequested e)
 		{
+			// if no Source is set, do nothing
+			if (avPlayerViewController.Player?.CurrentItem == null)
+            {
+				return;
+            }
+			
 			switch (e.State)
 			{
 				case MediaElementState.Playing:

--- a/XamarinCommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
+++ b/XamarinCommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
@@ -309,9 +309,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		{
 			// if no Source is set, do nothing
 			if (avPlayerViewController.Player?.CurrentItem == null)
-            {
 				return;
-            }
 			
 			switch (e.State)
 			{


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

This PR updates the iOS `MediaElementRenderer` to ignore `Play()`/`Pause()`/`Stop()` events if [AVPlayerItem](https://developer.apple.com/documentation/avfoundation/avplayeritem) is not yet set (using [constructor](https://developer.apple.com/documentation/avfoundation/avplayer/1387104-init) or [AVPlayer.replaceCurrentItem(AVPlayerItem?)](https://developer.apple.com/documentation/avfoundation/avplayer/1390806-replacecurrentitem), which is called when the Source is updated).

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #414

### API Changes ###

None

<!-- List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName` => `object Cell.NewPropertyName`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
public static class NewClass {
    public static int SomeProperty { get; set; }
    public static void SomeMethod(string value);
}
``` -->

### Behavioral Changes ###

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
