### PR TITLE
[AvatarView] Add the Attribute TypeConverter for NamedSize use

### DIFF
--- a/XamarinCommunityToolkit/Views/AvatarView/AvatarView.shared.cs
+++ b/XamarinCommunityToolkit/Views/AvatarView/AvatarView.shared.cs
@@ -89,6 +89,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			set => SetValue(FontFamilyProperty, value);
 		}
 
+		[TypeConverter(typeof(FontSizeConverter))]
 		public double FontSize
 		{
 			get => (double)GetValue(FontSizeProperty);

--- a/XamarinCommunityToolkitSample/Pages/Views/AvatarViewPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/AvatarViewPage.xaml
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<pages:BasePage x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.AvatarViewPage"
+                xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:views="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit"
-                xmlns:viewmodels="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Views"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.AvatarViewPage"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-                xmlns:rsx="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit">
+                xmlns:rsx="clr-namespace:Xamarin.CommunityToolkit.Extensions;assembly=Xamarin.CommunityToolkit"
+                xmlns:viewmodels="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Views"
+                xmlns:views="clr-namespace:Xamarin.CommunityToolkit.UI.Views;assembly=Xamarin.CommunityToolkit">
 
     <pages:BasePage.BindingContext>
         <viewmodels:AvatarViewViewModel />
@@ -16,24 +16,36 @@
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <AbsoluteLayout>
-                        <StackLayout Padding="15, 10" Orientation="Horizontal"
-                                     Spacing="10" AbsoluteLayout.LayoutBounds="0,0,1,1"
-                                     AbsoluteLayout.LayoutFlags="All">
+                        <StackLayout Padding="15, 10"
+                                     AbsoluteLayout.LayoutBounds="0,0,1,1"
+                                     AbsoluteLayout.LayoutFlags="All"
+                                     Orientation="Horizontal"
+                                     Spacing="10">
 
-                            <views:AvatarView Size="{Binding Value, Source={x:Reference Slider}}"
-                                              Text="{Binding Initials}" Source="{Binding Source}"
-                                              ColorTheme="{x:Static views:ColorTheme.Jungle}"/>
+                            <views:AvatarView ColorTheme="{x:Static views:ColorTheme.Jungle}"
+                                              FontSize="Medium"
+                                              Size="{Binding Value,
+                                                             Source={x:Reference Slider}}"
+                                              Source="{Binding Source}"
+                                              Text="{Binding Initials}" />
 
-                            <Label Text="{Binding Name}" FontSize="20" VerticalOptions="CenterAndExpand" />
+                            <Label FontSize="20"
+                                   Text="{Binding Name}"
+                                   VerticalOptions="CenterAndExpand" />
                         </StackLayout>
-                        <BoxView Color="Black" AbsoluteLayout.LayoutBounds="0,1,1,1" AbsoluteLayout.LayoutFlags="PositionProportional,WidthProportional" />
+                        <BoxView AbsoluteLayout.LayoutBounds="0,1,1,1"
+                                 AbsoluteLayout.LayoutFlags="PositionProportional,WidthProportional"
+                                 Color="Black" />
                     </AbsoluteLayout>
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>
         <StackLayout Padding="{StaticResource ContentPadding}">
             <Label Text="{rsx:Translate AvatarViewSizeText}" />
-            <Slider x:Name="Slider" Maximum="80" Minimum="40" ThumbColor="{StaticResource PrimaryColor}"/>
+            <Slider x:Name="Slider"
+                    Maximum="80"
+                    Minimum="40"
+                    ThumbColor="{StaticResource PrimaryColor}" />
         </StackLayout>
     </StackLayout>
 </pages:BasePage>

--- a/XamarinCommunityToolkitSample/Pages/Views/AvatarViewPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/AvatarViewPage.xaml
@@ -25,7 +25,7 @@
                             <views:AvatarView ColorTheme="{x:Static views:ColorTheme.Jungle}"
                                               FontSize="Medium"
                                               Size="{Binding Value,
-                                                             Source={x:Reference Slider}}"
+                                              Source={x:Reference Slider}}"
                                               Source="{Binding Source}"
                                               Text="{Binding Initials}" />
 


### PR DESCRIPTION
### Description of Change ###

Aligning FontSize property with the framework behavior for using NamedSize when declaring the view in Xaml.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #471 

### API Changes ###

Changed:

 - AvatarView :
Adding attribute `[TypeConverter(typeof(FontSizeConverter))]` to FontSize property


### Behavioral Changes ###


### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
