### PR TITLE
Fixes GravatarImageSource doesn't work first time

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/GravatarImageSource/Shared/GravatarImageSourceHandler.android.ios.macos.tizen.uwp.wpf.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/GravatarImageSource/Shared/GravatarImageSourceHandler.android.ios.macos.tizen.uwp.wpf.cs
@@ -52,6 +52,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 #else
 				await File.WriteAllBytesAsync(cacheFileInfo.FullName, imageBytes);
 #endif
+				cacheFileInfo.Refresh();
 			}
 			finally
 			{


### PR DESCRIPTION
### Description of Change ###
We must refresh FileInfo after saving content by file's path otherwise FileInfo instance will return **False** for **Exists** property.

### Bugs Fixed ###
- Fixes #526

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
