### PR TITLE
[iOS] MediaElement ignores volume set before media start

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
@@ -95,6 +95,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 					volumeObserver = avPlayerViewController.Player.AddObserver("volume", NSKeyValueObservingOptions.New, ObserveVolume);
 				}
 
+				UpdateVolume();
+
 				if (Element.AutoPlay)
 					Play();
 			}
@@ -247,8 +249,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 					break;
 
 				case nameof(ToolKitMediaElement.Volume):
-					if (avPlayerViewController.Player != null)
-						avPlayerViewController.Player.Volume = (float)Element.Volume;
+					UpdateVolume();
 					break;
 			}
 		}
@@ -294,6 +295,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			if (Element.KeepScreenOn)
 				SetKeepScreenOn(true);
+		}
+
+		void UpdateVolume()
+		{
+			if (avPlayerViewController.Player != null)
+				avPlayerViewController.Player.Volume = (float)Element.Volume;
 		}
 
 		void MediaElementStateRequested(object sender, StateRequested e)


### PR DESCRIPTION
### Description of Change ###
Set Volume on every media source set.

### Bugs Fixed ###
- Fixes #703

### API Changes ###
None


### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
