### PR TITLE
[Bug] AvatarView Aspect

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/AvatarView/AvatarView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/AvatarView/AvatarView.shared.cs
@@ -128,7 +128,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		{
 			IsClippedToBounds = true;
 			MainLayout.Children.Add(Label, new Rectangle(0.5, 0.5, -1, -1), AbsoluteLayoutFlags.PositionProportional);
-			MainLayout.Children.Add(Image, new Rectangle(0.5, 0.5, -1, -1), AbsoluteLayoutFlags.PositionProportional);
+			MainLayout.Children.Add(Image, new Rectangle(0, 0, 1, 1), AbsoluteLayoutFlags.All);
 			control.IsClippedToBounds = true;
 			control.HasShadow = false;
 			control.Padding = 0;
@@ -193,16 +193,28 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				}
 				catch (OperationCanceledException)
 				{
-					Xamarin.Forms.Internals.Log.Warning("CancellationException", "IsImageSourceValidAsync was cancelled.");
+					Forms.Internals.Log.Warning("CancellationException", "IsImageSourceValidAsync was cancelled.");
 				}
-				catch (System.Exception ex)
+				catch (Exception ex)
 				{
-					Xamarin.Forms.Internals.Log.Warning("Error", ex.Message);
+					Forms.Internals.Log.Warning("Error", ex.Message);
 					throw;
 				}
 				Image.Source = Source;
 			}
+
 			Image.Aspect = Aspect;
+			if (Aspect == Aspect.AspectFit)
+			{
+				AbsoluteLayout.SetLayoutBounds(Image, new Rectangle(.5, .5, -1, -1));
+				AbsoluteLayout.SetLayoutFlags(Image, AbsoluteLayoutFlags.PositionProportional);
+			}
+			else
+			{
+				AbsoluteLayout.SetLayoutBounds(Image, new Rectangle(0, 0, 1, 1));
+				AbsoluteLayout.SetLayoutFlags(Image, AbsoluteLayoutFlags.All);
+			}
+
 			Image.BatchCommit();
 
 			Label.BatchBegin();


### PR DESCRIPTION
### Description of Change ###
The bug was introduced during fixing another bug in https://github.com/xamarin/XamarinCommunityToolkit/pull/465
We should force Image to fill all space in case Aspect has value AspectFill or Fill.

So, we preserve existing behavior for AspectFit but return back to initial behavior for Fill options.

![image](https://user-images.githubusercontent.com/10124814/100488761-3357b580-3121-11eb-84cd-d9a76ac37774.png)

### Bugs Fixed ###
- Fixes #599 

### API Changes ###
None

### Behavioral Changes ###
The image will be spread over the all space that is taken by its Frame.

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
