### PR TITLE
#704 [Bug] No padding around text in a Toast or Snackbar

### DIFF
--- a/samples/XCT.Sample/Pages/Views/SnackBarPage.xaml
+++ b/samples/XCT.Sample/Pages/Views/SnackBarPage.xaml
@@ -7,7 +7,8 @@
     <StackLayout Spacing="10" Margin="20">
         <Button Clicked="DisplaySnackBarClicked" Text="Show SnackBar"></Button>
         <Button Clicked="DisplayToastClicked" Text="Show toast"></Button>
-        <Button Clicked="DisplaySnackBarAdvancedClicked" Text="Show SnackBar"></Button>
+        <Button Clicked="DisplaySnackBarAdvancedClicked" Text="Show Advanced SnackBar"></Button>
+        <Button Clicked="DisplaySnackBarWithPadding" Text="Show SnackBar with Padding"></Button>
         <Label x:Name="StatusText"></Label>
     </StackLayout>
 </pages:BasePage>

--- a/samples/XCT.Sample/Pages/Views/SnackBarPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Views/SnackBarPage.xaml.cs
@@ -24,6 +24,22 @@ namespace Xamarin.CommunityToolkit.Sample.Pages.Views
 			StatusText.Text = result ? "SnackBar is closed by user" : "SnackBar is closed by timeout";
 		}
 
