### PR TITLE
[Bug] null-ing MediaElement.Source has no effect

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample.Android/Properties/AndroidManifest.xml
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample.Android/Properties/AndroidManifest.xml
@@ -3,7 +3,7 @@
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
 	<application android:label="XamarinCommunityToolkitSample.Android"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-  <uses-permission android:name="android.permission.INTERNET"/>
+	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.CAMERA" />
 	<uses-permission android:name="android.permission.RECORD_AUDIO" />
 </manifest>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Pages/Views/MediaElementPage.xaml
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Pages/Views/MediaElementPage.xaml
@@ -11,6 +11,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <xct:MediaElement
             x:Name="mediaElement"
@@ -22,5 +23,6 @@
             HorizontalOptions="Fill"
             SeekCompleted="OnSeekCompleted" />
         <Slider Grid.Row="1" BindingContext="{x:Reference mediaElement}" Value="{Binding Position, Converter={StaticResource TimeSpanConverter}}" Maximum="{Binding Duration, Converter={StaticResource TimeSpanConverter}}"/>
+        <Button Grid.Row="2" Text="Reset Source (Set Null)" Clicked="OnResetClicked" />
     </Grid>
 </pages:BasePage>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Pages/Views/MediaElementPage.xaml.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.Sample/Pages/Views/MediaElementPage.xaml.cs
@@ -13,5 +13,7 @@ namespace Xamarin.CommunityToolkit.Sample.Pages.Views
 		void OnMediaEnded(object sender, EventArgs e) => Console.WriteLine("Media ended.");
 
 		void OnSeekCompleted(object sender, EventArgs e) => Console.WriteLine("Seek completed.");
+
+		void OnResetClicked(object sender, EventArgs e) => mediaElement.Source = null;
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
@@ -326,9 +326,13 @@ namespace Xamarin.CommunityToolkit.UI.Views
 					Controller.CurrentState = view.IsPlaying ? MediaElementState.Playing : MediaElementState.Stopped;
 				}
 			}
-			else if (view.IsPlaying)
+			else
 			{
 				view.StopPlayback();
+				view.SeekTo(0);
+				view.SetVideoURI(null);
+				view.Visibility = ViewStates.Gone;
+				view.Visibility = ViewStates.Visible;
 				Controller.CurrentState = MediaElementState.Stopped;
 			}
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/UWP/MediaElementRenderer.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/UWP/MediaElementRenderer.uwp.cs
@@ -257,7 +257,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		protected virtual void UpdateSource()
 		{
 			if (Element.Source == null)
+			{
+				Control.Stop();
+				Control.Source = null;
 				return;
+			}
 
 			if (Element.Source is UriMediaSource uriSource)
 				Control.Source = uriSource.Uri;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
@@ -100,11 +100,10 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 			else
 			{
-				if (Element.CurrentState == MediaElementState.Playing || Element.CurrentState == MediaElementState.Buffering)
-				{
-					avPlayerViewController.Player.Pause();
-					Controller.CurrentState = MediaElementState.Stopped;
-				}
+				avPlayerViewController.Player?.Pause();
+				avPlayerViewController.Player?.ReplaceCurrentItemWithPlayerItem(null);
+				DisposeObservers(ref statusObserver);
+				Controller.CurrentState = MediaElementState.Stopped;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###
We should stop and reset MediaElement if **null** source set.

### Bugs Fixed ###
- Fixes #407 

### API Changes ###
None

### Behavioral Changes ###
None (only bug fix)

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
