### PR TITLE
Fixed Snackbar Foreground text color UWP-WPF

### DIFF
--- a/XamarinCommunityToolkit/Views/SnackBar/Helpers/SnackBarLayout.uwp.wpf.cs
+++ b/XamarinCommunityToolkit/Views/SnackBar/Helpers/SnackBarLayout.uwp.wpf.cs
@@ -27,7 +27,8 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers
 			{
 				Text = options.MessageOptions.Message,
 				FontSize = options.MessageOptions.FontSize,
-				FontFamily = new FontFamily(options.MessageOptions.FontFamily)
+				FontFamily = new FontFamily(options.MessageOptions.FontFamily),
+				Foreground = options.MessageOptions.Foreground.ToBrush()
 			};
 #else
 			Background = options.BackgroundColor.ToBrush();
@@ -35,7 +36,8 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers
 			{
 				Content = options.MessageOptions.Message,
 				FontSize = options.MessageOptions.FontSize,
-				FontFamily = new FontFamily(options.MessageOptions.FontFamily)
+				FontFamily = new FontFamily(options.MessageOptions.FontFamily),
+				Foreground = options.MessageOptions.Foreground.ToBrush()
 			};
 #endif
 			Children.Add(messageLabel);


### PR DESCRIPTION
### Description of Change ###

Set Snackbar Foreground text color for UWP and WPF from the `MessageOptions.Foreground`

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)