### PR TITLE
Path fix in Xamarin.CommunityToolkit.Sample.csproj

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Xamarin.CommunityToolkit.Sample.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Xamarin.CommunityToolkit.Sample.csproj
@@ -104,6 +104,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\XamarinCommunityToolkit\Xamarin.CommunityToolkit.csproj" />
+    <ProjectReference Include="..\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Xamarin.CommunityToolkit.Sample project build fix.

### Description of Change ###

Change the path in https://github.com/xamarin/XamarinCommunityToolkit/blob/19616fd3666456458d4eb368b396f163591a0866/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Xamarin.CommunityToolkit.Sample.csproj#L107 to `<ProjectReference Include="..\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj" />`

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #611 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
