### PR TITLE
Fix "ListIsNullOrEmptyConverter doesn't respect ObservableCollection updates"

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/ListIsNotNullOrEmptyConverter.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/ListIsNotNullOrEmptyConverter.shared.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Specialized;
 using System.Globalization;
 using Xamarin.CommunityToolkit.Extensions.Internals;
 using Xamarin.Forms;
+using static Xamarin.CommunityToolkit.Converters.ListIsNullOrEmptyConverter;
 
 namespace Xamarin.CommunityToolkit.Converters
 {
@@ -23,6 +25,17 @@ namespace Xamarin.CommunityToolkit.Converters
 		{
 			if (value is null)
 				return false;
+
+			if (value is INotifyCollectionChanged observable && value is ICollection collection)
+			{
+				var binding = new Binding
+				{
+					Mode = BindingMode.OneWay,
+					Path = nameof(ObservableCollectionWrapper.IsNotEmpty),
+					Source = new ObservableCollectionWrapper(observable, collection),
+				};
+				return binding;
+			}
 
 			if (value is IEnumerable list)
 				return list.GetEnumerator().MoveNext();

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/INotifyCollectionChangedEx.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/INotifyCollectionChangedEx.shared.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Specialized;
+
+namespace Xamarin.CommunityToolkit.ObjectModel.Extensions
+{
+	public static class INotifyCollectionChangedEx
+	{
+		public static void WeakSubscribe<T>(this INotifyCollectionChanged target, T subscriber, Action<T, object, EventArgs> action)
+		{
+			_ = target ?? throw new ArgumentNullException(nameof(target));
+			if (subscriber == null || action == null)
+			{
+				return;
+			}
+
+			var weakSubscriber = new WeakReference(subscriber, false);
+			target.CollectionChanged += handler;
+
+			void handler(object sender, NotifyCollectionChangedEventArgs e)
+			{
+				var s = (T)weakSubscriber.Target;
+				if (s == null)
+				{
+					target.CollectionChanged -= handler;
+					return;
+				}
+
+				action(s, sender, e);
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Made `ListIsNullOrEmptyConverter` and `ListIsNotNullOrEmptyConverter` respond to to `ObservableCollection` changes.

Didn't test it yet

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #768

### API Changes ###

`void WeakSubscribe<T>(this INotifyCollectionChanged target ...)`

### Behavioral Changes ###

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
