### PR TITLE
Prevent linker to remove OnTriggerHandled method

### DIFF
--- a/XamarinCommunityToolkit/Behaviors/EventToCommandBehavior.shared.cs
+++ b/XamarinCommunityToolkit/Behaviors/EventToCommandBehavior.shared.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Windows.Input;
 using Xamarin.Forms;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.CommunityToolkit.Behaviors
 {
@@ -75,6 +76,8 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			eventInfo = View.GetType().GetRuntimeEvent(eventName) ??
 				throw new ArgumentException($"{nameof(EventToCommandBehavior)}: Couldn't resolve the event.", nameof(EventName));
 
+			_ = eventHandlerMethodInfo ?? throw new NullReferenceException($"{nameof(eventHandlerMethodInfo)} is null, maybe it's a linker issue, please open a bug here: https://github.com/xamarin/XamarinCommunityToolkit/issues/");
+
 			eventHandler = eventHandlerMethodInfo.CreateDelegate(eventInfo.EventHandlerType, this) ??
 				throw new ArgumentException($"{nameof(EventToCommandBehavior)}: Couldn't create event handler.", nameof(EventName));
 
@@ -90,6 +93,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			eventHandler = null;
 		}
 
+		[Preserve(Conditional = true)]
 		protected virtual void OnTriggerHandled(object sender = null, object eventArgs = null)
 		{
 			var parameter = CommandParameter


### PR DESCRIPTION
### Description of Change ###

Add a PreserveAttribute into the OnTriggerHandled method inside the class EventToCommandBehavior. Don't need unit tests.
Also Added a better error message if some user sees this error again.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #426

### Behavioral Changes ###

Now we don't see any NRE exception related to the invocation of the control event. And now all devs will be happy!
The new error message
<img width="508" alt="New error message when the eventInfo is null" src="https://user-images.githubusercontent.com/20712372/98481951-d3828480-21dc-11eb-8974-db1dea50e094.png">

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
