### PR TITLE
Fixes AvatarView Source property binding

### DIFF
--- a/XamarinCommunityToolkit/Views/AvatarView/AvatarView.shared.cs
+++ b/XamarinCommunityToolkit/Views/AvatarView/AvatarView.shared.cs
@@ -1,7 +1,4 @@
-﻿using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using static System.Math;
 
 namespace Xamarin.CommunityToolkit.UI.Views
@@ -134,6 +131,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			control.HasShadow = false;
 			control.Padding = 0;
 			control.Content = MainLayout;
+
+			Image.BindingContextChanged += (s, e) => OnValuePropertyChanged(true);
 		}
 
 		protected override void OnSizeAllocated(double width, double height)
@@ -183,10 +182,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			Image.BatchBegin();
 			if (shouldUpdateSource)
 			{
+				if (Image.Source == Source)
+					Image.Source = null;
+
 				Image.IsVisible = await imageSourceValidator.IsImageSourceValidAsync(Source);
 				Image.Source = Source;
 			}
-
 			Image.Aspect = Aspect;
 			Image.BatchCommit();
 

--- a/XamarinCommunityToolkitSample/Pages/Views/AvatarViewPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/AvatarViewPage.xaml
@@ -26,8 +26,12 @@
                                               FontSize="Medium"
                                               Size="{Binding Value,
                                               Source={x:Reference Slider}}"
-                                              Source="{Binding Source}"
-                                              Text="{Binding Initials}" />
+                                              Text="{Binding Initials}">
+
+                                <views:AvatarView.Source>
+                                    <UriImageSource Uri="{Binding Source}" />
+                                </views:AvatarView.Source>
+                            </views:AvatarView>
 
                             <Label FontSize="20"
                                    Text="{Binding Name}"


### PR DESCRIPTION
### Description of Change ###
Force reset Image's Source once its BindingContext changed 

### Bugs Fixed ###
- Fixes #512

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
