### PR TITLE
Alter AsyncCommand parameters to match Command ones, and add CommandHelper (#771)

### DIFF
--- a/samples/XCT.Sample/Pages/AboutPage.xaml
+++ b/samples/XCT.Sample/Pages/AboutPage.xaml
@@ -14,7 +14,11 @@
     <pages:BasePage.BindingContext>
         <viewmodels:AboutViewModel />
     </pages:BasePage.BindingContext>
-    
+
+    <ContentPage.Behaviors>
+        <xct:EventToCommandBehavior EventName="Appearing" Command="{Binding PageAppearingCommand}"/>
+    </ContentPage.Behaviors>
+
     <pages:BasePage.Content>
         <StackLayout Padding="{StaticResource ContentPadding}">
             <Label Text="Thank you Xamarin Community Toolkit contributors"

--- a/samples/XCT.Sample/Pages/AboutPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/AboutPage.xaml.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Linq;
-using Octokit;
-using Xamarin.CommunityToolkit.Sample.ViewModels;
-using Xamarin.Essentials;
-using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Sample.Pages
 {
@@ -11,12 +6,6 @@ namespace Xamarin.CommunityToolkit.Sample.Pages
 	{
 		public AboutPage()
 			=> InitializeComponent();
-
-		protected override async void OnAppearing()
-		{
-			base.OnAppearing();
-			await ((AboutViewModel)BindingContext).OnAppearing();
-		}
 
 		async void OnCloseClicked(object sender, EventArgs e)
 			=> await Navigation.PopModalAsync();

--- a/samples/XCT.Sample/Pages/Base/BasePage.cs
+++ b/samples/XCT.Sample/Pages/Base/BasePage.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Windows.Input;
-using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.CommunityToolkit.Sample.Models;
 using Xamarin.Forms;
 
@@ -8,12 +8,12 @@ namespace Xamarin.CommunityToolkit.Sample.Pages
 {
 	public class BasePage : ContentPage
 	{
-		ICommand navigateCommand;
+		public BasePage() =>
+			NavigateCommand = CommandHelper.Create<SectionModel>(sectionModel => Navigation.PushAsync(PreparePage(sectionModel)));
 
 		public Color DetailColor { get; set; }
 
-		public ICommand NavigateCommand => navigateCommand ??= new AsyncCommand<SectionModel>(sectionModel
-			=> Navigation.PushAsync(PreparePage(sectionModel)));
+		public ICommand NavigateCommand { get; }
 
 		Page PreparePage(SectionModel model)
 		{

--- a/samples/XCT.Sample/Pages/Converters/ByteArrayToImageSourcePage.xaml
+++ b/samples/XCT.Sample/Pages/Converters/ByteArrayToImageSourcePage.xaml
@@ -16,6 +16,10 @@
          </ResourceDictionary>
     </ContentPage.Resources>
 
+    <ContentPage.Behaviors>
+        <xct:EventToCommandBehavior EventName="Appearing" Command="{Binding PageAppearingCommand}"/>
+    </ContentPage.Behaviors>
+
     <pages:BasePage.Content>
 
         <StackLayout Orientation="Vertical" VerticalOptions="Center">

--- a/samples/XCT.Sample/Pages/Converters/ByteArrayToImageSourcePage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/ByteArrayToImageSourcePage.xaml.cs
@@ -1,16 +1,8 @@
-﻿using Xamarin.CommunityToolkit.Sample.ViewModels.Converters;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
 	public partial class ByteArrayToImageSourcePage : BasePage
 	{
 		public ByteArrayToImageSourcePage()
 			=> InitializeComponent();
-
-		protected override async void OnAppearing()
-		{
-			base.OnAppearing();
-			await ((ByteArrayToImageSourceViewModel)BindingContext).OnAppearing();
-		}
 	}
 }

--- a/samples/XCT.Sample/ViewModels/AboutViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/AboutViewModel.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Octokit;
-using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.Essentials;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels
@@ -18,7 +18,18 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 
 		string emptyViewText = "Loading data...";
 
-		ICommand selectedContributorCommand;
+		public AboutViewModel()
+		{
+			PageAppearingCommand = CommandHelper.Create(OnAppearing);
+			SelectedContributorCommand = CommandHelper.Create(async () =>
+			{
+				if (SelectedContributor is null)
+					return;
+
+				await Launcher.OpenAsync(SelectedContributor.HtmlUrl);
+				SelectedContributor = null;
+			});
+		}
 
 		public RepositoryContributor[] Contributors
 		{
@@ -38,14 +49,9 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 			set => SetProperty(ref emptyViewText, value);
 		}
 
-		public ICommand SelectedContributorCommand => selectedContributorCommand ??= new AsyncCommand(async () =>
-		{
-			if (SelectedContributor is null)
-				return;
+		public ICommand PageAppearingCommand { get; }
 
-			await Launcher.OpenAsync(SelectedContributor.HtmlUrl);
-			SelectedContributor = null;
-		});
+		public ICommand SelectedContributorCommand { get; }
 
 		public async Task OnAppearing()
 		{

--- a/samples/XCT.Sample/ViewModels/Base/BaseGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Base/BaseGalleryViewModel.cs
@@ -2,23 +2,24 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
-using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.CommunityToolkit.Sample.Models;
-using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels
 {
 	public abstract class BaseGalleryViewModel : BaseViewModel
 	{
-		ICommand filterCommand;
-
-		public BaseGalleryViewModel() => Filter();
+		public BaseGalleryViewModel()
+		{
+			Filter();
+			FilterCommand = CommandHelper.Create(Filter);
+		}
 
 		public abstract IEnumerable<SectionModel> Items { get; }
 
 		public IEnumerable<SectionModel> FilteredItems { get; private set; }
 
-		public ICommand FilterCommand => filterCommand ??= new Command(Filter);
+		public ICommand FilterCommand { get; }
 
 		public string FilterValue { private get; set; }
 

--- a/samples/XCT.Sample/ViewModels/Behaviors/EventToCommandBehaviorViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Behaviors/EventToCommandBehaviorViewModel.cs
@@ -1,20 +1,21 @@
 ﻿using System.Windows.Input;
-using Xamarin.Forms;
+using Xamarin.CommunityToolkit.Helpers;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 {
 	public class EventToCommandBehaviorViewModel : BaseViewModel
 	{
-		ICommand incrementCommand;
-
 		int clickCount;
 
-		public ICommand IncrementCommand => incrementCommand ??= new Command(() => ClickCount++);
+		public EventToCommandBehaviorViewModel() =>
+			IncrementCommand = CommandHelper.Create(() => ClickCount++);
 
 		public int ClickCount
 		{
 			get => clickCount;
 			set => SetProperty(ref clickCount, value);
 		}
+
+		public ICommand IncrementCommand { get; }
 	}
 }

--- a/samples/XCT.Sample/ViewModels/Behaviors/MaxLengthReachedBehaviorViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Behaviors/MaxLengthReachedBehaviorViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Windows.Input;
-using Xamarin.Forms;
+using Xamarin.CommunityToolkit.Helpers;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 {
@@ -17,7 +17,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 		public ICommand MaxLengthReachedCommand { get; }
 
 		public MaxLengthReachedBehaviorViewModel()
-			=> MaxLengthReachedCommand = new Command<string>(OnCommandExecuted);
+			=> MaxLengthReachedCommand = CommandHelper.Create<string>(OnCommandExecuted);
 
 		void OnCommandExecuted(string text)
 			=> CommandExecutions += string.Format("MaxLength reached with value: '{0}'.", text) + Environment.NewLine;

--- a/samples/XCT.Sample/ViewModels/Behaviors/UserStoppedTypingBehaviorViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Behaviors/UserStoppedTypingBehaviorViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Windows.Input;
-using Xamarin.Forms;
+using Xamarin.CommunityToolkit.Helpers;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 {
@@ -21,7 +21,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 		#endregion Properties
 
 		public UserStoppedTypingBehaviorViewModel()
-			=> SearchCommand = new Command<string>(PerformSearch);
+			=> SearchCommand = CommandHelper.Create<string>(PerformSearch);
 
 		void PerformSearch(string searchTerms)
 			=> PerformedSearches += string.Format("Performed search for '{0}'.", searchTerms) + Environment.NewLine;

--- a/samples/XCT.Sample/ViewModels/Converters/ByteArrayToImageSourceViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Converters/ByteArrayToImageSourceViewModel.cs
@@ -1,7 +1,9 @@
 ﻿using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using Octokit;
+using Xamarin.CommunityToolkit.Helpers;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 {
@@ -24,6 +26,11 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 			get => isBusy;
 			set => SetProperty(ref isBusy, value);
 		}
+
+		public ICommand PageAppearingCommand { get; }
+
+		public ByteArrayToImageSourceViewModel() =>
+			PageAppearingCommand = CommandHelper.Create(OnAppearing);
 
 		public async Task OnAppearing()
 		{

--- a/samples/XCT.Sample/ViewModels/Converters/ItemSelectedEventArgsViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Converters/ItemSelectedEventArgsViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Windows.Input;
-using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
@@ -15,7 +15,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 				new Person() { Id = 3, Name = "Person 3" }
 			};
 
-		public ICommand ItemSelectedCommand { get; private set; } = new AsyncCommand<Person>(person
-			=> Application.Current.MainPage.DisplayAlert("Item Tapped: ", person.Name, "Cancelf"));
+		public ICommand ItemSelectedCommand { get; } =
+			CommandHelper.Create<Person>(person => Application.Current.MainPage.DisplayAlert("Item Tapped: ", person.Name, "Cancelf"));
 	}
 }

--- a/samples/XCT.Sample/ViewModels/Converters/ItemTappedEventArgsViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Converters/ItemTappedEventArgsViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Windows.Input;
-using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
@@ -15,8 +15,8 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 				new Person() { Id = 3, Name = "Person 3" }
 			};
 
-		public ICommand ItemTappedCommand { get; private set; } = new AsyncCommand<Person>(person
-			=> Application.Current.MainPage.DisplayAlert("Item Tapped: ", person.Name, "Cancel"));
+		public ICommand ItemTappedCommand { get; } =
+			CommandHelper.Create<Person>(person => Application.Current.MainPage.DisplayAlert("Item Tapped: ", person.Name, "Cancel"));
 	}
 
 	public class Person

--- a/samples/XCT.Sample/ViewModels/Markup/SearchViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Markup/SearchViewModel.cs
@@ -6,88 +6,94 @@ using Xamarin.Essentials;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Markup
 {
-    public class SearchViewModel : BaseViewModel
-    {
-        ICommand backCommand, likeCommand, openTwitterSearchCommand, openHelpCommand;
+	public class SearchViewModel : BaseViewModel
+	{
+		public string SearchText { get; set; }
 
-        public string SearchText { get; set; }
+		public List<Tweet> SearchResults { get; set; }
 
-        public List<Tweet> SearchResults { get; set; }
+		public SearchViewModel()
+		{
+			SearchText = "#CSharpForMarkup";
 
-        public SearchViewModel()
-        {
-            SearchText = "#CSharpForMarkup";
+			SearchResults = new List<Tweet>
+			{
+				new Tweet
+				{
+					AuthorImage = "https://pbs.twimg.com/profile_images/1267649264391503873/I6w-glU8_400x400.jpg",
+					Header = "David Ortinau @davidortinau · 25/01/2020",
+					Body = new List<TextFragment>
+					{
+						new TextFragment { Text = "would it surprise you to know that the last project I personally shipped was Xamarin.Forms, C# w/ " },
+						new TextFragment { Text = "#CSharpForMarkup", IsMatch = true },
+						new TextFragment { Text = ", & @ReactiveXUI?" }
+					},
+				},
+				new Tweet
+				{
+					AuthorImage = "https://pbs.twimg.com/profile_images/2159034926/MACAW_vincenth_LThumb_400x400.jpg",
+					Header = "VincentH.NET @vincenth_net · 26/03/2020",
+					Body = new List<TextFragment>
+					{
+						new TextFragment { Text = "Had an inspiring call with @matthewrdev about supporting #XamarinForms C# Markup in @mfractor\uD83D\uDE0E\n\nSo many great ideas. Autoformat, Convert XAML to C# Markup (all examples on internet!), auto split UI logic and markup...\n\nExcited " },
+						new TextFragment { Text = "#CSharpForMarkup", IsMatch = true },
+						new TextFragment { Text = "\uD83D\uDD25" }
+					},
+				},
+				new Tweet
+				{
+					AuthorImage = "https://pbs.twimg.com/profile_images/1175428143944847361/0kfeW53l_400x400.jpg",
+					Header = "RK @rkonit · 05/02/2020",
+					Body = new List<TextFragment>
+					{
+						new TextFragment { Text = "\"Never Say Never\" in Open-source space. It's happening and reminds me early days of winforms.\n\n" },
+						new TextFragment { Text = "#CSharpForMarkup", IsMatch = true },
+						new TextFragment { Text = " #Xamarin #XamarinForms" }
+					},
+				}
+			};
 
-            SearchResults = new List<Tweet>
-            {
-                new Tweet
-                {
-                    AuthorImage = "https://pbs.twimg.com/profile_images/1267649264391503873/I6w-glU8_400x400.jpg",
-                    Header = "David Ortinau @davidortinau · 25/01/2020",
-                    Body = new List<TextFragment>
-                    {
-                        new TextFragment { Text = "would it surprise you to know that the last project I personally shipped was Xamarin.Forms, C# w/ " },
-                        new TextFragment { Text = "#CSharpForMarkup", IsMatch = true },
-                        new TextFragment { Text = ", & @ReactiveXUI?" }
-                    },
-                },
-                new Tweet
-                {
-                    AuthorImage = "https://pbs.twimg.com/profile_images/2159034926/MACAW_vincenth_LThumb_400x400.jpg",
-                    Header = "VincentH.NET @vincenth_net · 26/03/2020",
-                    Body = new List<TextFragment>
-                    {
-                        new TextFragment { Text = "Had an inspiring call with @matthewrdev about supporting #XamarinForms C# Markup in @mfractor\uD83D\uDE0E\n\nSo many great ideas. Autoformat, Convert XAML to C# Markup (all examples on internet!), auto split UI logic and markup...\n\nExcited " },
-                        new TextFragment { Text = "#CSharpForMarkup", IsMatch = true },
-                        new TextFragment { Text = "\uD83D\uDD25" }
-                    },
-                },
-                new Tweet
-                {
-                    AuthorImage = "https://pbs.twimg.com/profile_images/1175428143944847361/0kfeW53l_400x400.jpg",
-                    Header = "RK @rkonit · 05/02/2020",
-                    Body = new List<TextFragment>
-                    {
-                        new TextFragment { Text = "\"Never Say Never\" in Open-source space. It's happening and reminds me early days of winforms.\n\n" },
-                        new TextFragment { Text = "#CSharpForMarkup", IsMatch = true },
-                        new TextFragment { Text = " #Xamarin #XamarinForms" }
-                    },
-                }
-            };
-        }
+			BackCommand = new RelayCommand(Back);
+			LikeCommand = new RelayCommand<Tweet>(Like);
+			OpenTwitterSearchCommand = new RelayCommandAsync(OpenTwitterSearch);
+			OpenHelpCommand = new RelayCommandAsync(OpenHelp);
 
-        public ICommand BackCommand => backCommand ??= new RelayCommand(Back);
+		}
 
-        public ICommand LikeCommand => likeCommand ??= new RelayCommand<Tweet>(Like);
+		public ICommand BackCommand { get; }
 
-        public ICommand OpenTwitterSearchCommand => openTwitterSearchCommand ??= new RelayCommandAsync(OpenTwitterSearch);
+		public ICommand LikeCommand { get; }
 
-        public ICommand OpenHelpCommand => openHelpCommand ??= new RelayCommandAsync(OpenHelp);
+		public ICommand OpenTwitterSearchCommand { get; }
 
-        void Back() { }
+		public ICommand OpenHelpCommand { get; }
 
-        void Like(Tweet tweet) => tweet.IsLikedByMe = !tweet.IsLikedByMe;
+		void Back()
+		{
+		}
 
-        Task OpenHelp() => Launcher.OpenAsync(new Uri("https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/markup.md"));
+		void Like(Tweet tweet) => tweet.IsLikedByMe = !tweet.IsLikedByMe;
 
-        Task OpenTwitterSearch() => Launcher.OpenAsync(new Uri("https://twitter.com/search?q=%23CSharpForMarkup"));
+		Task OpenHelp() => Launcher.OpenAsync(new Uri("https://github.com/MicrosoftDocs/xamarin-communitytoolkit/blob/master/docs/markup.md"));
 
-        public class Tweet : BaseViewModel
-        {
-            public string AuthorImage { get; set; }
+		Task OpenTwitterSearch() => Launcher.OpenAsync(new Uri("https://twitter.com/search?q=%23CSharpForMarkup"));
 
-            public string Header { get; set; }
+		public class Tweet : BaseViewModel
+		{
+			public string AuthorImage { get; set; }
 
-            public List<TextFragment> Body { get; set; }
+			public string Header { get; set; }
 
-            public bool IsLikedByMe { get; set; }
-        }
+			public List<TextFragment> Body { get; set; }
 
-        public class TextFragment
-        {
-            public string Text { get; set; }
+			public bool IsLikedByMe { get; set; }
+		}
 
-            public bool IsMatch { get; set; }
-        }
-    }
+		public class TextFragment
+		{
+			public string Text { get; set; }
+
+			public bool IsMatch { get; set; }
+		}
+	}
 }

--- a/samples/XCT.Sample/ViewModels/SettingViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/SettingViewModel.cs
@@ -5,14 +5,11 @@ using System.Windows.Input;
 using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.CommunityToolkit.Sample.Models;
 using Xamarin.CommunityToolkit.Sample.Resx;
-using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels
 {
 	public class SettingViewModel : BaseViewModel
 	{
-		public SettingViewModel() => LoadLanguages();
-
 		IList<Language> supportedLanguages;
 
 		public IList<Language> SupportedLanguages
@@ -29,13 +26,18 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 			set => SetProperty(ref selectedLanguage, value);
 		}
 
-		ICommand changeLanguageCommand;
+		public ICommand ChangeLanguageCommand { get; }
 
-		public ICommand ChangeLanguageCommand => changeLanguageCommand ??= new Command(() =>
+		public SettingViewModel()
 		{
-			LocalizationResourceManager.Current.SetCulture(CultureInfo.GetCultureInfo(SelectedLanguage.CI));
 			LoadLanguages();
-		});
+
+			ChangeLanguageCommand = CommandHelper.Create(() =>
+			{
+				LocalizationResourceManager.Current.SetCulture(CultureInfo.GetCultureInfo(SelectedLanguage.CI));
+				LoadLanguages();
+			});
+		}
 
 		void LoadLanguages()
 		{

--- a/samples/XCT.Sample/ViewModels/Views/BadgeViewViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/BadgeViewViewModel.cs
@@ -1,5 +1,5 @@
 ﻿using System.Windows.Input;
-using Xamarin.Forms;
+using Xamarin.CommunityToolkit.Helpers;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 {
@@ -7,12 +7,17 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 	{
 		int counter;
 
-		public BadgeViewViewModel() => Counter = 3;
+		public BadgeViewViewModel()
+		{
+			Counter = 3;
+
+			IncreaseCommand = CommandHelper.Create(Increase);
+			DecreaseCommand = CommandHelper.Create(Decrease);
+		}
 
 		public int Counter
 		{
 			get => counter;
-
 			set
 			{
 				counter = value;
@@ -20,9 +25,9 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 			}
 		}
 
-		public ICommand IncreaseCommand => new Command(Increase);
+		public ICommand IncreaseCommand { get; }
 
-		public ICommand DecreaseCommand => new Command(Decrease);
+		public ICommand DecreaseCommand { get; }
 
 		void Increase() => Counter++;
 

--- a/samples/XCT.Sample/ViewModels/Views/ExpanderViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/ExpanderViewModel.cs
@@ -1,21 +1,23 @@
 ﻿using System.Windows.Input;
-using Xamarin.Forms;
+using Xamarin.CommunityToolkit.Helpers;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 {
 	public partial class ExpanderViewModel : BaseViewModel
 	{
-		ICommand command;
-
-		public ICommand Command => command ??= new Command(p =>
+		public ExpanderViewModel()
 		{
-			var sender = (Item)p;
-			if (!sender.IsExpanded)
-				return;
+			Command = CommandHelper.Create<Item>(sender =>
+			{
+				if (!sender.IsExpanded)
+					return;
 
-			foreach (var item in Items)
-				item.IsExpanded = sender == item;
-		});
+				foreach (var item in Items)
+					item.IsExpanded = sender == item;
+			});
+		}
+
+		public ICommand Command { get; }
 
 		public Item[] Items { get; } = new Item[]
 		{

--- a/samples/XCT.Sample/ViewModels/Views/GravatarImageViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/GravatarImageViewModel.cs
@@ -1,4 +1,6 @@
-﻿using Xamarin.CommunityToolkit.UI.Views;
+﻿using System;
+using System.Linq;
+using Xamarin.CommunityToolkit.UI.Views;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 {
@@ -9,17 +11,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 		int size = 50;
 		DefaultGravatar defaultGravatar = DefaultGravatar.MysteryPerson;
 
-		public DefaultGravatar[] Defaults { get; } = new[]
-		{
-			DefaultGravatar.Blank,
-			DefaultGravatar.FileNotFound,
-			DefaultGravatar.Identicon,
-			DefaultGravatar.MonsterId,
-			DefaultGravatar.MysteryPerson,
-			DefaultGravatar.Retro,
-			DefaultGravatar.Robohash,
-			DefaultGravatar.Wavatar
-		};
+		public DefaultGravatar[] Defaults { get; } = Enum.GetValues(typeof(DefaultGravatar)).Cast<DefaultGravatar>().ToArray();
 
 		public bool EnableCache
 		{

--- a/samples/XCT.Sample/ViewModels/Views/StateLayoutViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/StateLayoutViewModel.cs
@@ -1,14 +1,12 @@
 ﻿using System.Threading.Tasks;
 using System.Windows.Input;
+using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.CommunityToolkit.UI.Views;
-using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 {
 	public class StateLayoutViewModel : BaseViewModel
 	{
-		ICommand fullscreenLoadingCommand;
-		ICommand cycleStatesCommand;
 		string customState;
 		LayoutState currentState;
 		LayoutState mainState;
@@ -31,28 +29,19 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 			set => SetProperty(ref customState, value);
 		}
 
-		public ICommand FullscreenLoadingCommand
-		{
-			get => fullscreenLoadingCommand;
-			set => SetProperty(ref fullscreenLoadingCommand, value);
-		}
+		public ICommand FullscreenLoadingCommand { get; }
 
-		public ICommand CycleStatesCommand
-		{
-			get => cycleStatesCommand;
-			set => SetProperty(ref cycleStatesCommand, value);
-		}
+		public ICommand CycleStatesCommand { get; }
 
 		public StateLayoutViewModel()
 		{
-			FullscreenLoadingCommand = new Command(async (x) =>
+			FullscreenLoadingCommand = CommandHelper.Create(async () =>
 			{
 				MainState = LayoutState.Loading;
 				await Task.Delay(2000);
 				MainState = LayoutState.None;
 			});
-
-			CycleStatesCommand = new Command(async (x) => await CycleStates());
+			CycleStatesCommand = CommandHelper.Create(CycleStates);
 		}
 
 		async Task CycleStates()

--- a/samples/XCT.Sample/ViewModels/Views/TabItemsSourceViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/TabItemsSourceViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.Windows.Input;
+using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
@@ -19,13 +20,16 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 		public TabItemsSourceViewModel()
 		{
 			LoadMonkeys();
+
+			ClearDataCommand = CommandHelper.Create(ClearData);
+			UpdateDataCommand = CommandHelper.Create(UpdateData);
 		}
 
 		public ObservableCollection<Monkey> Monkeys { get; set; }
 
-		public ICommand ClearDataCommand => new Command(ClearData);
+		public ICommand ClearDataCommand { get; }
 
-		public ICommand UpdateDataCommand => new Command(UpdateData);
+		public ICommand UpdateDataCommand { get; }
 
 		void LoadMonkeys()
 		{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/DateTimeOffsetConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/DateTimeOffsetConverter_Tests.cs
@@ -19,23 +19,23 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 		public static IEnumerable<object[]> GetData() =>
 			new List<object[]>
 			{
-				new object[] { testDateTimeNow, testDateTimeNow },
-				new object[] { DateTimeOffset.MinValue, DateTime.MinValue },
-				new object[] { DateTimeOffset.MaxValue, DateTime.MaxValue },
-				new object[] { testDateTimeOffsetLocal, testDateTimeLocal },
+				new object[] { testDateTimeNow, testDateTimeNow},
+				new object[] { DateTimeOffset.MinValue, DateTime.MinValue},
+				new object[] { DateTimeOffset.MaxValue, DateTime.MaxValue},
+				new object[] {  testDateTimeOffsetLocal, testDateTimeLocal },
 				new object[] { testDateTimeOffsetUtc, testDateTimeUtc },
-				new object[] { testDateTimeOffsetUtc, testDateTimeUnspecified },
+				new object[] { testDateTimeOffsetUtc, testDateTimeUnspecified},
 			};
 
 		public static IEnumerable<object[]> GetDataReverse() =>
 			new List<object[]>
 			{
-				new object[] { testDateTimeNow, testDateTimeNow },
-				new object[] { DateTime.MinValue, DateTimeOffset.MinValue },
-				new object[] { DateTime.MaxValue, DateTimeOffset.MaxValue },
+				new object[] { testDateTimeNow, testDateTimeNow},
+				new object[] { DateTime.MinValue, DateTimeOffset.MinValue},
+				new object[] { DateTime.MaxValue, DateTimeOffset.MaxValue},
 				new object[] { testDateTimeLocal, testDateTimeOffsetLocal },
-				new object[] { testDateTimeUtc, testDateTimeOffsetUtc },
-				new object[] { testDateTimeUnspecified, testDateTimeOffsetUtc },
+				new object[] { testDateTimeUtc, testDateTimeOffsetUtc},
+				new object[] { testDateTimeUnspecified, testDateTimeOffsetUtc},
 			};
 
 		[Theory]

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/DateTimeOffsetConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/DateTimeOffsetConverter_Tests.cs
@@ -19,23 +19,23 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 		public static IEnumerable<object[]> GetData() =>
 			new List<object[]>
 			{
-				new object[] { testDateTimeNow, testDateTimeNow},
-				new object[] { DateTimeOffset.MinValue, DateTime.MinValue},
-				new object[] { DateTimeOffset.MaxValue, DateTime.MaxValue},
-				new object[] {  testDateTimeOffsetLocal, testDateTimeLocal },
+				new object[] { testDateTimeNow, testDateTimeNow },
+				new object[] { DateTimeOffset.MinValue, DateTime.MinValue },
+				new object[] { DateTimeOffset.MaxValue, DateTime.MaxValue },
+				new object[] { testDateTimeOffsetLocal, testDateTimeLocal },
 				new object[] { testDateTimeOffsetUtc, testDateTimeUtc },
-				new object[] { testDateTimeOffsetUtc, testDateTimeUnspecified},
+				new object[] { testDateTimeOffsetUtc, testDateTimeUnspecified },
 			};
 
 		public static IEnumerable<object[]> GetDataReverse() =>
 			new List<object[]>
 			{
-				new object[] { testDateTimeNow, testDateTimeNow},
-				new object[] { DateTime.MinValue, DateTimeOffset.MinValue},
-				new object[] { DateTime.MaxValue, DateTimeOffset.MaxValue},
+				new object[] { testDateTimeNow, testDateTimeNow },
+				new object[] { DateTime.MinValue, DateTimeOffset.MinValue },
+				new object[] { DateTime.MaxValue, DateTimeOffset.MaxValue },
 				new object[] { testDateTimeLocal, testDateTimeOffsetLocal },
-				new object[] { testDateTimeUtc, testDateTimeOffsetUtc},
-				new object[] { testDateTimeUnspecified, testDateTimeOffsetUtc},
+				new object[] { testDateTimeUtc, testDateTimeOffsetUtc },
+				new object[] { testDateTimeUnspecified, testDateTimeOffsetUtc },
 			};
 
 		[Theory]

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/AsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/AsyncCommand_Tests.cs
@@ -60,7 +60,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 
 			// Assert
 
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(default));
 		}
 
 		[Fact]
@@ -72,7 +72,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			// Act
 
 			// Assert
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(default));
 		}
 
 		[Fact]
@@ -84,7 +84,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			// Act
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(default));
 		}
 
 		[Fact]
@@ -96,7 +96,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			// Act
 
 			// Assert
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(default));
 		}
 
 		[Fact]
@@ -109,15 +109,15 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			var command = new AsyncCommand(NoParameterTask, commandCanExecute);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			bool commandCanExecute(object parameter) => canCommandExecute;
+			bool commandCanExecute() => canCommandExecute;
 
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(default));
 
 			// Act
 			canCommandExecute = true;
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(default));
 			Assert.False(didCanExecuteChangeFire);
 
 			// Act
@@ -125,7 +125,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 
 			// Assert
 			Assert.True(didCanExecuteChangeFire);
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(default));
 
 			void handleCanExecuteChanged(object sender, EventArgs e) => didCanExecuteChangeFire = true;
 		}
@@ -146,13 +146,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 
 			// Assert
 			Assert.True(command.IsExecuting);
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(default));
 
 			// Act
 			await asyncCommandTask;
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(default));
 			Assert.Equal(0, canExecuteChangedCount);
 
 			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
@@ -174,13 +174,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 
 			// Assert
 			Assert.True(command.IsExecuting);
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(default));
 
 			// Act
 			await asyncCommandTask;
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(default));
 			Assert.Equal(2, canExecuteChangedCount);
 
 			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/IAsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/IAsyncCommand_Tests.cs
