### PR TITLE
RangeSlider: Added events and StepValue

### DIFF
--- a/XamarinCommunityToolkitSample/Pages/Views/RangeSliderPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/RangeSliderPage.xaml
@@ -35,6 +35,7 @@
                 x:Name="RangeSlider"
                 MaximumValue="10"
                 MinimumValue="-10"
+                StepValue="0.01"
                 LowerValue="-10"
                 UpperValue="10"
                 ValueLabelStringFormat="{StaticResource CustomValueLabeStringFormat}"


### PR DESCRIPTION
### Description of Change ###
Added new events and property RangeSlider for easier observing drag status and selected value (Lower / Upper).

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #376 

### API Changes ###
```csharp
public event EventHandler ValueChanged;
public event EventHandler LowerValueChanged;
public event EventHandler UpperValueChanged;
public event EventHandler DragStarted;
public event EventHandler LowerDragStarted;
public event EventHandler UpperDragStarted;
public event EventHandler DragCompleted;
public event EventHandler LowerDragCompleted;
public event EventHandler UpperDragCompleted;
public double StepValue { get; set; }
```

### Behavioral Changes ###
None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
