### PR TITLE
Fixed fatal error on media element

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
@@ -24,6 +24,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		AVCaptureDevicePosition? lastPosition;
 		bool isBusy;
 		bool isAvailable;
+		bool isDisposed;
 		CameraFlashMode flashMode;
 		readonly float imgScale = 1f;
 
@@ -528,14 +529,27 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				if (input != null)
 					captureSession.RemoveInput(input);
 			}
+
 			input?.Dispose();
+			input = null;
+
 			imageOutput?.Dispose();
+			imageOutput = null;
+
 			photoOutput?.Dispose();
+			photoOutput = null;
+
 			videoOutput?.Dispose();
+			videoOutput = null;
 		}
 
 		protected override void Dispose(bool disposing)
 		{
+			if (isDisposed)
+				return;
+
+			isDisposed = true;
+
 			if (device?.TorchMode == AVCaptureTorchMode.On)
 			{
 				flashMode = CameraFlashMode.Off;
@@ -543,6 +557,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 
 			ClearCaptureSession();
+			captureSession?.Dispose();
+
 			base.Dispose(disposing);
 		}
 	}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
@@ -358,10 +358,10 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			if (e.OldElement != null)
 			{
-				Element.PropertyChanged -= OnElementPropertyChanged;
-				Element.SeekRequested -= MediaElementSeekRequested;
-				Element.StateRequested -= MediaElementStateRequested;
-				Element.PositionRequested -= MediaElementPositionRequested;
+				e.OldElement.PropertyChanged -= OnElementPropertyChanged;
+				e.OldElement.SeekRequested -= MediaElementSeekRequested;
+				e.OldElement.StateRequested -= MediaElementStateRequested;
+				e.OldElement.PositionRequested -= MediaElementPositionRequested;
 				SetKeepScreenOn(false);
 
 				// stop video if playing

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
@@ -84,15 +84,15 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				var item = new AVPlayerItem(asset);
 				DisposeObservers(ref statusObserver);
 
-				statusObserver = (NSObject)item.AddObserver("status", NSKeyValueObservingOptions.New, ObserveStatus);
+				statusObserver = item.AddObserver("status", NSKeyValueObservingOptions.New, ObserveStatus);
 
 				if (avPlayerViewController.Player != null)
 					avPlayerViewController.Player.ReplaceCurrentItemWithPlayerItem(item);
 				else
 				{
 					avPlayerViewController.Player = new AVPlayer(item);
-					rateObserver = (NSObject)avPlayerViewController.Player.AddObserver("rate", NSKeyValueObservingOptions.New, ObserveRate);
-					volumeObserver = (NSObject)avPlayerViewController.Player.AddObserver("volume", NSKeyValueObservingOptions.New, ObserveVolume);
+					rateObserver = avPlayerViewController.Player.AddObserver("rate", NSKeyValueObservingOptions.New, ObserveRate);
+					volumeObserver = avPlayerViewController.Player.AddObserver("volume", NSKeyValueObservingOptions.New, ObserveVolume);
 				}
 
 				if (Element.AutoPlay)


### PR DESCRIPTION
### Description of Change ###

Changed the clean-up of the control to `Dispose` method.

For future references, when we have an observer like this:
`avPlayerViewController?.Player?.RemoveObserver(volumeObserver, "volume");` where we need to specify a key, we can't remove it and after Dispose it (e.g. `volumeObserver.Dispose()`) because that will lead an exception. If you just remove the observer (`RemoveObserver(volumeObserver, "volume")`) you will see in the output that you don't dipose it, and maybe this object can be alive in the memory (I guess). But if you just call the Dispose method (`volumeObserver.Dispose()`) nothing breaks and you don't see the warning in the output window.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #558

### API Changes ###

<!-- List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `NSObject statusObserver => `IDisposable statusObserver `
 - `NSObject rateObserver=> `IDisposable rateObserver`
 - `NSObject volumeObserver=> `IDisposable volumeObserver`
- all inside the `if (old.Element != null) was moved to `Dispose(bool disposing)` 

Removed:
- `avPlayerViewController?.Player?.RemoveObserver(rateObserver, "rate");`
- `avPlayerViewController?.Player?.RemoveObserver(volumeObserver, "volume");`

### Behavioral Changes ###

Now when you navigate back the app doesn't crash and Gerald and Javier will be happy.

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
