### PR TITLE
Fixes #604

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Pages/Views/AvatarViewPage.xaml
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Pages/Views/AvatarViewPage.xaml
@@ -4,6 +4,8 @@
                 xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
                 xmlns:viewmodels="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Views"
+                xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+                ios:Page.UseSafeArea="true"
                 x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.AvatarViewPage">
 
     <pages:BasePage.BindingContext>


### PR DESCRIPTION
### Description of Change ###

Added configuration to the page, so it uses iOS "Safe Area" and the Slider moves up into an area where it can be moved horizontally.

### Bugs Fixed ###

- Fixes #604 

### Behavioral Changes ###

Now users on iOS devices that shows the "Home indicator" instead of having a home button, can move the Slider horizontally.

**Before:**
![image](https://user-images.githubusercontent.com/837894/99889931-4880a000-2c5a-11eb-82f5-bf362fa06146.png)

**After:**
![image](https://user-images.githubusercontent.com/837894/99889922-3868c080-2c5a-11eb-8475-1c0390008251.png)

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard