### PR TITLE
Sample app: Implemented filter for gallery pages

### DIFF
--- a/XamarinCommunityToolkitSample/App.xaml
+++ b/XamarinCommunityToolkitSample/App.xaml
@@ -91,38 +91,47 @@
 
         <!-- Content templates -->
         <ControlTemplate x:Key="GalleryPageTemplate">
-            <CollectionView ItemsSource="{TemplateBinding BindingContext.Items}">
-                <CollectionView.Header>
-                    <BoxView HeightRequest="32" />
-                </CollectionView.Header>
-                <CollectionView.Footer>
-                    <BoxView HeightRequest="32" />
-                </CollectionView.Footer>
-                <CollectionView.ItemTemplate>
-                    <DataTemplate>
-                        <Grid Padding="20,12">
-                            <custom:PancakeView Style="{StaticResource card}">
-                                <custom:PancakeView.GestureRecognizers>
-                                    <TapGestureRecognizer 
-                                        Command="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
-                                        CommandParameter="{Binding .}" />
-                                </custom:PancakeView.GestureRecognizers>
-                                <Grid ColumnSpacing="20">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="12" />
-                                        <ColumnDefinition Width="*" />
-                                    </Grid.ColumnDefinitions>
-                                    <BoxView BackgroundColor="{Binding DetailColor, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}" />
-                                    <StackLayout Grid.Column="1" Spacing="8" Padding="0,24,24,24">
-                                        <Label Style="{StaticResource label_section_header}" Text="{Binding Title}" />
-                                        <Label Text="{Binding Description}" />
-                                    </StackLayout>
-                                </Grid>
-                            </custom:PancakeView>
-                        </Grid>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
+            <StackLayout Spacing="0">
+                <CollectionView ItemsSource="{TemplateBinding BindingContext.FilteredItems}">
+                    <CollectionView.Header>
+                        <ContentView Padding="20,12">
+                            <Entry Placeholder="Filter"
+                                   HeightRequest="40"
+                                   IsTextPredictionEnabled="False"
+                                   ReturnType="Search"
+                                   ReturnCommand="{TemplateBinding BindingContext.FilterCommand}"
+                                   Text="{TemplateBinding BindingContext.FilterValue, Mode=OneWayToSource}"/>
+                        </ContentView>
+                    </CollectionView.Header>
+                    <CollectionView.Footer>
+                        <BoxView HeightRequest="32" />
+                    </CollectionView.Footer>
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <Grid Padding="20,12">
+                                <custom:PancakeView Style="{StaticResource card}">
+                                    <custom:PancakeView.GestureRecognizers>
+                                        <TapGestureRecognizer 
+                                            Command="{Binding NavigateCommand, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}"
+                                            CommandParameter="{Binding .}" />
+                                    </custom:PancakeView.GestureRecognizers>
+                                    <Grid ColumnSpacing="20">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="12" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <BoxView BackgroundColor="{Binding DetailColor, Source={x:RelativeSource AncestorType={x:Type ContentPage}}}" />
+                                        <StackLayout Grid.Column="1" Spacing="8" Padding="0,24,24,24">
+                                            <Label Style="{StaticResource label_section_header}" Text="{Binding Title}" />
+                                            <Label Text="{Binding Description}" />
+                                        </StackLayout>
+                                    </Grid>
+                                </custom:PancakeView>
+                            </Grid>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </StackLayout>
         </ControlTemplate>
 
     </Application.Resources>

--- a/XamarinCommunityToolkitSample/ViewModels/Base/BaseGalleryViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Base/BaseGalleryViewModel.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Input;
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.CommunityToolkit.Sample.Models;
+using Xamarin.Forms;
+
+namespace Xamarin.CommunityToolkit.Sample.ViewModels
+{
+	public abstract class BaseGalleryViewModel : BaseViewModel
+	{
+		ICommand filterCommand;
+
+		public BaseGalleryViewModel() => Filter();
+
+		public abstract IEnumerable<SectionModel> Items { get; }
+
+		public IEnumerable<SectionModel> FilteredItems { get; private set; }
+
+		public ICommand FilterCommand => filterCommand ??= new Command(Filter);
+
+		public string FilterValue { private get; set; }
+
+		void Filter()
+		{
+			FilterValue ??= string.Empty;
+			FilteredItems = Items.Where(item => item.Title.IndexOf(FilterValue, StringComparison.InvariantCultureIgnoreCase) >= 0);
+			OnPropertyChanged(nameof(FilteredItems));
+		}
+	}
+}

--- a/XamarinCommunityToolkitSample/ViewModels/Behaviors/BehaviorsGalleryViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Behaviors/BehaviorsGalleryViewModel.cs
@@ -5,9 +5,9 @@ using Xamarin.CommunityToolkit.Sample.Pages.Behaviors;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 {
-	public class BehaviorsGalleryViewModel : BaseViewModel
+	public class BehaviorsGalleryViewModel : BaseGalleryViewModel
 	{
-		public IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		public override IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
 		{
 			new SectionModel(
 				typeof(EmailValidationBehaviorPage),

--- a/XamarinCommunityToolkitSample/ViewModels/Converters/ConvertersGalleryViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Converters/ConvertersGalleryViewModel.cs
@@ -6,9 +6,9 @@ using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 {
-	public class ConvertersGalleryViewModel : BaseViewModel
+	public class ConvertersGalleryViewModel : BaseGalleryViewModel
 	{
-		public IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		public override IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
 		{
 			new SectionModel(
 				typeof(ItemTappedEventArgsPage),

--- a/XamarinCommunityToolkitSample/ViewModels/Effects/EffectsGalleryViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Effects/EffectsGalleryViewModel.cs
@@ -5,9 +5,9 @@ using Xamarin.CommunityToolkit.Sample.Pages.Effects;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Effects
 {
-	public class EffectsGalleryViewModel : BaseViewModel
+	public class EffectsGalleryViewModel : BaseGalleryViewModel
 	{
-		public IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		public override IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
 		{
 			new SectionModel(
 				typeof(SafeAreaEffectPage),

--- a/XamarinCommunityToolkitSample/ViewModels/Views/ViewsGalleryViewModel.cs
+++ b/XamarinCommunityToolkitSample/ViewModels/Views/ViewsGalleryViewModel.cs
@@ -4,9 +4,9 @@ using Xamarin.CommunityToolkit.Sample.Pages.Views;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 {
-	public class ViewsGalleryViewModel : BaseViewModel
+	public class ViewsGalleryViewModel : BaseGalleryViewModel
 	{
-		public IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		public override IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
 		{
 			new SectionModel(typeof(AvatarViewPage), "AvatarView",
 				"The AvatarView represents a user's name by using the initials and a generated background color"),


### PR DESCRIPTION
### Description of Change ###
Now you can filter sections in the galleries of the sample app.
It helps to find the needed page by filtering items source.

1) Focus entry
2) Input a part of **title** of the item you are looking for.
3) Press "Search"
4) **Filtered items appear**

**NOTE**: We don't filter items on TextChanged because we reload items in CollectionView what causes Search Entry focus resigning.

<img src="https://user-images.githubusercontent.com/10124814/97096964-bd24e680-167c-11eb-8a24-cde93e35bec7.png" width="300">

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
