### PR TITLE
Fix TouchEffect + Button.Command

### DIFF
--- a/samples/XCT.Sample/Pages/TestCases/TestCasesGalleryPage.xaml
+++ b/samples/XCT.Sample/Pages/TestCases/TestCasesGalleryPage.xaml
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.TestCases.TestCasesGalleryPage">
-    <pages:BasePage.Content>
-    </pages:BasePage.Content>
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.TestCases"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.TestCases.TestCasesGalleryPage"
+                ControlTemplate="{StaticResource GalleryPageTemplate}">
+    <pages:BasePage.BindingContext>
+        <vm:TestCasesGalleryViewModel />
+    </pages:BasePage.BindingContext>
 </pages:BasePage>

--- a/samples/XCT.Sample/Pages/TestCases/TouchEffectButtonPage.xaml
+++ b/samples/XCT.Sample/Pages/TestCases/TouchEffectButtonPage.xaml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+                ios:Page.UseSafeArea="true"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.TestCases.TouchEffectButtonPage"
+                x:Name="Page">
+    <pages:BasePage.Resources>
+        <Style x:Key="ButtonStyle" TargetType="View">
+            <Setter Property="HeightRequest" Value="50" />
+            <Setter Property="WidthRequest" Value="200" />
+            <Setter Property="BackgroundColor" Value="LightSkyBlue" />
+            <Setter Property="HorizontalOptions" Value="Center" />
+        </Style>
+    </pages:BasePage.Resources>
+
+
+    <StackLayout Padding="{StaticResource ContentPadding}"
+                 Spacing="20">
+
+        <Label Text="When you click over the button you should see that button's command is executed." />
+
+        <Button Style="{StaticResource ButtonStyle}"
+                Text="Button"
+                Command="{Binding Command, Source={x:Reference Page}}"
+                xct:TouchEffect.PressedScale="1.2" />
+
+        <ImageButton Style="{StaticResource ButtonStyle}"
+                     Source="help"
+                     Command="{Binding Command, Source={x:Reference Page}}"
+                     xct:TouchEffect.PressedRotation="180" />
+    </StackLayout>
+
+</pages:BasePage>

--- a/samples/XCT.Sample/Pages/TestCases/TouchEffectButtonPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/TestCases/TouchEffectButtonPage.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Input;
+using Xamarin.Forms;
+
+namespace Xamarin.CommunityToolkit.Sample.Pages.TestCases
+{
+	public partial class TouchEffectButtonPage
+	{
+		ICommand command;
+
+		public TouchEffectButtonPage()
+			=> InitializeComponent();
+
+		public ICommand Command => command ??= new Command(() => this.DisplayAlert("Command executed ", null, "OK"));
+	}
+}

--- a/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using Xamarin.CommunityToolkit.Sample.Models;
+using Xamarin.CommunityToolkit.Sample.Pages.TestCases;
+
+namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases
+{
+	public class TestCasesGalleryViewModel : BaseGalleryViewModel
+	{
+		public override IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		{
+			new SectionModel(
+				typeof(TouchEffectButtonPage),
+				"TouchEffect + Button",
+				"TouchEffect must automatically invoke button'c command execution."),
+		};
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/GestureManager.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/GestureManager.shared.cs
@@ -199,6 +199,9 @@ namespace Xamarin.CommunityToolkit.Effects
 			if (!sender.CanExecute || (sender.LongPressCommand != null && sender.InteractionStatus == TouchInteractionStatus.Completed))
 				return;
 
+			if (sender.Element is IButtonController button)
+				button.SendClicked();
+
 			sender.Command?.Execute(sender.CommandParameter);
 			sender.RaiseCompleted();
 		}


### PR DESCRIPTION
### Description of Change ###

We call IButtonController.SendClicked method on TouchEffect side because TouchEffet intercepts button's events.
Also, we prevent the iOS button's highlight animation  due to its freezing with TouchEffect (instead we force to enable TouchEffect's native animation)

The **FIRST** test case is added 🥇 

### Bugs Fixed ###
- Fixes #687

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
