### PR TITLE
Fix culture not persisted to new pages

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizationResourceManagerTests/LocalizationResourceManagerTests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizationResourceManagerTests/LocalizationResourceManagerTests.cs
@@ -30,7 +30,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			var responceIndexerCulture1 = localizationManager[testString];
 			var responceGetValueCulture1 = localizationManager.GetValue(testString);
 			var responceResourceManagerCulture1 = resourceManager.GetString(testString, initialCulture);
-			localizationManager.CurrentCulture = culture2;
+			localizationManager.SetCulture(culture2);
 			var responceIndexerCulture2 = localizationManager[testString];
 			var responceGetValueCulture2 = localizationManager.GetValue(testString);
 			var responceResourceManagerCulture2 = resourceManager.GetString(testString, culture2);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizationResourceManagerTests/LocalizationResourceManagerTests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizationResourceManagerTests/LocalizationResourceManagerTests.cs
@@ -12,8 +12,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 		{
 			resourceManager = new MockResourceManager();
 			localizationManager = new LocalizationResourceManager();
-			localizationManager.Init(resourceManager);
-			localizationManager.SetCulture(initialCulture);
+			localizationManager.Init(resourceManager, initialCulture);
 		}
 
 		readonly LocalizationResourceManager localizationManager;
@@ -31,10 +30,10 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			var responceIndexerCulture1 = localizationManager[testString];
 			var responceGetValueCulture1 = localizationManager.GetValue(testString);
 			var responceResourceManagerCulture1 = resourceManager.GetString(testString, initialCulture);
-			localizationManager.SetCulture(culture2);
+			localizationManager.CurrentCulture = culture2;
 			var responceIndexerCulture2 = localizationManager[testString];
 			var responceGetValueCulture2 = localizationManager.GetValue(testString);
