### PR TITLE
Bump Forms 5 dependency to pre-5

### DIFF
--- a/Xamarin.CommunityToolkit.MarkupSample.sln
+++ b/Xamarin.CommunityToolkit.MarkupSample.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.CommunityToolkit.Ma
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.CommunityToolkit.MarkupSample", "src\Markup\Xamarin.CommunityToolkit.MarkupSample\Xamarin.CommunityToolkit.MarkupSample.csproj", "{BC630A82-C833-4FF8-88E0-1B6748A20EE3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.CommunityToolkit.Markup", "src\Markup\Xamarin.CommunityToolkit.Markup\Xamarin.CommunityToolkit.Markup.csproj", "{43B59086-39F0-43D3-901B-4742E9857435}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -171,6 +173,30 @@ Global
 		{BC630A82-C833-4FF8-88E0-1B6748A20EE3}.Release|x86.ActiveCfg = Release|Any CPU
 		{BC630A82-C833-4FF8-88E0-1B6748A20EE3}.Release|x86.Build.0 = Release|Any CPU
 		{BC630A82-C833-4FF8-88E0-1B6748A20EE3}.Release|x86.Deploy.0 = Release|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Debug|ARM.Build.0 = Debug|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Debug|x64.Build.0 = Debug|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Debug|x86.Build.0 = Debug|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Release|ARM.ActiveCfg = Release|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Release|ARM.Build.0 = Release|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Release|iPhone.Build.0 = Release|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Release|x64.ActiveCfg = Release|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Release|x64.Build.0 = Release|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Release|x86.ActiveCfg = Release|Any CPU
+		{43B59086-39F0-43D3-901B-4742E9857435}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample.Android/Xamarin.CommunityToolkit.Sample.Android.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample.Android/Xamarin.CommunityToolkit.Sample.Android.csproj
@@ -52,7 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1709-pre4" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1791-pre5" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="Xamarin.Forms.PancakeView">
       <Version>2.3.0.759</Version>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample.GTK/Xamarin.CommunityToolkit.Sample.GTK.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample.GTK/Xamarin.CommunityToolkit.Sample.GTK.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -81,10 +81,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms">
-      <Version>5.0.0.1709-pre4</Version>
+      <Version>5.0.0.1791-pre5</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms.Platform.GTK">
-      <Version>5.0.0.1709-pre4</Version>
+      <Version>5.0.0.1791-pre5</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms.PancakeView" Version="2.3.0.759" />
   </ItemGroup>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample.UWP/Xamarin.CommunityToolkit.Sample.UWP.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample.UWP/Xamarin.CommunityToolkit.Sample.UWP.csproj
@@ -146,7 +146,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1709-pre4" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1791-pre5" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.10" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
   </ItemGroup>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample.WPF/Xamarin.CommunityToolkit.Sample.WPF.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample.WPF/Xamarin.CommunityToolkit.Sample.WPF.csproj
@@ -114,10 +114,10 @@
       <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>5.0.0.1709-pre4</Version>
+      <Version>5.0.0.1791-pre5</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms.Platform.WPF">
-      <Version>5.0.0.1709-pre4</Version>
+      <Version>5.0.0.1791-pre5</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms.PancakeView" Version="2.3.0.759" />
   </ItemGroup>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample.iOS/Xamarin.CommunityToolkit.Sample.iOS.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample.iOS/Xamarin.CommunityToolkit.Sample.iOS.csproj
@@ -139,7 +139,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1709-pre4" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1791-pre5" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="Xamarin.Forms.PancakeView">
       <Version>2.3.0.759</Version>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Xamarin.CommunityToolkit.Sample.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Xamarin.CommunityToolkit.Sample.csproj
@@ -13,7 +13,7 @@
     <EmbeddedResource Include="Fonts\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1709-pre4" />  
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1791-pre5" />  
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="Xamarin.Forms.PancakeView" Version="2.3.0.759" />

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
@@ -23,7 +23,11 @@
     <RepositoryUrl>https://github.com/xamarin/XamarinCommunityToolkit</RepositoryUrl>
     <PackageReleaseNotes>
       
+      
+      
       <!-- See if we can host these on MS docs? -->
+    
+    
     
     </PackageReleaseNotes>
     <DefineConstants>$(DefineConstants);</DefineConstants>
@@ -68,7 +72,7 @@
     <Compile Include="**/*.shared.*.cs" />
     <None Include="..\..\..\LICENSE" PackagePath="" Pack="true" />
     <None Include="..\..\..\assets\XamarinCommunityToolkit_128x128.png" PackagePath="icon.png" Pack="true" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1709-pre4" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1791-pre5" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard1.0')) ">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
@@ -197,5 +201,11 @@
   <ItemGroup>
     <Compile Remove="build\*.cs" />
     <None Include="build\**\*.cs;build\**\*.targets" Pack="true" PackagePath="build" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Xamarin.Forms.Platform.GTK" Version="5.0.0.1791-pre5" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Xamarin.Forms.Platform.GTK" Version="5.0.0.1791-pre5" />
   </ItemGroup>
 </Project>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
@@ -22,13 +22,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <RepositoryUrl>https://github.com/xamarin/XamarinCommunityToolkit</RepositoryUrl>
     <PackageReleaseNotes>
-      
-      
-      
       <!-- See if we can host these on MS docs? -->
-    
-    
-    
     </PackageReleaseNotes>
     <DefineConstants>$(DefineConstants);</DefineConstants>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
@@ -146,20 +140,20 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.1709-pre4" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.1791-pre5" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) AND '$(OS)' == 'Windows_NT' ">
     <Compile Include="**\*.wpf.cs" />
     <Compile Include="**\*.wpf.*.cs" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.1709-pre4" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.1791-pre5" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net471')) ">
     <Compile Include="**\*.gtk.cs" />
     <Compile Include="**\*.gtk.*.cs" />
