### PR TITLE
Fixes "MediaElement with IsLooping="True" restarting all videos"

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
@@ -196,7 +196,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void PlayedToEnd(NSNotification notification)
 		{
-			if (Element == null)
+			if (Element == null || notification.Object != avPlayerViewController.Player?.CurrentItem)
 				return;
 
 			if (Element.IsLooping)


### PR DESCRIPTION
### Description of Change ###
Prevent restarting all media elements videos when any of them is played to end and is going to restart.

### Bugs Fixed ###
- Fixes #596

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
