### PR TITLE
Fix Android TouchEffect crash

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
@@ -13,6 +13,7 @@ using AndroidOS = Android.OS;
 using System.ComponentModel;
 using Xamarin.CommunityToolkit.Effects;
 using Xamarin.CommunityToolkit.Android.Effects;
+using Android.OS;
 
 [assembly: ExportEffect(typeof(PlatformTouchEffect), nameof(TouchEffect))]
 
@@ -66,30 +67,30 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 				accessibilityManager.AddTouchExplorationStateChangeListener(accessibilityListener);
 			}
 
-			if (effect.NativeAnimation && AndroidOS.Build.VERSION.SdkInt >= AndroidOS.BuildVersionCodes.Lollipop)
-			{
-				View.Clickable = true;
-				View.LongClickable = true;
-				CreateRipple();
+			if (Build.VERSION.SdkInt < BuildVersionCodes.Lollipop || !effect.NativeAnimation)
+				return;
 
-				if (Group != null)
+			View.Clickable = true;
+			View.LongClickable = true;
+			CreateRipple();
+
+			if (Group != null)
+			{
+				rippleView = new FrameLayout(Group.Context)
 				{
-					rippleView = new FrameLayout(Group.Context)
-					{
-						LayoutParameters = new ViewGroup.LayoutParams(-1, -1),
-						Clickable = false,
-						Focusable = false,
-					};
-					View.LayoutChange += OnLayoutChange;
-					rippleView.Background = ripple;
-					Group.AddView(rippleView);
-					rippleView.BringToFront();
-				}
-				else
-				{
-					rippleView = View;
-					rippleView.Foreground = ripple;
-				}
+					LayoutParameters = new ViewGroup.LayoutParams(-1, -1),
+					Clickable = false,
+					Focusable = false,
+				};
+				View.LayoutChange += OnLayoutChange;
+				rippleView.Background = ripple;
+				Group.AddView(rippleView);
+				rippleView.BringToFront();
+			}
+			else if (Build.VERSION.SdkInt >= BuildVersionCodes.M)
+			{
+				rippleView = View;
+				rippleView.Foreground = ripple;
 			}
 		}
 
@@ -359,8 +360,11 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			if (group == null || (Group as IVisualElementRenderer)?.Element == null)
 				return;
 
-			rippleView.Right = group.Width;
-			rippleView.Bottom = group.Height;
+			if (rippleView != null)
+			{
+				rippleView.Right = group.Width;
+				rippleView.Bottom = group.Height;
+			}
 		}
 
 		sealed class AccessibilityListener : Java.Lang.Object,


### PR DESCRIPTION
### Description of Change ###
Prevent TouchEffect crashing on Android when an effect is applied to Image on Android API below 23.

Problem: ```setForeground``` method is available starting API 23.
Solution: just ignore native animation if API is not available.


### Bugs Fixed ###
- Fixes #737

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