+		async void DisplaySnackBarWithPadding(object sender, EventArgs args)
+		{
+			var options = new SnackBarOptions()
+			{
+				BackgroundColor = Color.FromHex("#CC0000"),
+				MessageOptions = new MessageOptions
+				{
+					Message = "msg",
+					Foreground = Color.White,
+					Font = Font.SystemFontOfSize(16),
+					Padding = new Thickness(10, 20, 30, 40)
+				}
+			};
+
+			await this.DisplaySnackBarAsync(options);
+		}
 		async void DisplayToastClicked(object sender, EventArgs args)
 		{
 			await this.DisplayToastAsync(GenerateLongText(5));
@@ -33,47 +49,47 @@ namespace Xamarin.CommunityToolkit.Sample.Pages.Views
 		async void DisplaySnackBarAdvancedClicked(object sender, EventArgs args)
 		{
 			const string SmileIcon = "\uf118";
-			var messageOptions = new MessageOptions
-			{
-				Foreground = Color.DeepSkyBlue,
-				Font = Font.OfSize("FARegular", 40),
-				Message = SmileIcon
-			};
-
-			var actionOptions = new List<SnackBarActionOptions>
-			{
-				new SnackBarActionOptions
-				{
-					ForegroundColor = Color.Red,
-					BackgroundColor = Color.Green,
-					Font = Font.OfSize("Times New Roman", 15),
-					Text = "Action1",
-					Action = () =>
-					{
-						Debug.WriteLine("1");
-						return Task.CompletedTask;
-					}
-				},
-				new SnackBarActionOptions
-				{
-					ForegroundColor = Color.Green,
-					BackgroundColor = Color.Red,
-					Font = Font.OfSize("Times New Roman", 20),
-					Text = "Action2",
-					Action = () =>
-					{
-						Debug.WriteLine("2");
-						return Task.CompletedTask;
-					}
-				}
-			};
 			var options = new SnackBarOptions
 			{
-				MessageOptions = messageOptions,
+				MessageOptions = new MessageOptions
+				{
+					Foreground = Color.DeepSkyBlue,
+					Font = Font.OfSize("FARegular", 40),
+					Padding = new Thickness(10, 20, 30, 40),
+					Message = SmileIcon
+				},
 				Duration = TimeSpan.FromMilliseconds(5000),
 				BackgroundColor = Color.Coral,
 				IsRtl = CultureInfo.CurrentCulture.TextInfo.IsRightToLeft,
-				Actions = actionOptions
+				Actions = new List<SnackBarActionOptions>
+				{
+					new SnackBarActionOptions
+					{
+						ForegroundColor = Color.Red,
+						BackgroundColor = Color.Green,
+						Font = Font.OfSize("Times New Roman", 15),
+						Padding = new Thickness(10, 20, 30, 40),
+						Text = "Action1",
+						Action = () =>
+						{
+							Debug.WriteLine("1");
+							return Task.CompletedTask;
+						}
+					},
+					new SnackBarActionOptions
+					{
+						ForegroundColor = Color.Green,
+						BackgroundColor = Color.Red,
+						Font = Font.OfSize("Times New Roman", 20),
+						Padding = new Thickness(40, 30, 20, 10),
+						Text = "Action2",
+						Action = () =>
+						{
+							Debug.WriteLine("2");
+							return Task.CompletedTask;
+						}
+					}
+				}
 			};
 			var result = await this.DisplaySnackBarAsync(options);
 			StatusText.Text = result ? "SnackBar is closed by user" : "SnackBar is closed by timeout";

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/NativeSnackButton.ios.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/NativeSnackButton.ios.macos.cs
@@ -1,30 +1,75 @@
 ﻿using System;
 using System.Threading.Tasks;
+using CoreGraphics;
 #if __IOS__
 using Xamarin.CommunityToolkit.UI.Views.Helpers.iOS;
+using UIKit;
 #elif __MACOS__
 using Xamarin.CommunityToolkit.UI.Views.Helpers.macOS;
+using AppKit;
 #endif
 
 namespace Xamarin.CommunityToolkit.Views.Snackbar.Helpers
 {
-	class NativeActionButton
+#if __IOS__
+	class NativeSnackButton : UIButton
+#else
+	class NativeSnackButton : NSButton
+#endif
 	{
-		public Func<Task> Action { get; protected set; }
-
-		public string ActionButtonText { get; protected set; }
-
-		public NativeSnackButtonAppearance Appearance { get; protected set; } = new NativeSnackButtonAppearance();
-
-		public NativeActionButton SetAction(Func<Task> action)
+		public NativeSnackButton(double left, double top, double right, double bottom)
+#if __IOS__
+			: base(UIButtonType.System)
+#endif
 		{
-			Action = action;
+			Left = left;
+			Top = top;
+			Right = right;
+			Bottom = bottom;
+			LineBreakMode = NativeSnackButtonAppearance.LineBreakMode;
+#if __IOS__
+			ContentEdgeInsets = new UIEdgeInsets((nfloat)top, (nfloat)left, (nfloat)bottom, (nfloat)right);
+			TouchUpInside += async (s, e) =>
+			{
+				await SnackButtonAction();
+			};
+		}
+#else
+			WantsLayer = true;
+			Activated += async (s, e) =>
+			{
+				await SnackButtonAction();
+			};
+		}
+
+		public override CGSize IntrinsicContentSize => new CGSize(
+			base.IntrinsicContentSize.Width + Left + Right,
+			base.IntrinsicContentSize.Height + Top + Bottom);
+#endif
+
+		public double Left { get; }
+
+		public double Top { get; }
+
+		public double Right { get; }
+
+		public double Bottom { get; }
+
+		public Func<Task> SnackButtonAction { get; protected set; }
+
+		public NativeSnackButton SetAction(Func<Task> action)
+		{
+			SnackButtonAction = action;
 			return this;
 		}
 
-		public NativeActionButton SetActionButtonText(string title)
+		public NativeSnackButton SetActionButtonText(string title)
 		{
-			ActionButtonText = title;
+#if __IOS__
+			SetTitle(title, UIControlState.Normal);
+#else
+			Title = title;
+#endif
 			return this;
 		}
 	}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/PaddedLabel.ios.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/PaddedLabel.ios.macos.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using CoreGraphics;
+#if __IOS__
+using UIKit;
+#else
+using AppKit;
+#endif
+
+namespace Xamarin.CommunityToolkit.UI.Views.Helpers
+{
+#if __IOS__
+	class PaddedLabel : UILabel
+#else
+	class PaddedLabel : NSTextField
+#endif
+	{
+		public PaddedLabel(nfloat left, nfloat top, nfloat right, nfloat bottom)
+		{
+			Left = left;
+			Top = top;
+			Right = right;
+			Bottom = bottom;
+		}
+
+		public nfloat Left { get; }
+
+		public nfloat Top { get; }
+
+		public nfloat Right { get; }
+
+		public nfloat Bottom { get; }
+
+		public override CGSize IntrinsicContentSize => new CGSize(
+			base.IntrinsicContentSize.Width + Left + Right,
+			base.IntrinsicContentSize.Height + Top + Bottom);
+
+#if __IOS__
+		public override void DrawText(CGRect rect)
+		{
+			var insets = new UIEdgeInsets(Top, Left, Bottom, Right);
+			base.DrawText(insets.InsetRect(rect));
+		}
+#endif
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/SnackBarLayout.ios.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/SnackBarLayout.ios.macos.cs
@@ -6,21 +6,19 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers
 	{
 		public nfloat MarginBottom { get; set; } = 10.0f;
 
-		public nfloat MarginCenter { get; set; } = 0.0f;
-
-		public nfloat MarginLeading { get; set; } = 10.0f;
+		public nfloat MarginLeft { get; set; } = 10.0f;
 
 		public nfloat MarginTop { get; set; } = 10.0f;
 
-		public nfloat MarginTrailing { get; set; } = 10.0f;
+		public nfloat MarginRight { get; set; } = 10.0f;
 
 		public nfloat PaddingBottom { get; set; } = 10.0f;
 
-		public nfloat PaddingLeading { get; set; } = 10.0f;
+		public nfloat PaddingLeft { get; set; } = 10.0f;
 
 		public nfloat PaddingTop { get; set; } = 10.0f;
 
-		public nfloat PaddingTrailing { get; set; } = 10.0f;
+		public nfloat PaddingRight { get; set; } = 10.0f;
 
 		public nfloat Spacing { get; set; } = 10.0f;
 	}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/SnackBarLayout.uwp.wpf.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/SnackBarLayout.uwp.wpf.cs
@@ -33,13 +33,25 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers
 #else
 			var messageLabel = new Label
 			{
-				Content = options.MessageOptions.Message,
+				Content = options.MessageOptions.Message
 			};
 #endif
+			messageLabel.Padding = new Thickness(options.MessageOptions.Padding.Left,
+					options.MessageOptions.Padding.Top,
+					options.MessageOptions.Padding.Right,
+					options.MessageOptions.Padding.Bottom);
+
 			if (options.MessageOptions.Font != Forms.Font.Default)
 			{
-				messageLabel.FontSize = options.MessageOptions.Font.FontSize;
-				messageLabel.FontFamily = new FontFamily(options.MessageOptions.Font.FontFamily);
+				if (options.MessageOptions.Font.FontSize > 0)
+				{
+					messageLabel.FontSize = options.MessageOptions.Font.FontSize;
+				}
+
+				if (options.MessageOptions.Font.FontFamily != null)
+				{
+					messageLabel.FontFamily = new FontFamily(options.MessageOptions.Font.FontFamily);
+				}
 			}
 
 			if (options.MessageOptions.Foreground != Forms.Color.Default)
@@ -61,7 +73,11 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers
 					{
 						OnSnackBarActionExecuted?.Invoke();
 						await action.Action();
-					})
+					}),
+					Padding = new Thickness(action.Padding.Left,
+						action.Padding.Top,
+						action.Padding.Right,
+						action.Padding.Bottom)
 				};
 				if (action.Font != Forms.Font.Default)
 				{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/IOSSnackBar.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/IOSSnackBar.ios.cs
@@ -14,7 +14,7 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS
 	{
 		NSTimer timer;
 
-		public List<NativeActionButton> Actions { get; protected set; } = new List<NativeActionButton>();
+		public List<NativeSnackButton> Actions { get; protected set; } = new List<NativeSnackButton>();
 
 		public Func<Task> TimeoutAction { get; protected set; }
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackBarAppearance.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackBarAppearance.ios.cs
@@ -19,15 +19,9 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS
 		public static UIFont DefaultFont { get; } = Forms.Font.Default.ToUIFont();
 	}
 
-	class NativeSnackButtonAppearance
+	static class NativeSnackButtonAppearance
 	{
-		public UIColor Background { get; set; } = DefaultColor;
-
-		public UIColor Foreground { get; set; } = DefaultColor;
-
-		public UIFont Font { get; set; } = DefaultFont;
-
-		public UILineBreakMode LineBreakMode { get; set; } = UILineBreakMode.MiddleTruncation;
+		public static UILineBreakMode LineBreakMode { get; set; } = UILineBreakMode.MiddleTruncation;
 
 		public static UIColor DefaultColor { get; } = Forms.Color.Default.ToUIColor();
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackbarViews/ActionMessageSnackBarView.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackbarViews/ActionMessageSnackBarView.ios.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using UIKit;
+﻿using UIKit;
 using Xamarin.CommunityToolkit.UI.Views.Helpers.iOS.SnackBarViews;
+using Xamarin.CommunityToolkit.Views.Snackbar.Helpers;
 
 namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS
 {
@@ -11,39 +11,12 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS
 		{
 		}
 
-		// Gets the maximum width of the action button. Possible values 0 to 1.
-		protected virtual nfloat ActionButtonMaxWidth => 1f;
-
 		protected override void Initialize()
 		{
 			base.Initialize();
 
-			foreach (var action in SnackBar.Actions)
+			foreach (var actionButton in SnackBar.Actions)
 			{
-				var actionButton = new UIButton(UIButtonType.System);
-				if (action.Appearance.Background != NativeSnackButtonAppearance.DefaultColor)
-				{
-					actionButton.BackgroundColor = action.Appearance.Background;
-				}
-
-				if (action.Appearance.Foreground != NativeSnackButtonAppearance.DefaultColor)
-				{
-					actionButton.SetTitleColor(action.Appearance.Foreground, UIControlState.Normal);
-				}
-
-				if (action.Appearance.Font != NativeSnackButtonAppearance.DefaultFont)
-				{
-					actionButton.Font = action.Appearance.Font;
-				}
-
-				actionButton.SetTitle(action.ActionButtonText, UIControlState.Normal);
-				actionButton.TitleLabel.LineBreakMode = action.Appearance.LineBreakMode;
-				actionButton.TouchUpInside += async (s, e) =>
-				{
-					await action.Action();
-					Dismiss();
-				};
-
 				StackView.AddArrangedSubview(actionButton);
 			}
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackbarViews/BaseSnackBarView.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackbarViews/BaseSnackBarView.ios.cs
@@ -32,12 +32,12 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS.SnackBar
 		{
 			this.SafeBottomAnchor().ConstraintEqualTo(GetBottomAnchor(), -SnackBar.Layout.MarginBottom).Active = true;
 			this.SafeTopAnchor().ConstraintGreaterThanOrEqualTo(GetTopAnchor(), SnackBar.Layout.MarginTop).Active = true;
-			this.SafeLeadingAnchor().ConstraintGreaterThanOrEqualTo(ParentView.SafeLeadingAnchor(), SnackBar.Layout.MarginLeading).Active = true;
-			this.SafeTrailingAnchor().ConstraintLessThanOrEqualTo(ParentView.SafeTrailingAnchor(), -SnackBar.Layout.MarginTrailing).Active = true;
+			this.SafeLeadingAnchor().ConstraintGreaterThanOrEqualTo(ParentView.SafeLeadingAnchor(), SnackBar.Layout.MarginLeft).Active = true;
+			this.SafeTrailingAnchor().ConstraintLessThanOrEqualTo(ParentView.SafeTrailingAnchor(), -SnackBar.Layout.MarginRight).Active = true;
 			this.SafeCenterXAnchor().ConstraintEqualTo(ParentView.SafeCenterXAnchor()).Active = true;
 
-			StackView.SafeLeadingAnchor().ConstraintEqualTo(this.SafeLeadingAnchor(), SnackBar.Layout.PaddingLeading).Active = true;
-			StackView.SafeTrailingAnchor().ConstraintEqualTo(this.SafeTrailingAnchor(), -SnackBar.Layout.PaddingTrailing).Active = true;
+			StackView.SafeLeadingAnchor().ConstraintEqualTo(this.SafeLeadingAnchor(), SnackBar.Layout.PaddingLeft).Active = true;
+			StackView.SafeTrailingAnchor().ConstraintEqualTo(this.SafeTrailingAnchor(), -SnackBar.Layout.PaddingRight).Active = true;
 			StackView.SafeBottomAnchor().ConstraintEqualTo(this.SafeBottomAnchor(), -SnackBar.Layout.PaddingBottom).Active = true;
 			StackView.SafeTopAnchor().ConstraintEqualTo(this.SafeTopAnchor(), SnackBar.Layout.PaddingTop).Active = true;
 		}
@@ -78,6 +78,7 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS.SnackBar
 			AddSubview(StackView);
 			StackView.Axis = UILayoutConstraintAxis.Horizontal;
 			StackView.TranslatesAutoresizingMaskIntoConstraints = false;
+			StackView.Spacing = SnackBar.Layout.Spacing;
 			if (SnackBar.Appearance.Background != NativeSnackBarAppearance.DefaultColor)
 			{
 				StackView.BackgroundColor = SnackBar.Appearance.Background;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackbarViews/MessageSnackBarView.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackbarViews/MessageSnackBarView.ios.cs
@@ -1,5 +1,4 @@
-﻿using UIKit;
-using Xamarin.CommunityToolkit.UI.Views.Helpers.iOS.SnackBar;
+﻿using Xamarin.CommunityToolkit.UI.Views.Helpers.iOS.SnackBar;
 
 namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS.SnackBarViews
 {
@@ -14,7 +13,10 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS.SnackBarViews
 		{
 			base.Initialize();
 
-			var messageLabel = new UILabel
+			var messageLabel = new PaddedLabel(SnackBar.Layout.PaddingLeft,
+				SnackBar.Layout.PaddingTop,
+				SnackBar.Layout.PaddingRight,
+				SnackBar.Layout.PaddingBottom)
 			{
 				Text = SnackBar.Message,
 				Lines = 0,

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/macOS/MacOSSnackBar.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/macOS/MacOSSnackBar.macos.cs
@@ -14,7 +14,7 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.macOS
 
 		public Func<Task> TimeoutAction { get; protected set; }
 
-		public List<NativeActionButton> Actions { get; protected set; } = new List<NativeActionButton>();
+		public List<NativeSnackButton> Actions { get; protected set; } = new List<NativeSnackButton>();
 
 		public NativeSnackBarAppearance Appearance { get; protected set; } = new NativeSnackBarAppearance();
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/macOS/SnackBarAppearance.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/macOS/SnackBarAppearance.macos.cs
@@ -1,4 +1,5 @@
 ﻿using AppKit;
+using CoreGraphics;
 using Xamarin.Forms.Platform.MacOS;
 
 namespace Xamarin.CommunityToolkit.UI.Views.Helpers.macOS
@@ -11,22 +12,20 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.macOS
 
 		public NSFont Font { get; set; } = DefaultFont;
 
+		public CGRect Padding { get; set; } = DefaultPadding;
+
 		public NSTextAlignment TextAlignment { get; set; } = NSTextAlignment.Left;
 
 		public static NSColor DefaultColor { get; } = Forms.Color.Default.ToNSColor();
 
 		public static NSFont DefaultFont { get; } = Forms.Font.Default.ToNSFont();
+
+		public static CGRect DefaultPadding { get; } = new CGRect(0, 0, 0, 0);
 	}
 
-	class NativeSnackButtonAppearance
+	static class NativeSnackButtonAppearance
 	{
-		public NSColor Background { get; set; } = DefaultColor;
-
-		public NSColor Foreground { get; set; } = DefaultColor;
-
-		public NSFont Font { get; set; } = DefaultFont;
-
-		public NSLineBreakMode LineBreakMode { get; set; } = NSLineBreakMode.TruncatingMiddle;
+		public static NSLineBreakMode LineBreakMode { get; set; } = NSLineBreakMode.TruncatingMiddle;
 
 		public static NSColor DefaultColor { get; } = Forms.Color.Default.ToNSColor();
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/macOS/SnackbarViews/ActionMessageSnackBarView.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/macOS/SnackbarViews/ActionMessageSnackBarView.macos.cs
@@ -10,35 +10,11 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.macOS.SnackBarViews
 		{
 		}
 
-		// Gets the maximum width of the action button. Possible values 0 to 1.
-		protected virtual nfloat ActionButtonMaxWidth => 1f;
-
 		protected override void Initialize()
 		{
 			base.Initialize();
-			foreach (var action in SnackBar.Actions)
+			foreach (var actionButton in SnackBar.Actions)
 			{
-				var actionButton = new NSButton
-				{
-					Title = action.ActionButtonText,
-					WantsLayer = true,
-					LineBreakMode = action.Appearance.LineBreakMode,
-				};
-				if (SnackBar.Appearance.Background != NativeSnackButtonAppearance.DefaultColor)
-				{
-					actionButton.Layer.BackgroundColor = action.Appearance.Background.CGColor;
-				}
-
-				if (SnackBar.Appearance.Font != NativeSnackButtonAppearance.DefaultFont)
-				{
-					actionButton.Font = action.Appearance.Font;
-				}
-
-				actionButton.Activated += async (s, e) =>
-				{
-					await action.Action();
-					Dismiss();
-				};
 				StackView.AddArrangedSubview(actionButton);
 			}
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/macOS/SnackbarViews/BaseSnackBarView.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/macOS/SnackbarViews/BaseSnackBarView.macos.cs
@@ -29,12 +29,12 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.macOS.SnackBarViews
 		{
 			BottomAnchor.ConstraintEqualToAnchor(ParentView.BottomAnchor, -SnackBar.Layout.MarginBottom).Active = true;
 			TopAnchor.ConstraintGreaterThanOrEqualToAnchor(ParentView.TopAnchor, SnackBar.Layout.MarginTop).Active = true;
-			LeadingAnchor.ConstraintGreaterThanOrEqualToAnchor(ParentView.LeadingAnchor, SnackBar.Layout.MarginLeading).Active = true;
-			TrailingAnchor.ConstraintGreaterThanOrEqualToAnchor(ParentView.TrailingAnchor, -SnackBar.Layout.MarginTrailing).Active = true;
+			LeadingAnchor.ConstraintGreaterThanOrEqualToAnchor(ParentView.LeadingAnchor, SnackBar.Layout.MarginLeft).Active = true;
+			TrailingAnchor.ConstraintGreaterThanOrEqualToAnchor(ParentView.TrailingAnchor, -SnackBar.Layout.MarginRight).Active = true;
 			CenterXAnchor.ConstraintEqualToAnchor(ParentView.CenterXAnchor).Active = true;
 
-			StackView.LeadingAnchor.ConstraintEqualToAnchor(LeadingAnchor, SnackBar.Layout.PaddingLeading).Active = true;
-			StackView.TrailingAnchor.ConstraintEqualToAnchor(TrailingAnchor, -SnackBar.Layout.PaddingTrailing).Active = true;
+			StackView.LeadingAnchor.ConstraintEqualToAnchor(LeadingAnchor, SnackBar.Layout.PaddingLeft).Active = true;
+			StackView.TrailingAnchor.ConstraintEqualToAnchor(TrailingAnchor, -SnackBar.Layout.PaddingRight).Active = true;
 			StackView.BottomAnchor.ConstraintEqualToAnchor(BottomAnchor, -SnackBar.Layout.PaddingBottom).Active = true;
 			StackView.TopAnchor.ConstraintEqualToAnchor(TopAnchor, SnackBar.Layout.PaddingTop).Active = true;
 		}
@@ -51,7 +51,7 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.macOS.SnackBarViews
 
 			StackView.Orientation = NSUserInterfaceLayoutOrientation.Horizontal;
 			StackView.TranslatesAutoresizingMaskIntoConstraints = false;
-			StackView.Spacing = 5;
+			StackView.Spacing = SnackBar.Layout.Spacing;
 			TranslatesAutoresizingMaskIntoConstraints = false;
 		}
 	}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/macOS/SnackbarViews/MessageSnackBarView.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/macOS/SnackbarViews/MessageSnackBarView.macos.cs
@@ -1,4 +1,6 @@
-﻿using AppKit;
+﻿using System;
+using AppKit;
+using CoreGraphics;
 
 namespace Xamarin.CommunityToolkit.UI.Views.Helpers.macOS.SnackBarViews
 {
@@ -12,7 +14,10 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.macOS.SnackBarViews
 		protected override void Initialize()
 		{
 			base.Initialize();
-			var messageLabel = new NSTextField
+			var messageLabel = new PaddedLabel(SnackBar.Layout.PaddingLeft,
+				SnackBar.Layout.PaddingTop,
+				SnackBar.Layout.PaddingRight,
+				SnackBar.Layout.PaddingBottom)
 			{
 				StringValue = SnackBar.Message,
 				Selectable = false,

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Options/MessageOptions.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Options/MessageOptions.shared.cs
@@ -24,5 +24,12 @@ namespace Xamarin.CommunityToolkit.UI.Views.Options
 		public Color Foreground { get; set; } = DefaultForeground;
 
 		public static Color DefaultForeground { get; set; } = Color.Default;
+
+		/// <summary>
+		/// Gets or sets the padding for the SnackBar message.
+		/// </summary>
+		public Thickness Padding { get; set; }
+
+		public static Thickness DefaultPadding { get; set; } = new Thickness(0, 0, 0, 0);
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Options/SnackBarActionOptions.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Options/SnackBarActionOptions.shared.cs
@@ -40,5 +40,12 @@ namespace Xamarin.CommunityToolkit.UI.Views.Options
 		public Color ForegroundColor { get; set; } = DefaultForegroundColor;
 
 		public static Color DefaultForegroundColor { get; set; } = Color.Default;
+
+		/// <summary>
+		/// Gets or sets the padding for the SnackBar message.
+		/// </summary>
+		public Thickness Padding { get; set; }
+
+		public static Thickness DefaultPadding { get; set; } = new Thickness(0, 0, 0, 0);
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.android.cs
@@ -26,6 +26,15 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			var snackTextView = snackBarView.FindViewById<TextView>(Resource.Id.snackbar_text);
 			snackTextView.SetMaxLines(10);
+
+			if (arguments.MessageOptions.Padding != MessageOptions.DefaultPadding)
+			{
+				snackBarView.SetPadding((int)arguments.MessageOptions.Padding.Left,
+					(int)arguments.MessageOptions.Padding.Top,
+					(int)arguments.MessageOptions.Padding.Right,
+					(int)arguments.MessageOptions.Padding.Bottom);
+			}
+
 			if (arguments.MessageOptions.Foreground != Forms.Color.Default)
 			{
 				snackTextView.SetTextColor(arguments.MessageOptions.Foreground.ToAndroid());
@@ -33,7 +42,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			if (arguments.MessageOptions.Font != Font.Default)
 			{
-				snackTextView.SetTextSize(ComplexUnitType.Dip, (float)arguments.MessageOptions.Font.FontSize);
+				if (arguments.MessageOptions.Font.FontSize > 0)
+				{
+					snackTextView.SetTextSize(ComplexUnitType.Dip, (float)arguments.MessageOptions.Font.FontSize);
+				}
+
 				snackTextView.SetTypeface(arguments.MessageOptions.Font.ToTypeface(), TypefaceStyle.Normal);
 			}
 
@@ -55,9 +68,21 @@ namespace Xamarin.CommunityToolkit.UI.Views
 					snackActionButtonView.SetBackgroundColor(action.BackgroundColor.ToAndroid());
 				}
 
-				if (action.Font != Forms.Font.Default)
+				if (action.Padding != SnackBarActionOptions.DefaultPadding)
 				{
-					snackActionButtonView.SetTextSize(ComplexUnitType.Dip, (float)action.Font.FontSize);
+					snackActionButtonView.SetPadding((int)action.Padding.Left,
+						(int)action.Padding.Top,
+						(int)action.Padding.Right,
+						(int)action.Padding.Bottom);
+				}
+
+				if (action.Font != Font.Default)
+				{
+					if (action.Font.FontSize > 0)
+					{
+						snackTextView.SetTextSize(ComplexUnitType.Dip, (float)action.Font.FontSize);
+					}
+
 					snackActionButtonView.SetTypeface(action.Font.ToTypeface(), TypefaceStyle.Normal);
 				}
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.gtk.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.gtk.cs
@@ -35,6 +35,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			var message = new Gtk.Label(arguments.MessageOptions.Message);
 			message.ModifyFont(new FontDescription { AbsoluteSize = arguments.MessageOptions.Font.FontSize, Family = arguments.MessageOptions.Font.FontFamily });
 			message.ModifyFg(StateType.Normal, arguments.MessageOptions.Foreground.ToGtkColor());
+			message.SetPadding((int)arguments.MessageOptions.Padding.Left, (int)arguments.MessageOptions.Padding.Top);
 			snackBarLayout.Add(message);
 			snackBarLayout.SetChildPacking(message, false, false, 0, PackType.Start);
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.ios.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.ios.macos.cs
@@ -43,6 +43,14 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				snackBar.Appearance.Foreground = arguments.MessageOptions.Foreground.ToUIColor();
 			}
 
+			if (arguments.MessageOptions.Padding != MessageOptions.DefaultPadding)
+			{
+				snackBar.Layout.PaddingTop = (nfloat)arguments.MessageOptions.Padding.Top;
+				snackBar.Layout.PaddingLeft = (nfloat)arguments.MessageOptions.Padding.Left;
+				snackBar.Layout.PaddingBottom = (nfloat)arguments.MessageOptions.Padding.Bottom;
+				snackBar.Layout.PaddingRight = (nfloat)arguments.MessageOptions.Padding.Right;
+			}
+
 			snackBar.Appearance.TextAlignment = arguments.IsRtl ? UITextAlignment.Right : UITextAlignment.Left;
 
 			if (!UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
@@ -71,37 +79,35 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			foreach (var action in arguments.Actions)
 			{
-				var actionButton = new NativeActionButton();
+				var actionButton = new NativeSnackButton(action.Padding.Left,
+					action.Padding.Top,
+					action.Padding.Right,
+					action.Padding.Bottom);
 				actionButton.SetActionButtonText(action.Text);
 #if __IOS__
 				if (action.BackgroundColor != Color.Default)
 				{
-					actionButton.Appearance.Background = action.BackgroundColor.ToUIColor();
+					actionButton.BackgroundColor = action.BackgroundColor.ToUIColor();
 				}
 
 				if (action.Font != Font.Default)
 				{
-					actionButton.Appearance.Font = action.Font.ToUIFont();
+					actionButton.Font = action.Font.ToUIFont();
 				}
 
 				if (action.ForegroundColor != Color.Default)
 				{
-					actionButton.Appearance.Foreground = action.ForegroundColor.ToUIColor();
+					actionButton.SetTitleColor(action.ForegroundColor.ToUIColor(), UIControlState.Normal);
 				}
 #elif __MACOS__
 				if (action.BackgroundColor != Color.Default)
 				{
-					actionButton.Appearance.Background = action.BackgroundColor.ToNSColor();
+					actionButton.Layer.BackgroundColor = action.BackgroundColor.ToCGColor();
 				}
 
 				if (action.Font != Font.Default)
 				{
-					actionButton.Appearance.Font = action.Font.ToNSFont();
-				}
-
-				if (action.ForegroundColor != Color.Default)
-				{
-					actionButton.Appearance.Foreground = action.ForegroundColor.ToNSColor();
+					actionButton.Font = action.Font.ToNSFont();
 				}
 #endif
 				actionButton.SetAction(async () =>


### PR DESCRIPTION
### Description of Change ###

Add padding for message and action buttons
![image](https://user-images.githubusercontent.com/33021114/103480441-0f048e00-4ddd-11eb-9638-4c5a299c015a.png)


### Bugs Fixed ###
- Fixes #704

### API Changes ###

Added: 
 
- `Thickness Padding { get; set; }`

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