@@ -82,7 +82,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			// Act
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(0));
 			Assert.True(command2.CanExecute(true));
 		}
 
@@ -96,7 +96,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			// Act
 
 			// Assert
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(0));
 			Assert.False(command2.CanExecute("Hello World"));
 		}
 
@@ -140,13 +140,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 
 			// Assert
 			Assert.True(command.IsExecuting);
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(0));
 
 			// Act
 			await asyncCommandTask;
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(0));
 			Assert.Equal(0, canExecuteChangedCount);
 
 			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
@@ -168,13 +168,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 
 			// Assert
 			Assert.True(command.IsExecuting);
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(0));
 
 			// Act
 			await asyncCommandTask;
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(0));
 			Assert.Equal(2, canExecuteChangedCount);
 
 			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/ICommand_AsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/ICommand_AsyncCommand_Tests.cs
@@ -100,7 +100,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			// Act
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(0));
 		}
 
 		[Fact]
@@ -112,7 +112,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			// Act
 
 			// Assert
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(0));
 		}
 
 		[Fact]
@@ -131,7 +131,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 		public void ICommand_Parameter_CanExecuteDynamic_Test()
 		{
 			// Arrange
-			ICommand command = new AsyncCommand<int>(IntParameterTask, CanExecuteDynamic);
+			ICommand command = new AsyncCommand<int, object>(IntParameterTask, CanExecuteDynamic);
 
 			// Act
 
@@ -144,7 +144,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 		public void ICommand_Parameter_CanExecuteChanged_Test()
 		{
 			// Arrange
-			ICommand command = new AsyncCommand<int>(IntParameterTask, CanExecuteDynamic);
+			ICommand command = new AsyncCommand<int, object>(IntParameterTask, CanExecuteDynamic);
 
 			// Act
 
@@ -167,14 +167,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			command.Execute(Delay);
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(0));
 
 			// Act
 			await IntParameterTask(Delay);
 			await IntParameterTask(Delay);
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(0));
 			Assert.Equal(0, canExecuteChangedCount);
 
 			command.CanExecuteChanged += handleCanExecuteChanged;
