### PR TITLE
apply flash change only when it is available

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
@@ -305,7 +305,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		public void SwitchFlash(CameraFlashMode newFlashMode)
 		{
-			if (isAvailable && device != null && newFlashMode != flashMode)
+			if (isAvailable && device != null && newFlashMode != flashMode && device.FlashAvailable)
 			{
 				flashMode = newFlashMode;
 				SwitchFlash();


### PR DESCRIPTION
### Description of Change ###

Do not try to set flash on iOS when it is not available in hardware.
There are no new tests for this change as there seem to be no straightforward way to mock the `AVCaptureDevice`.
Sample that exhibits this behaviour is already in repo.

### Bugs Fixed ###

- Fixes #614 

### API Changes ###

none

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
