### PR TITLE
Fixed naming convention of CaptureModeProperty

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/CameraView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/CameraView.shared.cs
@@ -62,12 +62,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			set => SetValue(SavePhotoToFileProperty, value);
 		}*/
 
-		public static readonly BindableProperty CaptureOptionsProperty = BindableProperty.Create(nameof(CaptureMode), typeof(CameraCaptureMode), typeof(CameraView), CameraCaptureMode.Default);
+		public static readonly BindableProperty CaptureModeProperty = BindableProperty.Create(nameof(CaptureMode), typeof(CameraCaptureMode), typeof(CameraView), CameraCaptureMode.Default);
 
 		public CameraCaptureMode CaptureMode
 		{
-			get => (CameraCaptureMode)GetValue(CaptureOptionsProperty);
-			set => SetValue(CaptureOptionsProperty, value);
+			get => (CameraCaptureMode)GetValue(CaptureModeProperty);
+			set => SetValue(CaptureModeProperty, value);
 		}
 
 		public static readonly BindableProperty VideoStabilizationProperty = BindableProperty.Create(nameof(VideoStabilization), typeof(bool), typeof(CameraView), false);


### PR DESCRIPTION
### Description of Change ###

Changed PropertyName to fix naming convention.


-Can't test the MACOS compile, but it should work.
-Tests are ok on Windows and working on an Android device
-No samples necessary in my opinion.
-Documentation Update not necessary

### Bugs Fixed ###
- Fixes [#774 ](https://github.com/xamarin/XamarinCommunityToolkit/issues/774)

### API Changes ###
None

### Behavioral Changes ###

-Intellisense should work now
-MVVM supported with naming convention on CameraView

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ x] Has tests (MACOS / IOS not tested)
- [ ] Has samples
- [x ] Rebased on top of main at time of PR
- [x ] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
