### PR TITLE
Fix Android font size

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.android.cs
@@ -24,7 +24,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			var snackTextView = snackBarView.FindViewById<TextView>(Resource.Id.snackbar_text);
 			snackTextView.SetMaxLines(10);
 			snackTextView.SetTextColor(arguments.MessageOptions.Foreground.ToAndroid());
-			snackTextView.SetTextSize(ComplexUnitType.Pt, (float)arguments.MessageOptions.FontSize);
+			snackTextView.SetTextSize(ComplexUnitType.Px, (float)arguments.MessageOptions.FontSize);
 			snackTextView.LayoutDirection = arguments.IsRtl
 				? global::Android.Views.LayoutDirection.Rtl
 				: global::Android.Views.LayoutDirection.Inherit;
@@ -35,7 +35,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				snackBar.SetActionTextColor(action.ForegroundColor.ToAndroid());
 				var snackActionButtonView = snackBarView.FindViewById<TextView>(Resource.Id.snackbar_action);
 				snackActionButtonView.SetBackgroundColor(action.BackgroundColor.ToAndroid());
-				snackActionButtonView.SetTextSize(ComplexUnitType.Pt, (float)action.FontSize);
+				snackActionButtonView.SetTextSize(ComplexUnitType.Px, (float)action.FontSize);
 				snackActionButtonView.LayoutDirection = arguments.IsRtl
 					? global::Android.Views.LayoutDirection.Rtl
 					: global::Android.Views.LayoutDirection.Inherit;


### PR DESCRIPTION
Use pixels instead of points. Now it is consistent with other platforms

Partially fix #607 

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
