### PR TITLE
[Android] MediaElement Volume is only taken into account when set after Media has been started 

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
@@ -258,7 +258,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 					break;
 
 				case nameof(MediaElement.Volume):
-					mediaPlayer?.SetVolume((float)MediaElement.Volume, (float)MediaElement.Volume);
+					UpdateVolume();
 					break;
 			}
 
@@ -333,6 +333,14 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 		}
 
+		protected void UpdateVolume()
+		{
+			if (view == null)
+				return;
+
+			mediaPlayer?.SetVolume((float)MediaElement.Volume, (float)MediaElement.Volume);
+		}
+
 		protected string ResolveMsAppDataUri(Uri uri)
 		{
 			if (uri.Scheme == "ms-appdata")
@@ -370,6 +378,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			UpdateLayoutParameters();
 
 			mediaPlayer = mp;
+			UpdateVolume();
 			mp.Looping = MediaElement.IsLooping;
 			mp.SeekTo(0);
 


### PR DESCRIPTION
### Description of Change ###
Update volume on media start.

### Bugs Fixed ###
- Fixes #398 

### API Changes ###
None


### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
