### PR TITLE
Ignore Opacity for Android MediaElement

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
@@ -44,6 +44,18 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			view.SetMediaController(controller);
 		}
 
+		public override float Alpha
+		{
+			get => view.Alpha;
+			set =>
+
+				// VideoView opens a separate Window above the current one.
+				// This is because it is based on the SurfaceView.
+				// And we cannot set alpha or perform animations with it because it is not synchronized with your other UI elements.
+				// We may set 0 or 1 alpha only.
+				view.Alpha = Math.Sign(Math.Abs(value));
+		}
+
 		protected ToolKitMediaElement MediaElement { get; set; }
 
 		IMediaElementController Controller => MediaElement;


### PR DESCRIPTION
### Description of Change ###
Android VideoView opens a separate Window above the current one.
This is because it is based on the SurfaceView.
And we cannot set alpha or perform animations with it because it is not synchronized with your other UI elements.
We may set 0 or 1 alpha only.

### Bugs Fixed ###
- Fixes #530 

### API Changes ###
None

### Behavioral Changes ###
Android MediaElement is not disappearing if alpha is set to value from the interval (0;1)

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
