### PR TITLE
[Bug][Uwp] TextValidationBehavior inconsistent when not setting ValidStyle

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/ValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/ValidationBehavior.shared.cs
@@ -178,9 +178,17 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 			if (View == null || (ValidStyle ?? InvalidStyle) == null)
 				return;
 
-			View.Style = IsValid
-				? ValidStyle
-				: InvalidStyle;
+			using (View.Batch())
+			{
+				var style = IsValid
+					? ValidStyle
+					: InvalidStyle;
+
+				if (style == null)
+					View.ClearValue(VisualElement.StyleProperty);
+
+				View.Style = style;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
Try to fix ValidationBehavior bug on UWP

### Bugs Fixed ###
- Fixes #678

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
