### PR TITLE
RangeSlider in Scrollview (Android)

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/RangeSlider/RangeSlider.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/RangeSlider/RangeSlider.shared.cs
@@ -112,7 +112,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			= BindableProperty.Create(nameof(ValueLabelSpacing), typeof(double), typeof(RangeSlider), 5.0, propertyChanged: OnLayoutPropertyChanged);
 
 		public static BindableProperty ThumbRadiusProperty
-		   = BindableProperty.Create(nameof(ThumbRadius), typeof(double), typeof(RangeSlider), -1.0, propertyChanged: OnLayoutPropertyChanged);
+			= BindableProperty.Create(nameof(ThumbRadius), typeof(double), typeof(RangeSlider), -1.0, propertyChanged: OnLayoutPropertyChanged);
 
 		public static BindableProperty LowerThumbRadiusProperty
 			= BindableProperty.Create(nameof(LowerThumbRadius), typeof(double), typeof(RangeSlider), -1.0, propertyChanged: OnLayoutPropertyChanged);
@@ -319,13 +319,13 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			set => SetValue(TrackRadiusProperty, value);
 		}
 
-		Frame Track { get; } = CreateFrameElement();
+		Frame Track { get; } = CreateFrameElement<Frame>();
 
-		Frame TrackHighlight { get; } = CreateFrameElement();
+		Frame TrackHighlight { get; } = CreateFrameElement<Frame>();
 
-		Frame LowerThumb { get; } = CreateFrameElement();
+		Frame LowerThumb { get; } = CreateFrameElement<ThumbFrame>();
 
-		Frame UpperThumb { get; } = CreateFrameElement();
+		Frame UpperThumb { get; } = CreateFrameElement<ThumbFrame>();
 
 		Label LowerValueLabel { get; } = CreateLabelElement();
 
@@ -383,8 +383,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			OnLayoutPropertyChanged();
 		}
 
-		static Frame CreateFrameElement()
-			=> new Frame
+		static Frame CreateFrameElement<TFrame>() where TFrame : Frame, new()
+			=> new TFrame
 			{
 				Padding = 0,
 				HasShadow = false,

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/RangeSlider/ThumbFrame.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/RangeSlider/ThumbFrame.shared.cs
@@ -1,0 +1,15 @@
+﻿using Xamarin.Forms;
+
+namespace Xamarin.CommunityToolkit.UI.Views
+{
+	sealed class ThumbFrame : Frame
+	{
+		public ThumbFrame()
+		{
+#if __ANDROID__
+			if (System.DateTime.Now.Ticks < 0)
+				_ = new ThumbFrameRenderer(null);
+#endif
+		}
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/RangeSlider/ThumbFrameRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/RangeSlider/ThumbFrameRenderer.android.cs
@@ -1,0 +1,33 @@
+﻿using Android.Content;
+using Android.Views;
+using Xamarin.CommunityToolkit.UI.Views;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android.FastRenderers;
+
+[assembly: ExportRenderer(typeof(ThumbFrame), typeof(ThumbFrameRenderer))]
+
+namespace Xamarin.CommunityToolkit.UI.Views
+{
+	sealed class ThumbFrameRenderer : FrameRenderer
+	{
+		public ThumbFrameRenderer(Context context)
+            : base(context)
+		{
+		}
+
+		public override bool OnTouchEvent(MotionEvent e)
+		{
+			switch (e.ActionMasked)
+			{
+				case MotionEventActions.Down:
+					Parent?.RequestDisallowInterceptTouchEvent(true);
+					break;
+				case MotionEventActions.Up:
+				case MotionEventActions.Cancel:
+					Parent?.RequestDisallowInterceptTouchEvent(false);
+					break;
+			}
+			return base.OnTouchEvent(e);
+		}
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/RangeSlider/ThumbFrameRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/RangeSlider/ThumbFrameRenderer.android.cs
@@ -11,7 +11,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 	sealed class ThumbFrameRenderer : FrameRenderer
 	{
 		public ThumbFrameRenderer(Context context)
-            : base(context)
+			: base(context)
 		{
 		}
 


### PR DESCRIPTION
### Description of Change ###
We should call RequestDisallowInterceptTouchEvent when the user interacts with thumbs (move them) for preventing scrolling on Android.

I added an internal class ThumbFrame that has a custom renderer for android where we prevent scrolling if a user drags it.

### Bugs Fixed ###
- Fixes #502 

### API Changes ###
None

### Behavioral Changes ###
None (only bugfix)

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