-    <PackageReference Include="Xamarin.Forms.Platform.GTK" Version="5.0.0.1709-pre4" />
+    <PackageReference Include="Xamarin.Forms.Platform.GTK" Version="5.0.0.1791-pre5" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -201,11 +195,5 @@
   <ItemGroup>
     <Compile Remove="build\*.cs" />
     <None Include="build\**\*.cs;build\**\*.targets" Pack="true" PackagePath="build" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Xamarin.Forms.Platform.GTK" Version="5.0.0.1791-pre5" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="Xamarin.Forms.Platform.GTK" Version="5.0.0.1791-pre5" />
   </ItemGroup>
 </Project>

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
@@ -15,9 +15,7 @@
     <PackageProjectUrl>https://github.com/xamarin/XamarinCommunityToolkit</PackageProjectUrl> 
     <RepositoryUrl>https://github.com/xamarin/XamarinCommunityToolkit</RepositoryUrl>
     <PackageReleaseNotes>
-      
       <!-- See if we can host these on MS docs? -->
-    
     </PackageReleaseNotes>
     <DefineConstants>$(DefineConstants);</DefineConstants>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
@@ -15,7 +15,9 @@
     <PackageProjectUrl>https://github.com/xamarin/XamarinCommunityToolkit</PackageProjectUrl> 
     <RepositoryUrl>https://github.com/xamarin/XamarinCommunityToolkit</RepositoryUrl>
     <PackageReleaseNotes>
+      
       <!-- See if we can host these on MS docs? -->
+    
     </PackageReleaseNotes>
     <DefineConstants>$(DefineConstants);</DefineConstants>
     <UseFullSemVerForNuGet>false</UseFullSemVerForNuGet>
@@ -49,7 +51,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1709-pre4" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1791-pre5" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\LICENSE" PackagePath="" Pack="true" />

--- a/src/Markup/Xamarin.CommunityToolkit.MarkupSample.UWP/Xamarin.CommunityToolkit.MarkupSample.UWP.csproj
+++ b/src/Markup/Xamarin.CommunityToolkit.MarkupSample.UWP/Xamarin.CommunityToolkit.MarkupSample.UWP.csproj
@@ -146,7 +146,7 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.10" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="Xamarin.Forms">
-      <Version>5.0.0.1709-pre4</Version>
+      <Version>5.0.0.1791-pre5</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms.DebugRainbows">
       <Version>1.1.4</Version>

--- a/src/Markup/Xamarin.CommunityToolkit.MarkupSample.iOS/Xamarin.CommunityToolkit.MarkupSample.iOS.csproj
+++ b/src/Markup/Xamarin.CommunityToolkit.MarkupSample.iOS/Xamarin.CommunityToolkit.MarkupSample.iOS.csproj
@@ -125,7 +125,7 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="Xamarin.Forms">
-      <Version>5.0.0.1709-pre4</Version>
+      <Version>5.0.0.1791-pre5</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms.DebugRainbows">
       <Version>1.1.4</Version>
@@ -134,7 +134,7 @@
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.CommunityToolkit.MarkupSample\Xamarin.CommunityToolkit.MarkupSample.csproj">
-      <Project>{C5010869-5697-4C8A-9715-1791228F8569}</Project>
+      <Project>{BC630A82-C833-4FF8-88E0-1B6748A20EE3}</Project>
       <Name>Xamarin.CommunityToolkit.MarkupSample</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/Markup/Xamarin.CommunityToolkit.MarkupSample/SearchViewModel.cs
+++ b/src/Markup/Xamarin.CommunityToolkit.MarkupSample/SearchViewModel.cs
@@ -65,7 +65,7 @@ namespace Xamarin.CommunityToolkit.MarkupSample
 
         void Like(Tweet tweet) => tweet.IsLikedByMe = !tweet.IsLikedByMe;
 
-        Task OpenHelp() => Launcher.OpenAsync(new Uri("https://github.com/VincentH-Net/xamarin-communitytoolkit/blob/master/docs/markup.md"));
+        Task OpenHelp() => Launcher.OpenAsync(new Uri("https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/markup.md"));
         Task OpenTwitterSearch() => Launcher.OpenAsync(new Uri("https://twitter.com/search?q=%23CSharpForMarkup"));
 
         public class Tweet : BaseViewModel

--- a/src/Markup/Xamarin.CommunityToolkit.MarkupSample/Xamarin.CommunityToolkit.MarkupSample.csproj
+++ b/src/Markup/Xamarin.CommunityToolkit.MarkupSample/Xamarin.CommunityToolkit.MarkupSample.csproj
@@ -12,9 +12,11 @@
 
   <ItemGroup>
     <PackageReference Include="PropertyChanged.Fody" Version="3.3.1" PrivateAssets="all" />
-    <PackageReference Include="Xamarin.CommunityToolkit.Markup" Version="1.0.0-pre5" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1709-pre4" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1791-pre5" />
     <PackageReference Include="Xamarin.Forms.DebugRainbows" Version="1.1.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Xamarin.CommunityToolkit.Markup\Xamarin.CommunityToolkit.Markup.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Change ###

What the title says!
In addition; removed the dependency from the Markup Sample to the NuGet, since that would now always require failing builds and having an additional PR after a new pre-release of XCT was released. Instead it now references the actual Markup source project.

Also in Markup sample fixed a link to point to MicrosoftDocs account
