### PR TITLE
[Android] Make TouchEffect working with Images

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Pages/Effects/TouchEffectPage.xaml
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Pages/Effects/TouchEffectPage.xaml
@@ -11,52 +11,49 @@
             <Setter Property="HorizontalOptions" Value="CenterAndExpand" />
             <Setter Property="VerticalOptions" Value="CenterAndExpand" />
             <Setter Property="Spacing" Value="10" />
-        </Style> 
+        </Style>
     </pages:BasePage.Resources>
+    <ScrollView>
+        <StackLayout Padding="{StaticResource ContentPadding}">
 
-    <Grid RowDefinitions="Auto,*,*,*,*" Padding="{StaticResource ContentPadding}">
-
-        <Label Grid.Row="0"
+            <Label
                HorizontalOptions="CenterAndExpand"
                FontSize="Title"
                TextColor="Black"
                Text="{Binding Count, StringFormat='Touches: {0}', Source={x:Reference Page}}" />
 
-        <StackLayout Grid.Row="1"
-                     Style="{StaticResource GridRowContentStyle}">
-            <Label Text="Image | Toggle | Hover" />
-            <Image xct:TouchEffect.NormalBackgroundImageSource="{xct:ImageResource Id=Xamarin.CommunityToolkit.Sample.Images.button.png}"
+            <StackLayout Style="{StaticResource GridRowContentStyle}">
+                <Label Text="Image | Toggle | Hover" />
+                <Image xct:TouchEffect.NormalBackgroundImageSource="{xct:ImageResource Id=Xamarin.CommunityToolkit.Sample.Images.button.png}"
                    xct:TouchEffect.PressedBackgroundImageSource="{xct:ImageResource Id=Xamarin.CommunityToolkit.Sample.Images.button_pressed.png}"
                    xct:TouchEffect.HoveredOpacity="0.8"
                    xct:TouchEffect.IsToggled="False"
                    xct:TouchEffect.Command="{Binding Command, Source={x:Reference Page}}"/>
 
-        </StackLayout>
+            </StackLayout>
 
-        <StackLayout Grid.Row="2"
-                     Style="{StaticResource GridRowContentStyle}">
+            <StackLayout Style="{StaticResource GridRowContentStyle}">
 
-            <Label Text="Scale | Fade | Animated" />
+                <Label Text="Scale | Fade | Animated" />
 
-            <StackLayout Orientation="Horizontal"
+                <StackLayout Orientation="Horizontal"
                          HorizontalOptions="CenterAndExpand"
                          xct:TouchEffect.AnimationDuration="250"
                          xct:TouchEffect.AnimationEasing="{x:Static Easing.CubicInOut}"
                          xct:TouchEffect.PressedScale="0.8"
                          xct:TouchEffect.PressedOpacity="0.6"
                          xct:TouchEffect.Command="{Binding Command, Source={x:Reference Page}}">
-                <BoxView Color="Gold" />
+                    <BoxView Color="Gold" />
                     <Label Text="The entire layout receives touches" />
-                <BoxView Color="Gold"/>
+                    <BoxView Color="Gold"/>
+                </StackLayout>
             </StackLayout>
-        </StackLayout>
 
-        <StackLayout Grid.Row="3"
-                     Style="{StaticResource GridRowContentStyle}">
+            <StackLayout Style="{StaticResource GridRowContentStyle}">
 
-            <Label Text="Native | Long Press" />
+                <Label Text="Native | Long Press" />
 
-            <StackLayout Orientation="Horizontal"
+                <StackLayout Orientation="Horizontal"
                          HorizontalOptions="CenterAndExpand"
                          BackgroundColor="Black"
                          Padding="20"
@@ -64,18 +61,17 @@
                          xct:TouchEffect.NativeAnimation="True"
                          xct:TouchEffect.LongPressCommand="{Binding LongPressCommand, Source={x:Reference Page}}"
                          xct:TouchEffect.Command="{Binding Command, Source={x:Reference Page}}">
-                <Label Text="TITLE"
+                    <Label Text="TITLE"
                        TextColor="White"
                        FontSize="Large"/>
+                </StackLayout>
             </StackLayout>
-        </StackLayout>
 
-        <StackLayout Grid.Row="4"
-                     Style="{StaticResource GridRowContentStyle}">
+            <StackLayout Style="{StaticResource GridRowContentStyle}">
 
-            <Label Text="Color | Rotation | Pulse | Animated" />
+                <Label Text="Color | Rotation | Pulse | Animated" />
 
-            <StackLayout Orientation="Horizontal"
+                <StackLayout Orientation="Horizontal"
                          HorizontalOptions="CenterAndExpand"
                          Padding="20"
                          xct:TouchEffect.AnimationDuration="500"
@@ -84,11 +80,17 @@
                          xct:TouchEffect.PressedBackgroundColor="Orange"
                          xct:TouchEffect.PressedRotation="15"
                          xct:TouchEffect.Command="{Binding Command, Source={x:Reference Page}}">
-                <Label Text="TITLE"
+                    <Label Text="TITLE"
                        TextColor="White"
                        FontSize="Large"/>
+                </StackLayout>
+            </StackLayout>
+
+            <StackLayout Style="{StaticResource GridRowContentStyle}">
+                <Label Text="Image | Native" />
+                <Image Source="{xct:ImageResource Id=Xamarin.CommunityToolkit.Sample.Images.button.png}"
+                  xct:TouchEffect.NativeAnimation="True" />
             </StackLayout>
         </StackLayout>
-
-    </Grid>
+    </ScrollView>
 </pages:BasePage>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
@@ -80,7 +80,7 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 						Clickable = false,
 						Focusable = false,
 					};
-					View.LayoutChange += LayoutChange;
+					View.LayoutChange += OnLayoutChange;
 					rippleView.Background = ripple;
 					Group.AddView(rippleView);
 					rippleView.BringToFront();
@@ -106,12 +106,12 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 					accessibilityManager.RemoveTouchExplorationStateChangeListener(accessibilityListener);
 					accessibilityListener.Dispose();
 					accessibilityManager = null;
-					accessibilityManager = null;
+					accessibilityListener = null;
 				}
 
 				if (View != null)
 				{
-					View.LayoutChange -= LayoutChange;
+					View.LayoutChange -= OnLayoutChange;
 					View.Touch -= OnTouch;
 					View.Click -= OnClick;
 				}
@@ -129,6 +129,7 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 						Group?.RemoveView(rippleView);
 						rippleView.Dispose();
 					}
+					rippleView = null;
 					ripple?.Dispose();
 				}
 			}
@@ -352,7 +353,7 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 				new[] { (int)nativeAnimationColor.ToAndroid() });
 		}
 
-		void LayoutChange(object sender, AView.LayoutChangeEventArgs e)
+		void OnLayoutChange(object sender, AView.LayoutChangeEventArgs e)
 		{
 			var group = (ViewGroup)sender;
 			if (group == null || (Group as IVisualElementRenderer)?.Element == null)


### PR DESCRIPTION
### Description of Change ###
TouchEffect didn't work with Images (including FFImageLoading). It happened because of FastRenderers structure (They have Container = null)

So we should add ripple native animation directly to the native view's foreground

Use this simple xaml for testing. Enable Native animation and verify ripple appears
```xaml
    <Image
        Margin="0"
        xct:TouchEffect.NativeAnimation="True"
        Source="SOME_IMAGE_HERE.png" />
```

### Bugs Fixed ###
- Fixes #660 

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