@@ -193,14 +193,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			command.Execute(Delay);
 
 			// Assert
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(0));
 
 			// Act
 			await IntParameterTask(Delay);
 			await IntParameterTask(Delay);
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(0));
 			Assert.Equal(2, canExecuteChangedCount);
 
 			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/AsyncValueCommand_Tests.cs
@@ -76,7 +76,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 
 			// Assert
 
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(default));
 			Assert.True(command2.CanExecute(true));
 		}
 
@@ -90,7 +90,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			// Act
 
 			// Assert
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(default));
 			Assert.False(command2.CanExecute("Hello World"));
 		}
 
@@ -128,7 +128,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			var command = new AsyncValueCommand(NoParameterTask, commandCanExecute);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			bool commandCanExecute(object parameter) => canCommandExecute;
+			bool commandCanExecute() => canCommandExecute;
 
 			Assert.False(command.CanExecute(null));
 
@@ -167,13 +167,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 
 			// Assert
 			Assert.True(command.IsExecuting);
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(default));
 
 			// Act
 			await asyncCommandTask;
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(default));
 			Assert.Equal(0, canExecuteChangedCount);
 		}
 
@@ -195,13 +195,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 
 			// Assert
 			Assert.True(command.IsExecuting);
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(default));
 
 			// Act
 			await asyncCommandTask;
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(default));
 			Assert.Equal(2, canExecuteChangedCount);
 		}
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/IAsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/IAsyncValueCommand_Tests.cs
@@ -97,8 +97,8 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			// Act
 
 			// Assert
