### PR TITLE
Fix preview size for camera view on Androud (#723)

### DIFF
--- a/samples/XCT.Sample/Pages/Views/CameraViewPage.xaml
+++ b/samples/XCT.Sample/Pages/Views/CameraViewPage.xaml
@@ -24,6 +24,7 @@
                     IsEnabled="False"
                     Maximum="10"
                     Minimum="1"
+                    HorizontalOptions="FillAndExpand"
                     ValueChanged="ZoomSlider_ValueChanged"
                     Value="1" />
             </StackLayout>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
@@ -36,12 +36,19 @@ using System.Linq;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 using Camera = Android.Hardware.Camera;
+using Math = System.Math;
 using Rect = Android.Graphics.Rect;
+using APoint = Android.Graphics.Point;
 
 namespace Xamarin.CommunityToolkit.UI.Views
 {
 	class CameraFragment : Fragment, TextureView.ISurfaceTextureListener
 	{
+		// Max preview width that is guaranteed by Camera2 API
+		const int MAX_PREVIEW_HEIGHT = 1080;
+		// Max preview height that is guaranteed by Camera2 API
+		const int MAX_PREVIEW_WIDTH = 1920;
+
 		CameraDevice device;
 		CaptureRequest.Builder sessionBuilder;
 		CameraCaptureSession session;
@@ -222,14 +229,42 @@ namespace Xamarin.CommunityToolkit.UI.Views
 					}
 					Element.MaxZoom = maxDigitalZoom = (float)characteristics.Get(CameraCharacteristics.ScalerAvailableMaxDigitalZoom);
 					activeRect = (Rect)characteristics.Get(CameraCharacteristics.SensorInfoActiveArraySize);
+					sensorOrientation = (int)characteristics.Get(CameraCharacteristics.SensorOrientation);
+
+					var displaySize = new APoint();
+					Activity.WindowManager.DefaultDisplay.GetSize(displaySize);
+					var rotatedViewWidth = texture.Width;
+					var rotatedViewHeight = texture.Height;
+					var maxPreviewWidth = displaySize.X;
+					var maxPreviewHeight = displaySize.Y;
+
+					if (sensorOrientation == 90 || sensorOrientation == 270)
+					{
+						rotatedViewWidth = texture.Height;
+						rotatedViewHeight = texture.Width;
+						maxPreviewWidth = displaySize.Y;
+						maxPreviewHeight = displaySize.X;
+					}
+
+					if (maxPreviewHeight > MAX_PREVIEW_HEIGHT)
+					{
+						maxPreviewHeight = MAX_PREVIEW_HEIGHT;
+					}
+
+					if (maxPreviewWidth > MAX_PREVIEW_WIDTH)
+					{
+						maxPreviewWidth = MAX_PREVIEW_WIDTH;
+					}
+
 					photoSize = GetMaxSize(map.GetOutputSizes((int)ImageFormatType.Jpeg));
 					videoSize = GetMaxSize(map.GetOutputSizes(Class.FromType(typeof(MediaRecorder))));
 					previewSize = ChooseOptimalSize(
 						map.GetOutputSizes(Class.FromType(typeof(SurfaceTexture))),
-						texture.Width,
-						texture.Height,
+						rotatedViewWidth,
+						rotatedViewHeight,
+						maxPreviewWidth,
+						maxPreviewHeight,
 						cameraTemplate == CameraTemplate.Record ? videoSize : photoSize);
-					sensorOrientation = (int)characteristics.Get(CameraCharacteristics.SensorOrientation);
 					cameraType = (LensFacing)(int)characteristics.Get(CameraCharacteristics.LensFacing);
 
 					if (Resources.Configuration.Orientation == AOrientation.Landscape)
@@ -923,17 +958,25 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		}
 
 		// chooses the smallest one whose width and height are at least as large as the respective requested values
-		ASize ChooseOptimalSize(ASize[] choices, int width, int height, ASize aspectRatio)
+		ASize ChooseOptimalSize(ASize[] choices, int width, int height, int maxWidth, int maxHeight, ASize aspectRatio)
 		{
 			var bigEnough = new List<ASize>();
+			var notBigEnough = new List<ASize>();
 			var w = aspectRatio.Width;
 			var h = aspectRatio.Height;
 			foreach (var option in choices)
 			{
-				if (option.Height == option.Width * h / w &&
-						option.Width >= width && option.Height >= height)
+				if (option.Width <= maxWidth && option.Height <= maxHeight &&
+				    option.Height == option.Width * h / w)
 				{
-					bigEnough.Add(option);
+					if (option.Width >= width && option.Height >= height)
+					{
+						bigEnough.Add(option);
+					}
+					else
+					{
+						notBigEnough.Add(option);
+					}
 				}
 			}
 
@@ -943,11 +986,15 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				var minArea = bigEnough.Min(s => s.Width * s.Height);
 				return bigEnough.First(s => s.Width * s.Height == minArea);
 			}
-			else
+
+			if (notBigEnough.Count > 0)
 			{
-				LogError("Couldn't find any suitable preview size");
-				return choices[0];
+				var maxArea = notBigEnough.Max(s => s.Height * s.Width);
+				return notBigEnough.First(s => s.Height * s.Width == maxArea);
 			}
+
+			LogError("Couldn't find any suitable preview size");
+			return choices[0];
 		}
 		#endregion
 	}


### PR DESCRIPTION
Fix is based on sample implementations for Camera2 API from Google
- https://github.com/android/camera-samples/blob/4aac9c7763c285d387194a558416a4458f29e275/CameraXTfLite/utils/src/main/java/com/example/android/camera/utils/CameraSizes.kt#L50-L78
- https://github.com/googlearchive/android-Camera2Raw/blob/master/Application/src/main/java/com/example/android/camera2raw/Camera2RawFragment.java#L1069-L1088

### Description of Change ###

- Calculate width and height dependent on orientation
- reduce the reoslution to max. supported preview resolution by Camera2 API (1920x1080)

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #723

### API Changes ###

None

### Behavioral Changes ###

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
