### PR TITLE
Fix "Cannot use EventToCommandBehavior for Page.Appearing event"

### DIFF
--- a/XamarinCommunityToolkit.UnitTests/Behaviors/EventToCommandBehavior_Tests.cs
+++ b/XamarinCommunityToolkit.UnitTests/Behaviors/EventToCommandBehavior_Tests.cs
@@ -32,5 +32,16 @@ namespace Xamarin.CommunityToolkit.UnitTests.Behaviors
 			};
 			listView.Behaviors.Add(behavior);
 		}
+
+		[Fact]
+		public void NoExceptionIfAttachedToPage()
+		{
+			var page = new ContentPage();
+			var behavior = new EventToCommandBehavior
+			{
+				EventName = nameof(Page.Appearing)
+			};
+			page.Behaviors.Add(behavior);
+		}
 	}
 }

--- a/XamarinCommunityToolkit/Behaviors/Animations/AnimationBehavior.shared.cs
+++ b/XamarinCommunityToolkit/Behaviors/Animations/AnimationBehavior.shared.cs
@@ -16,20 +16,20 @@ namespace Xamarin.CommunityToolkit.Behaviors
 		bool isAnimating;
 		TapGestureRecognizer tapGestureRecognizer;
 
-		protected override void OnAttachedTo(View bindable)
+		protected override void OnAttachedTo(VisualElement bindable)
 		{
 			base.OnAttachedTo(bindable);
 
-			if (!string.IsNullOrWhiteSpace(EventName))
+			if (!string.IsNullOrWhiteSpace(EventName) || !(bindable is View view))
 				return;
 
 			tapGestureRecognizer = new TapGestureRecognizer();
 			tapGestureRecognizer.Tapped += OnTriggerHandled;
-			View.GestureRecognizers.Clear();
-			View.GestureRecognizers.Add(tapGestureRecognizer);
+			view.GestureRecognizers.Clear();
+			view.GestureRecognizers.Add(tapGestureRecognizer);
 		}
 
-		protected override void OnDetachingFrom(View bindable)
+		protected override void OnDetachingFrom(VisualElement bindable)
 		{
 			if (tapGestureRecognizer != null)
 				tapGestureRecognizer.Tapped -= OnTriggerHandled;

--- a/XamarinCommunityToolkit/Behaviors/BaseBehavior.shared.cs
+++ b/XamarinCommunityToolkit/Behaviors/BaseBehavior.shared.cs
@@ -6,7 +6,7 @@ using Xamarin.Forms;
 namespace Xamarin.CommunityToolkit.Behaviors
 {
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public abstract class BaseBehavior<TView> : Behavior<TView> where TView : View
+	public abstract class BaseBehavior<TView> : Behavior<TView> where TView : VisualElement
 	{
 		static readonly MethodInfo getContextMethod
 			= typeof(BindableObject).GetRuntimeMethods()?.FirstOrDefault(m => m.Name == "GetContext");

--- a/XamarinCommunityToolkit/Behaviors/EventToCommandBehavior.shared.cs
+++ b/XamarinCommunityToolkit/Behaviors/EventToCommandBehavior.shared.cs
@@ -6,7 +6,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.CommunityToolkit.Behaviors
 {
-	public class EventToCommandBehavior : BaseBehavior<View>
+	public class EventToCommandBehavior : BaseBehavior<VisualElement>
 	{
 		public static readonly BindableProperty EventNameProperty =
 			BindableProperty.Create(nameof(EventName), typeof(string), typeof(EventToCommandBehavior), propertyChanged: OnEventNamePropertyChanged);
@@ -50,13 +50,13 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			set => SetValue(EventArgsConverterProperty, value);
 		}
 
-		protected override void OnAttachedTo(View bindable)
+		protected override void OnAttachedTo(VisualElement bindable)
 		{
 			base.OnAttachedTo(bindable);
 			RegisterEvent();
 		}
 
-		protected override void OnDetachingFrom(View bindable)
+		protected override void OnDetachingFrom(VisualElement bindable)
 		{
 			UnregisterEvent();
 			base.OnDetachingFrom(bindable);

--- a/XamarinCommunityToolkit/Behaviors/Validators/ValidationBehavior.shared.cs
+++ b/XamarinCommunityToolkit/Behaviors/Validators/ValidationBehavior.shared.cs
@@ -6,7 +6,7 @@ using Xamarin.Forms;
 namespace Xamarin.CommunityToolkit.Behaviors
 {
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public abstract class ValidationBehavior : BaseBehavior<View>
+	public abstract class ValidationBehavior : BaseBehavior<VisualElement>
 	{
 		public static readonly BindableProperty IsValidProperty =
 			BindableProperty.Create(nameof(IsValid), typeof(bool), typeof(ValidationBehavior), true, BindingMode.OneWayToSource);
@@ -87,7 +87,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 
 		protected abstract bool Validate(object value);
 
-		protected override void OnAttachedTo(View bindable)
+		protected override void OnAttachedTo(VisualElement bindable)
 		{
 			base.OnAttachedTo(bindable);
 
@@ -99,7 +99,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			isAttaching = false;
 		}
 
-		protected override void OnDetachingFrom(View bindable)
+		protected override void OnDetachingFrom(VisualElement bindable)
 		{
 			if (defaultValueBinding != null)
 			{


### PR DESCRIPTION
### Description of Change ###
Allow using behaviors with VisualElements (Pages)

### Bugs Fixed ###
- Fixes #583

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [X] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
