### PR TITLE
CameraView ShutterCommand Add Preserve Attribute

### DIFF
--- a/XamarinCommunityToolkit/Views/CameraView/CameraView.shared.cs
+++ b/XamarinCommunityToolkit/Views/CameraView/CameraView.shared.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Windows.Input;
 using Xamarin.Forms;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.CommunityToolkit.UI.Views
 {
@@ -24,6 +25,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		public static readonly BindableProperty ShutterCommandProperty = ShutterCommandPropertyKey.BindableProperty;
 
+		[Preserve(Conditional = true)]
 		public ICommand ShutterCommand => (ICommand)GetValue(ShutterCommandProperty);
 
 		public static readonly BindableProperty IsBusyProperty = BindableProperty.Create(nameof(IsBusy), typeof(bool), typeof(CameraView), false);


### PR DESCRIPTION
### Description of Change ###

In a release build on iOS if you use the CameraView ShutterCommand, it was being linked away causing a binding failure and then not working.

Adds the preserve attribute to make sure command isn't linked away on iOS.  Should only be preserved if the CameraView class is also preserved.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #503 - Not the cause of the native crash in 503, but is the cause of the Take Photo button not working in the sample app.

### Behavioral Changes ###

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
