### PR TITLE
Fixes BadgeView BadgeIndicatorContainer is visible if the Text property is 0 at the start

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BadgeView/BadgeView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BadgeView/BadgeView.shared.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Xamarin.Forms;
+using PropertyChangedEventArgs = System.ComponentModel.PropertyChangedEventArgs;
 
 namespace Xamarin.CommunityToolkit.UI.Views
 {
@@ -168,7 +169,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			BadgeIndicatorBackground.Content = BadgeText;
 
 			BadgeIndicatorContainer.Children.Add(BadgeIndicatorBackground);
-			BadgeIndicatorContainer.PropertyChanged += BadgeIndicatorContainerPropertyChanged;
+			BadgeIndicatorContainer.PropertyChanged += OnBadgeIndicatorContainerPropertyChanged;
 			BadgeText.SizeChanged += OnBadgeTextSizeChanged;
 
 			control.Children.Add(BadgeContent);
@@ -358,7 +359,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		void OnBadgeTextSizeChanged(object sender, EventArgs e)
 			=> UpdateBadgeViewPlacement(true);
 
-		void BadgeIndicatorContainerPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		void OnBadgeIndicatorContainerPropertyChanged(object sender, PropertyChangedEventArgs e)
 			=> UpdateBadgeViewPlacement(true);
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BadgeView/BadgeView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BadgeView/BadgeView.shared.cs
@@ -168,6 +168,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			BadgeIndicatorBackground.Content = BadgeText;
 
 			BadgeIndicatorContainer.Children.Add(BadgeIndicatorBackground);
+			BadgeIndicatorContainer.PropertyChanged += BadgeIndicatorContainerPropertyChanged;
+			BadgeText.SizeChanged += OnBadgeTextSizeChanged;
 
 			control.Children.Add(BadgeContent);
 			control.Children.Add(BadgeIndicatorContainer);
@@ -184,7 +186,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		   => new Grid
 		   {
 			   HorizontalOptions = LayoutOptions.Start,
-			   VerticalOptions = LayoutOptions.Start
+			   VerticalOptions = LayoutOptions.Start,
+			   IsVisible = false
 		   };
 
 		static Frame CreateIndicatorBackgroundElement()
@@ -351,5 +354,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			else
 				BadgeIndicatorContainer.IsVisible = badgeIsVisible;
 		}
+
+		void OnBadgeTextSizeChanged(object sender, EventArgs e)
+			=> UpdateBadgeViewPlacement(true);
+
+		void BadgeIndicatorContainerPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+			=> UpdateBadgeViewPlacement(true);
 	}
 }


### PR DESCRIPTION
### Description of Change ###
BadgeIndicatorContainer should be invisible by default because the default text value is "0".
Also, we should call UpdateBadgeViewPlacement when BadgeIndicatorContainer visibility or BadgeText value changed for aligning the badge inside the view.

### Bugs Fixed ###
- Fixes #638 

### API Changes ###
None

### Behavioral Changes ###
If the initial value is 0, the badgeview will be hidden (Not it's visible, but it's bug)

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
