### PR TITLE
Fixed MediaElement.Source

### DIFF
--- a/samples/XCT.Sample/Pages/TestCases/MediaElementSourcePage.xaml
+++ b/samples/XCT.Sample/Pages/TestCases/MediaElementSourcePage.xaml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<pages:BasePage
+    x:Class="Xamarin.CommunityToolkit.Sample.Pages.TestCases.MediaElementSourcePage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+    xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages.TestCases"
+    xmlns:xct="http://xamarin.com/schemas/2020/toolkit">
+    <ContentPage.BindingContext>
+        <vm:MediaElementViewModel />
+    </ContentPage.BindingContext>
+    <ContentPage.Content>
+        <Grid RowDefinitions="auto, *, *">
+            <Label Text="Both videos should execute" />
+
+            <xct:MediaElement Grid.Row="1" Source="{Binding VideoAsString}" />
+            <xct:MediaElement Grid.Row="2" Source="{Binding VideoAsMediaSource}" />
+        </Grid>
+    </ContentPage.Content>
+</pages:BasePage>

--- a/samples/XCT.Sample/Pages/TestCases/MediaElementSourcePage.xaml.cs
+++ b/samples/XCT.Sample/Pages/TestCases/MediaElementSourcePage.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.CommunityToolkit.Core;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.CommunityToolkit.Sample.Pages.TestCases
+{
+	public partial class MediaElementSourcePage
+	{
+		public MediaElementSourcePage()
+		{
+			InitializeComponent();
+		}
+	}
+
+
+	class MediaElementViewModel : BindableObject
+	{
+		public string VideoAsString { get; set; } = "https://tipcalculator.appwithkiss.com/video/Hint_1_2_EN_12.mov";
+
+		public MediaSource VideoAsMediaSource => MediaSource.FromUri(VideoAsString);
+	}
+}

--- a/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
@@ -12,6 +12,11 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases
 				typeof(TouchEffectButtonPage),
 				"TouchEffect + Button",
 				"TouchEffect must automatically invoke button'c command execution."),
+
+			new SectionModel(
+				typeof(MediaElementSourcePage),
+				"MediaElement with Source as string",
+				"MediaElement should reproduce the video."),
 		};
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Core/MediaSource.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Core/MediaSource.shared.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.Forms;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.CommunityToolkit.Core
 {
+	[Forms.Xaml.TypeConversion(typeof(MediaSourceConverter))]
 	public abstract class MediaSource : Element
 	{
 		readonly WeakEventManager weakEventManager = new WeakEventManager();
@@ -14,11 +16,15 @@ namespace Xamarin.CommunityToolkit.Core
 		public static MediaSource FromUri(Uri uri) =>
 			!uri.IsAbsoluteUri ? throw new ArgumentException("Uri must be be absolute", nameof(uri)) : new UriMediaSource { Uri = uri };
 
+		public static MediaSource FromUri(string uri) => FromUri(new Uri(uri));
+
+		[Preserve(Conditional = true)]
 		public static implicit operator MediaSource(string source) =>
 			Uri.TryCreate(source, UriKind.Absolute, out var uri) && uri.Scheme != "file"
 				? FromUri(uri)
 				: FromFile(source);
 
+		[Preserve(Conditional = true)]
 		public static implicit operator MediaSource(Uri uri) => uri == null ? null : FromUri(uri);
 
 		protected void OnSourceChanged() =>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Core/MediaSourceConverter.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Core/MediaSourceConverter.shared.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Xamarin.Forms;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.CommunityToolkit.Core
 {
-	[Forms.Xaml.TypeConversion(typeof(MediaSource))]
 	public sealed class MediaSourceConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
+using Xamarin.CommunityToolkit.Core;
 using Xamarin.Forms;
-using XCT = Xamarin.CommunityToolkit.Core;
 
 namespace Xamarin.CommunityToolkit.UI.Views
 {
@@ -35,7 +35,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		  BindableProperty.Create(nameof(ShowsPlaybackControls), typeof(bool), typeof(MediaElement), true);
 
 		public static readonly BindableProperty SourceProperty =
-		  BindableProperty.Create(nameof(Source), typeof(XCT.MediaSource), typeof(MediaElement),
+		  BindableProperty.Create(nameof(Source), typeof(MediaSource), typeof(MediaElement),
 			  propertyChanging: OnSourcePropertyChanging, propertyChanged: OnSourcePropertyChanged);
 
 		public static readonly BindableProperty VideoHeightProperty =
@@ -101,10 +101,10 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 		}
 
-		[Forms.TypeConverter(typeof(XCT.MediaSourceConverter))]
-		public XCT.MediaSource Source
+		[Forms.TypeConverter(typeof(MediaSourceConverter))]
+		public MediaSource Source
 		{
-			get => (XCT.MediaSource)GetValue(SourceProperty);
+			get => (MediaSource)GetValue(SourceProperty);
 			set => SetValue(SourceProperty, value);
 		}
 
@@ -219,9 +219,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		}
 
 		static void OnSourcePropertyChanged(BindableObject bindable, object oldvalue, object newvalue) =>
-			((MediaElement)bindable).OnSourcePropertyChanged((XCT.MediaSource)newvalue);
+			((MediaElement)bindable).OnSourcePropertyChanged((MediaSource)newvalue);
 
-		void OnSourcePropertyChanged(XCT.MediaSource newvalue)
+		void OnSourcePropertyChanged(MediaSource newvalue)
 		{
 			if (newvalue != null)
 			{
@@ -233,9 +233,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		}
 
 		static void OnSourcePropertyChanging(BindableObject bindable, object oldvalue, object newvalue) =>
-			((MediaElement)bindable).OnSourcePropertyChanging((XCT.MediaSource)oldvalue);
+			((MediaElement)bindable).OnSourcePropertyChanging((MediaSource)oldvalue);
 
-		void OnSourcePropertyChanging(XCT.MediaSource oldvalue)
+		void OnSourcePropertyChanging(MediaSource oldvalue)
 		{
 			if (oldvalue == null)
 				return;
@@ -274,9 +274,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			var oldval = (TimeSpan)oldValue;
 			var newval = (TimeSpan)newValue;
 			if (Math.Abs(newval.Subtract(oldval).TotalMilliseconds) > 300 && !element.isSeeking)
-			{
 				element.RequestSeek(newval);
-			}
 		}
 
 		static bool ValidateVolume(BindableObject o, object newValue)


### PR DESCRIPTION
### Description of Change ###

Now the linker will not remove the implicit operators.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #688

### API Changes ###

Changed:

```csharp
[Preserve(Conditional = true)]
public static implicit operator MediaSource(string source);

[Preserve(Conditional = true)]
public static implicit operator MediaSource(Uri uri);
```

### Behavioral Changes ###

Now the users can Binding the MediaElement.Source to a `string`.

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
