### PR TITLE
Rename reduce to Normalize whitespace for TextValidationBehavior

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/TextDecorationFlags.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/TextDecorationFlags.shared.cs
@@ -10,6 +10,6 @@ namespace Xamarin.CommunityToolkit.Behaviors
 		TrimEnd = 2,
 		Trim = 3,
 		NullToEmpty = 4,
-		ReduceWhiteSpaces = 8
+		NormalizeWhiteSpace = 8
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/TextValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/TextValidationBehavior.shared.cs
@@ -80,8 +80,8 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			if (flags.HasFlag(TextDecorationFlags.TrimEnd))
 				value = value.TrimEnd();
 
-			if (flags.HasFlag(TextDecorationFlags.ReduceWhiteSpaces))
-				value = ReduceWhiteSpaces(value);
+			if (flags.HasFlag(TextDecorationFlags.NormalizeWhiteSpace))
+				value = NormalizeWhiteSpace(value);
 
 			return value;
 		}
@@ -115,7 +115,10 @@ namespace Xamarin.CommunityToolkit.Behaviors
 				? new Regex(RegexPattern, RegexOptions)
 				: null;
 
-		string ReduceWhiteSpaces(string value)
+		// This method trims down multiple consecutive whitespaces
+		// back to one whitespace.
+		// I.e. "Hello    World" will become "Hello World"
+		string NormalizeWhiteSpace(string value)
 		{
 			var builder = new StringBuilder();
 			var isSpace = false;


### PR DESCRIPTION
### Description of Change ###

Renames `TextValidationBehavior.TextDecorationFlags` `ReduceWhiteSpace` to `NormalizeWhiteSpace` which is a slightly more descriptive name.

### Bugs Fixed ###
NA

### API Changes ###

Changed:

 - `TextDecorationFlags.ReduceWhiteSpace` => `TextDecorationFlags.NormalizeWhiteSpace`

### Behavioral Changes ###

People using this flag will need to update the name, functionality remains exactly the same
