### PR TITLE
Remove dependency on Markup from Toolkit

### DIFF
--- a/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
+++ b/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj" />
+    <ProjectReference Include="..\..\src\Markup\Xamarin.CommunityToolkit.Markup\Xamarin.CommunityToolkit.Markup.csproj" />
   </ItemGroup>
 </Project>
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
@@ -202,7 +202,4 @@
     <Compile Remove="build\*.cs" />
     <None Include="build\**\*.cs;build\**\*.targets" Pack="true" PackagePath="build" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\Markup\Xamarin.CommunityToolkit.Markup\Xamarin.CommunityToolkit.Markup.csproj" />
-  </ItemGroup>
 </Project>

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
@@ -57,4 +57,7 @@
     <None Include="..\..\..\LICENSE" PackagePath="" Pack="true" />
     <None Include="..\..\..\assets\XamarinCommunityToolkit_128x128.png" PackagePath="icon.png" Pack="true" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
@@ -57,7 +57,4 @@
     <None Include="..\..\..\LICENSE" PackagePath="" Pack="true" />
     <None Include="..\..\..\assets\XamarinCommunityToolkit_128x128.png" PackagePath="icon.png" Pack="true" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Change ###

Removes the dependency from the Toolkit to the Markup package. There is no dependency between the packages and currently this installs the Markup package as part of the Toolkit which is not strictly needed.

### Behavioral Changes ###

None for existing installs. People can uninstall the Markup package if they're not using it.

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