-			Assert.True(command.CanExecute(null));
-			Assert.True(command.CanExecute("Hello World"));
+			Assert.True(command.CanExecute(0));
+			Assert.True(command2.CanExecute("Hello World"));
 		}
 
 		[Fact]
@@ -111,7 +111,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			// Act
 
 			// Assert
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(0));
 			Assert.False(command2.CanExecute(true));
 		}
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/ICommand_AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/ICommand_AsyncValueCommand_Tests.cs
@@ -126,7 +126,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			// Act
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(0));
 		}
 
 		[Fact]
@@ -138,7 +138,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			// Act
 
 			// Assert
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(0));
 		}
 
 		[Fact]
@@ -157,7 +157,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public void ICommand_Parameter_CanExecuteDynamic_Test()
 		{
 			// Arrange
-			ICommand command = new AsyncValueCommand<int>(IntParameterTask, CanExecuteDynamic);
+			ICommand command = new AsyncValueCommand<int, object>(IntParameterTask, CanExecuteDynamic);
 
 			// Act
 
@@ -170,7 +170,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public void ICommand_Parameter_CanExecuteChanged_Test()
 		{
 			// Arrange
-			ICommand command = new AsyncValueCommand<int>(IntParameterTask, CanExecuteDynamic);
+			ICommand command = new AsyncValueCommand<int, object>(IntParameterTask, CanExecuteDynamic);
 
 			// Act
 
@@ -194,13 +194,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			command.Execute(Delay);
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(0));
 
 			// Act
 			await IntParameterTask(Delay);
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(0));
 			Assert.Equal(0, canExecuteChangedCount);
 		}
 
