### PR TITLE
Add BaseCommand.ChangeCanExecute()

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/AsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/AsyncCommand_Tests.cs
@@ -152,7 +152,9 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.False(didCanExecuteChangeFire);
 
 			// Act
+#pragma warning disable CS0618 // Type or member is obsolete
 			command.ChangeCanExecute();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Assert
 			Assert.True(didCanExecuteChangeFire);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/AsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/AsyncCommand_Tests.cs
@@ -100,7 +100,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 		}
 
 		[Fact]
-		public void AsyncCommand_CanExecuteChanged_Test()
+		public void AsyncCommand_RaiseCanExecuteChanged_Test()
 		{
 			// Arrange
 			var canCommandExecute = false;
@@ -122,6 +122,37 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 
 			// Act
 			command.RaiseCanExecuteChanged();
+
+			// Assert
+			Assert.True(didCanExecuteChangeFire);
+			Assert.True(command.CanExecute(null));
+
+			void handleCanExecuteChanged(object sender, EventArgs e) => didCanExecuteChangeFire = true;
+		}
+
+		[Fact]
+		public void AsyncCommand_ChangeCanExecute_Test()
+		{
+			// Arrange
+			var canCommandExecute = false;
+			var didCanExecuteChangeFire = false;
+
+			var command = new AsyncCommand(NoParameterTask, commandCanExecute);
+			command.CanExecuteChanged += handleCanExecuteChanged;
+
+			bool commandCanExecute(object parameter) => canCommandExecute;
+
+			Assert.False(command.CanExecute(null));
+
+			// Act
+			canCommandExecute = true;
+
+			// Assert
+			Assert.True(command.CanExecute(null));
+			Assert.False(didCanExecuteChangeFire);
+
+			// Act
+			command.ChangeCanExecute();
 
 			// Assert
 			Assert.True(didCanExecuteChangeFire);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/AsyncValueCommand_Tests.cs
@@ -119,7 +119,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		}
 
 		[Fact]
-		public void AsyncValueCommandCanExecuteChanged_Test()
+		public void AsyncValueCommand_RaiseCanExecuteChanged_Test()
 		{
 			// Arrange
 			var canCommandExecute = false;
@@ -141,6 +141,37 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 
 			// Act
 			command.RaiseCanExecuteChanged();
+
+			// Assert
+			Assert.True(didCanExecuteChangeFire);
+			Assert.True(command.CanExecute(null));
+
+			void handleCanExecuteChanged(object sender, EventArgs e) => didCanExecuteChangeFire = true;
+		}
+
+		[Fact]
+		public void AsyncValueCommand_ChangeCanExecute_Test()
+		{
+			// Arrange
+			var canCommandExecute = false;
+			var didCanExecuteChangeFire = false;
+
+			var command = new AsyncValueCommand(NoParameterTask, commandCanExecute);
+			command.CanExecuteChanged += handleCanExecuteChanged;
+
+			bool commandCanExecute(object parameter) => canCommandExecute;
+
+			Assert.False(command.CanExecute(null));
+
+			// Act
+			canCommandExecute = true;
+
+			// Assert
+			Assert.True(command.CanExecute(null));
+			Assert.False(didCanExecuteChangeFire);
+
+			// Act
+			command.ChangeCanExecute();
 
 			// Assert
 			Assert.True(didCanExecuteChangeFire);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/AsyncValueCommand_Tests.cs
@@ -171,7 +171,9 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			Assert.False(didCanExecuteChangeFire);
 
 			// Act
+#pragma warning disable CS0618 // Type or member is obsolete
 			command.ChangeCanExecute();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Assert
 			Assert.True(didCanExecuteChangeFire);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/BaseCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/BaseCommand.shared.cs
@@ -77,12 +77,17 @@ namespace Xamarin.CommunityToolkit.ObjectModel.Internals
 		};
 
 		/// <summary>
-		/// Raises the CanExecuteChanged event.
+		/// Raises the `ICommand.CanExecuteChanged` event.
 		/// </summary>
 		public void RaiseCanExecuteChanged()
 		{
 			// Automatically marshall to the Main Thread to adhere to the way that Xamarin.Forms automatically marshalls binding events to Main Thread
 			Device.BeginInvokeOnMainThread(() => weakEventManager.RaiseEvent(this, EventArgs.Empty, nameof(CanExecuteChanged)));
 		}
+
+		/// <summary>
+		/// Raises the `ICommand.CanExecuteChanged` event. Performs the same functionality as RaiseCanExecuteChanged leveraging the Xamarin.Forms.Command nomencalture to make the transition from Xamarin.Forms.Command easier.
+		/// </summary>
+		public void ChangeCanExecute() => RaiseCanExecuteChanged();
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/BaseCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/BaseCommand.shared.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.Forms;
 
@@ -86,9 +87,9 @@ namespace Xamarin.CommunityToolkit.ObjectModel.Internals
 		}
 
 		/// <summary>
-		/// Raises the `ICommand.CanExecuteChanged` event.
+		/// Raises the `ICommand.CanExecuteChanged` event. Recommend using RaiseCanExecuteChanged() instead.
 		/// </summary>
-		[Obsolete("Use RaiseCanExecuteChanged() instead")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void ChangeCanExecute() => RaiseCanExecuteChanged();
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/BaseCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/BaseCommand.shared.cs
@@ -86,8 +86,9 @@ namespace Xamarin.CommunityToolkit.ObjectModel.Internals
 		}
 
 		/// <summary>
-		/// Raises the `ICommand.CanExecuteChanged` event. Performs the same functionality as RaiseCanExecuteChanged leveraging the Xamarin.Forms.Command nomencalture to make the transition from Xamarin.Forms.Command easier.
+		/// Raises the `ICommand.CanExecuteChanged` event.
 		/// </summary>
+		[Obsolete("Use RaiseCanExecuteChanged() instead")]
 		public void ChangeCanExecute() => RaiseCanExecuteChanged();
 	}
 }


### PR DESCRIPTION
This PR is base on community feedback from @maxkoshevoi: https://github.com/xamarin/XamarinCommunityToolkit/discussions/709#discussioncomment-270001

### Description of Change ###

Because Xamarin.Forms.Command uses `ChangeCanExecute()`, adding `ChangeCanExecute()` to both `AsyncCommand` and `AsyncValueCommand` enables an easier, more seamless, transition from `Xamarin.Forms.Command` to `Xamarin.CommunityToolkit.ObjectModel.AsyncCommand`.


### API Changes ###

Adds `BaseCommand.ChangeCanExecute()`
- `BaseCommand.ChangeCanExecute()` leverages `BaseCommand.RaiseCanExecuteChanged()`


### Behavioral Changes ###

None, `BaseCommand.ChangeCanExecute()` leverages `BaseCommand.RaiseCanExecuteChanged()`:

```csharp
public void ChangeCanExecute() => RaiseCanExecuteChanged();
```

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [x] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
