### PR TITLE
Fixed wrong UWP TabView icons path

### DIFF
--- a/XamarinCommunityToolkitSample/App.xaml.cs
+++ b/XamarinCommunityToolkitSample/App.xaml.cs
@@ -1,14 +1,16 @@
 ﻿using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.CommunityToolkit.Sample.Pages;
 using Xamarin.CommunityToolkit.Sample.Resx;
-using Xamarin.Forms;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
 namespace Xamarin.CommunityToolkit.Sample
 {
-	public partial class App : Application
+	public partial class App : Forms.Application
 	{
 		public App()
 		{
+			On<Windows>().SetImageDirectory("Assets");
 			LocalizationResourceManager.Current.Init(AppResources.ResourceManager);
 
 			InitializeComponent();

--- a/XamarinCommunityToolkitSample/Pages/Views/TabView/CustomTabsPage.xaml
+++ b/XamarinCommunityToolkitSample/Pages/Views/TabView/CustomTabsPage.xaml
@@ -49,7 +49,7 @@
                             <OnPlatform x:TypeArguments="x:Int32">
                                 <On Platform="iOS" Value="30"/>
                                 <On Platform="Android" Value="60"/>
-                                <On Platform="UWP" Value="24"/>
+                                <On Platform="UWP" Value="36"/>
                             </OnPlatform>
                         </ImageButton.CornerRadius>
                         <ImageButton.IsVisible>


### PR DESCRIPTION
### Description of Change ###

Fixed wrong TabView icons path in UWP.

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