@@ -219,14 +219,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			command.Execute(Delay);
 
 			// Assert
-			Assert.False(command.CanExecute(null));
+			Assert.False(command.CanExecute(0));
 
 			// Act
 			await IntParameterTask(Delay);
 			await IntParameterTask(Delay);
 
 			// Assert
-			Assert.True(command.CanExecute(null));
+			Assert.True(command.CanExecute(0));
 			Assert.Equal(2, canExecuteChangedCount);
 		}
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/BaseCommandTests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/BaseCommandTests.cs
@@ -33,11 +33,19 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests
 			throw new NullReferenceException();
 		}
 
+		protected bool CanExecuteTrue() => true;
+
+		protected bool CanExecuteTrue(int parameter) => true;
+
 		protected bool CanExecuteTrue(bool parameter) => true;
 
 		protected bool CanExecuteTrue(string parameter) => true;
 
 		protected bool CanExecuteTrue(object parameter) => true;
+
+		protected bool CanExecuteFalse() => false;
+
+		protected bool CanExecuteFalse(int parameter) => false;
 
 		protected bool CanExecuteFalse(bool parameter) => false;
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/TextCaseConverter.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/TextCaseConverter.shared.cs
@@ -37,7 +37,7 @@ namespace Xamarin.CommunityToolkit.Converters
 			{
 				TextCaseType.Lower => value?.ToLowerInvariant(),
 				TextCaseType.Upper => value?.ToUpperInvariant(),
-				TextCaseType.FirstUpperRestLower => !string.IsNullOrWhiteSpace(value) 
+				TextCaseType.FirstUpperRestLower => !string.IsNullOrWhiteSpace(value)
 					? value.Substring(0, 1).ToUpperInvariant() + value.Substring(1).ToLowerInvariant()
 					: value,
 				_ => value

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/CommandHelper.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/CommandHelper.shared.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xamarin.Forms;
+
+namespace Xamarin.CommunityToolkit.Helpers
+{
+	public static class CommandHelper
+	{
+		public static IAsyncCommand Create(
+			Func<Task> action,
+			Func<bool> canExecute = null,
+			Action<Exception> onException = null,
+			bool continueOnCapturedContext = false,
+			bool allowsMultipleExecutions = true) =>
+			new AsyncCommand(action, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+
+		public static IAsyncCommand<TExecute> Create<TExecute>(
+			Func<TExecute, Task> action,
+			Func<bool> canExecute,
+			Action<Exception> onException = null,
+			bool continueOnCapturedContext = false,
+			bool allowsMultipleExecutions = true) =>
+			Create<TExecute>(action, ConvertCanExecute<TExecute>(canExecute), onException, continueOnCapturedContext, allowsMultipleExecutions);
+
+		public static IAsyncCommand<TCanExecute> Create<TCanExecute>(
+			Func<Task> action,
+			Func<TCanExecute, bool> canExecute,
+			Action<Exception> onException = null,
+			bool continueOnCapturedContext = false,
+			bool allowsMultipleExecutions = true) =>
+			Create<TCanExecute>(ConvertExecute<TCanExecute>(action), canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+
+		public static IAsyncCommand<T> Create<T>(
+			Func<T, Task> action,
+			Func<T, bool> canExecute = null,
+			Action<Exception> onException = null,
+			bool continueOnCapturedContext = false,
+			bool allowsMultipleExecutions = true) =>
+			Create<T, T>(action, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+
+		public static IAsyncCommand<TExecute, TCanExecute> Create<TExecute, TCanExecute>(
+			Func<TExecute, Task> action,
+			Func<TCanExecute, bool> canExecute = null,
+			Action<Exception> onException = null,
+			bool continueOnCapturedContext = false,
+			bool allowsMultipleExecutions = true) =>
+			new AsyncCommand<TExecute, TCanExecute>(action, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+
+		public static Command Create(Action action) =>
+			new Command(action);
+
+		public static Command Create(Action action, Func<bool> canExecute) =>
+			new Command(action, canExecute);
+
+		public static Command<T> Create<T>(Action<T> action) =>
+			new Command<T>(action);
+
+		public static Command<T> Create<T>(Action<T> action, Func<T, bool> canExecute) =>
+			new Command<T>(action, canExecute);
+
+		static Func<T, Task> ConvertExecute<T>(Func<Task> execute)
+		{
+			if (execute == null)
+				return null;
+
+			return _ => execute();
+		}
+
+		static Func<T, bool> ConvertCanExecute<T>(Func<bool> canExecute)
+		{
+			if (canExecute == null)
+				return null;
+
+			return _ => canExecute();
+		}
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/AsyncCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/AsyncCommand.shared.cs
@@ -37,7 +37,7 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 	/// <summary>
 	/// An implementation of IAsyncCommand. Allows Commands to safely be used asynchronously with Task.
 	/// </summary>
-	public class AsyncCommand<T> : BaseAsyncCommand<T, object>, IAsyncCommand<T>
+	public class AsyncCommand<T> : BaseAsyncCommand<T, T>, IAsyncCommand<T>
 	{
 		/// <summary>
 		/// Initializes a new instance of AsyncCommand
@@ -48,7 +48,7 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		public AsyncCommand(
 			Func<T, Task> execute,
-			Func<object, bool> canExecute = null,
+			Func<T, bool> canExecute = null,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true)
@@ -77,11 +77,11 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		public AsyncCommand(
 			Func<Task> execute,
-			Func<object, bool> canExecute = null,
+			Func<bool> canExecute = null,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true)
-			: base(ConvertExecute(execute), canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions)
+			: base(ConvertExecute(execute), ConvertCanExecute(canExecute), onException, continueOnCapturedContext, allowsMultipleExecutions)
 		{
 		}
 
@@ -97,6 +97,14 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 				return null;
 
 			return _ => execute();
+		}
+
+		static Func<object, bool> ConvertCanExecute(Func<bool> canExecute)
+		{
+			if (canExecute == null)
+				return null;
+
+			return _ => canExecute();
 		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/AsyncValueCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/AsyncValueCommand.shared.cs
@@ -34,7 +34,7 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 	/// <summary>
 	/// An implementation of IAsyncValueCommand. Allows Commands to safely be used asynchronously with Task.
 	/// </summary>
-	public class AsyncValueCommand<T> : BaseAsyncValueCommand<T, object>, IAsyncValueCommand<T>
+	public class AsyncValueCommand<T> : BaseAsyncValueCommand<T, T>, IAsyncValueCommand<T>
 	{
 		/// <summary>
 		/// Initializes a new instance of AsyncValueCommand
@@ -45,7 +45,7 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		public AsyncValueCommand(
 			Func<T, ValueTask> execute,
-			Func<object, bool> canExecute = null,
+			Func<T, bool> canExecute = null,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true)
@@ -74,11 +74,11 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		public AsyncValueCommand(
 			Func<ValueTask> execute,
-			Func<object, bool> canExecute = null,
+			Func<bool> canExecute = null,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true)
-			: base(ConvertExecute(execute), canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions)
+			: base(ConvertExecute(execute), ConvertCanExecute(canExecute), onException, continueOnCapturedContext, allowsMultipleExecutions)
 		{
 		}
 
@@ -94,6 +94,14 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 				return null;
 
 			return _ => execute();
+		}
+
+		static Func<object, bool> ConvertCanExecute(Func<bool> canExecute)
+		{
+			if (canExecute == null)
+				return null;
+
+			return _ => canExecute();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

- Updated `AsyncCommand` constructor parameters so they are consistent with `Command`s ones.
- Created `CommandHelper` helper class with `Create` method that can create both types of command based on provided parameters.
- Updated sample app to use `CommandHelper`
- Updated sample app to use `xct:EventToCommandBehavior` to map `Appearing` event to ViewModel's command

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #771
- Related to #709

### API Changes ###

- `AsyncCommand<T>` is now equivalent to `AsyncCommand<T, T>` instead of `AsyncCommand<T, object>`
- `AsyncCommand`s `canExecue` parameter has type `Func<bool>` instead of `Func<object, bool>`
- `static CommandHelper.Create()`

User can still pass `object`s into `canExecue`, but they'll need to explicitly ont-in into that: `AsyncCommand<T, object>`

### Behavioral Changes ###

This is breaking change that will affect users that pass `canExecute` as `Func<object, bool>` instead of creating with two type arguments to specify type of `canExecute`. So this change will push those users to a better (more statically checked) code.

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
