### PR TITLE
Update TabView behavior using Xamarin.Forms 5.0

### DIFF
--- a/XamarinCommunityToolkit/Views/TabView/TabView.shared.cs
+++ b/XamarinCommunityToolkit/Views/TabView/TabView.shared.cs
@@ -5,7 +5,6 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using Xamarin.CommunityToolkit.Effects;
 using Xamarin.Forms;
@@ -154,7 +153,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		{
 			// If TabView is used with Xamarin.Forms >= 5.0, the default value of the CarouselView Loop property is true,
 			// whereas in TabView we are not yet ready to support it. Access the property and disable the loop.
-			var loopProperty = contentContainer.GetType().GetProperty("Loop", BindingFlags.Public | BindingFlags.Instance);
+			var loopProperty = contentContainer.GetType().GetProperty("Loop");
 
 			if (loopProperty != null && loopProperty.CanWrite)
 				loopProperty.SetValue(contentContainer, false, null);

--- a/XamarinCommunityToolkit/Views/TabView/TabView.shared.cs
+++ b/XamarinCommunityToolkit/Views/TabView/TabView.shared.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Xamarin.CommunityToolkit.Effects;
 using Xamarin.Forms;
@@ -145,7 +146,18 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			BatchCommit();
 
+			DisableLoop();
 			UpdateIsEnabled();
+		}
+
+		void DisableLoop()
+		{
+			// If TabView is used with Xamarin.Forms >= 5.0, the default value of the CarouselView Loop property is true,
+			// whereas in TabView we are not yet ready to support it. Access the property and disable the loop.
+			var loopProperty = contentContainer.GetType().GetProperty("Loop", BindingFlags.Public | BindingFlags.Instance);
+
+			if (loopProperty != null && loopProperty.CanWrite)
+				loopProperty.SetValue(contentContainer, false, null);
 		}
 
 		public void Dispose()


### PR DESCRIPTION
### Description of Change ###

Disable the CarouselView Loop used internally by the TabView in case of use Xamarin.Forms 5.0-pre3.

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
