### PR TITLE
Try to fix iOS camera view crash on Dispose

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
@@ -24,6 +24,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		AVCaptureDevicePosition? lastPosition;
 		bool isBusy;
 		bool isAvailable;
+		bool isDisposed;
 		CameraFlashMode flashMode;
 		readonly float imgScale = 1f;
 
@@ -528,14 +529,27 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				if (input != null)
 					captureSession.RemoveInput(input);
 			}
+
 			input?.Dispose();
+			input = null;
+
 			imageOutput?.Dispose();
+			imageOutput = null;
+
 			photoOutput?.Dispose();
+			photoOutput = null;
+
 			videoOutput?.Dispose();
+			videoOutput = null;
 		}
 
 		protected override void Dispose(bool disposing)
 		{
+			if (isDisposed)
+				return;
+
+			isDisposed = true;
+
 			if (device?.TorchMode == AVCaptureTorchMode.On)
 			{
 				flashMode = CameraFlashMode.Off;
@@ -543,6 +557,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 
 			ClearCaptureSession();
+			captureSession?.Dispose();
+
 			base.Dispose(disposing);
 		}
 	}


### PR DESCRIPTION
### Description of Change ###
@jfversluis reported a crash with the attached stack trace

[message (1).txt](https://github.com/xamarin/XamarinCommunityToolkit/files/5628842/message.1.txt)

### Bugs Fixed ###
Try to fix this crash

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