-			var responceResourceManagerCulture2 = resourceManager.GetString(testString, initialCulture);
+			var responceResourceManagerCulture2 = resourceManager.GetString(testString, culture2);
 			resourceManager.GetString(testString, culture2);
 
 			// Assert

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizationResourceManagerTests/LocalizationResourceManagerTests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizationResourceManagerTests/LocalizationResourceManagerTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Globalization;
+using System.Resources;
+using Xamarin.CommunityToolkit.Helpers;
+using Xamarin.CommunityToolkit.UnitTests.Mocks;
+using Xunit;
+
+namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
+{
+	public class LocalizationResourceManagerTests
+	{
+		public LocalizationResourceManagerTests()
+		{
+			resourceManager = new MockResourceManager();
+			localizationManager = new LocalizationResourceManager();
+			localizationManager.Init(resourceManager);
+			localizationManager.SetCulture(initialCulture);
+		}
+
+		readonly LocalizationResourceManager localizationManager;
+		readonly ResourceManager resourceManager;
+		readonly CultureInfo initialCulture = CultureInfo.InvariantCulture;
+
+		[Fact]
+		public void LocalizationResourceManager_GetCulture_Equal_Indexer()
+		{
+			// Arrange
+			var testString = "test";
+			var culture2 = new CultureInfo("en");
+
+			// Act
+			var responceIndexerCulture1 = localizationManager[testString];
+			var responceGetValueCulture1 = localizationManager.GetValue(testString);
+			var responceResourceManagerCulture1 = resourceManager.GetString(testString, initialCulture);
+			localizationManager.SetCulture(culture2);
+			var responceIndexerCulture2 = localizationManager[testString];
+			var responceGetValueCulture2 = localizationManager.GetValue(testString);
+			var responceResourceManagerCulture2 = resourceManager.GetString(testString, initialCulture);
+			resourceManager.GetString(testString, culture2);
+
+			// Assert
+			Assert.Equal(responceResourceManagerCulture1, responceIndexerCulture1);
+			Assert.Equal(responceResourceManagerCulture1, responceGetValueCulture1);
+			Assert.Equal(responceResourceManagerCulture2, responceIndexerCulture2);
+			Assert.Equal(responceResourceManagerCulture2, responceGetValueCulture2);
+		}
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Mocks/MockResourceManager.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Mocks/MockResourceManager.cs
@@ -1,0 +1,10 @@
+﻿using System.Globalization;
+using System.Resources;
+
+namespace Xamarin.CommunityToolkit.UnitTests.Mocks
+{
+	class MockResourceManager : ResourceManager
+	{
+		public override string GetString(string name, CultureInfo culture) => culture.EnglishName;
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/LocalizationResourceManager.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/LocalizationResourceManager.shared.cs
@@ -29,13 +29,12 @@ namespace Xamarin.CommunityToolkit.Helpers
 		public string this[string text] =>
 			GetValue(text);
 
-		[Obsolete("Use " + nameof(CurrentCulture) + " to set culture")]
 		public void SetCulture(CultureInfo language) => CurrentCulture = language;
 
 		public CultureInfo CurrentCulture
 		{
 			get => currentCulture;
-			set
+			private set
 			{
 				currentCulture = value;
 				Invalidate();

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/LocalizationResourceManager.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/LocalizationResourceManager.shared.cs
@@ -20,7 +20,7 @@ namespace Xamarin.CommunityToolkit.Helpers
 		public void Init(ResourceManager resource, CultureInfo initialCulture)
 		{
 			resourceManager = resource;
-			CurrentCulture = initialCulture;
+			currentCulture = initialCulture;
 		}
 
 		public string GetValue(string text) =>
@@ -29,17 +29,13 @@ namespace Xamarin.CommunityToolkit.Helpers
 		public string this[string text] =>
 			GetValue(text);
 
-		public void SetCulture(CultureInfo language) => CurrentCulture = language;
-
-		public CultureInfo CurrentCulture
+		public void SetCulture(CultureInfo language)
 		{
-			get => currentCulture;
-			private set
-			{
-				currentCulture = value;
-				Invalidate();
-			}
+			currentCulture = language;
+			Invalidate();
 		}
+
+		public CultureInfo CurrentCulture => currentCulture;
 
 		public event PropertyChangedEventHandler PropertyChanged;
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/LocalizationResourceManager.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/LocalizationResourceManager.shared.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Globalization;
 using System.Resources;
 using System.Threading;
@@ -11,30 +12,40 @@ namespace Xamarin.CommunityToolkit.Helpers
 		public static LocalizationResourceManager Current { get; } = new LocalizationResourceManager();
 
 		ResourceManager resourceManager;
+		CultureInfo currentCulture = Thread.CurrentThread.CurrentUICulture;
 
-		public void Init(ResourceManager resource)
+		public void Init(ResourceManager resource) =>
+			resourceManager = resource;
+
+		public void Init(ResourceManager resource, CultureInfo initialCulture)
 		{
 			resourceManager = resource;
+			CurrentCulture = initialCulture;
 		}
 
-		public string this[string text] => resourceManager.GetString(text, CurrentCulture);
+		public string GetValue(string text) =>
+			resourceManager.GetString(text, CurrentCulture);
 
-		public void SetCulture(CultureInfo language)
+		public string this[string text] =>
+			GetValue(text);
+
+		[Obsolete("Use " + nameof(CurrentCulture) + " to set culture")]
+		public void SetCulture(CultureInfo language) => CurrentCulture = language;
+
+		public CultureInfo CurrentCulture
 		{
-			Thread.CurrentThread.CurrentUICulture = language;
-			Invalidate();
+			get => currentCulture;
+			set
+			{
+				currentCulture = value;
+				Invalidate();
+			}
 		}
-
-		public string GetValue(string text) => resourceManager.GetString(text, CultureInfo.CurrentCulture);
-
-		public CultureInfo CurrentCulture => Thread.CurrentThread.CurrentUICulture;
 
 		public event PropertyChangedEventHandler PropertyChanged;
 
-		public void Invalidate()
-		{
+		public void Invalidate() =>
 			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(null));
-		}
 	}
 #endif
 }


### PR DESCRIPTION
### Description of Change ###
Turns out `Thread.CurrentThread.CurrentUICulture` is unreliable way to store culture. When new page is created `CurrentUICulture` is reset to default for some reason (even though `ManagedThreadId` is the same).

- Created private field to store culture, so we don't depend on anyone to store it (when resource designer is created by Xamarin it also creates it (see image bellow), so it seems like good approach)
![image](https://user-images.githubusercontent.com/6609929/104227125-93948380-5451-11eb-97fb-04cad83acca2.png)
- Also refactored `LocalizationResourceManager` a bit while I have the opportunity
  - Added second `Init(ResourceManager resource, CultureInfo initialCulture)` so culture can be set right away. 
  - ~~Added setter to `CurrentCulture` and deprecated `SetCulture()`. Culture is handled via properties everywhere (`CultureInfo.CurrentCulture`, `Thread.CurrentThread.CurrentUICulture`, `AppResources.Culture`), so it feels like `LocalizationResourceManager.CurrentCulture` should have setter too.~~

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #745 

### API Changes ###

Added: 
 
- `void Init(ResourceManager resource, CultureInfo initialCulture)`
- Setter for `CurrentCulture`

Changed:

 - `Thread.CurrentThread.CurrentUICulture` => `CultureInfo currentCulture`

### Behavioral Changes ###

- Culture now stored internally instead of using `Thread.CurrentThread.CurrentUICulture` 
- Also `indexer` used `Thread.CurrentThread.CurrentUICulture` while `GetValue` used `CultureInfo.CurrentCulture`. Now they provide the same results.

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [x] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
