### PR TITLE
Fix AsyncCommand.CanExecute() null reference exception

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/AsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/AsyncCommand_Tests.cs
@@ -149,6 +149,19 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 		}
 
 		[Fact]
+		public void AsyncCommand_NoParameter_NoCanExecute_Test()
+		{
+			// Arrange
+			Func<bool> canExecute = null;
+			var command = new AsyncCommand(NoParameterTask, canExecute);
+
+			// Act
+
+			// Assert
+			Assert.True(command.CanExecute(null));
+		}
+
+		[Fact]
 		public void AsyncCommand_RaiseCanExecuteChanged_Test()
 		{
 			// Arrange

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/AsyncValueCommand_Tests.cs
@@ -172,6 +172,19 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		}
 
 		[Fact]
+		public void AsyncValueCommandNoParameter_NoCanExecute_Test()
+		{
+			// Arrange
+			Func<bool> canExecute = null;
+			var command = new AsyncValueCommand(NoParameterTask, canExecute);
+
+			// Act
+
+			// Assert
+			Assert.True(command.CanExecute(null));
+		}
+
+		[Fact]
 		public void AsyncValueCommand_RaiseCanExecuteChanged_Test()
 		{
 			// Arrange

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/ICommand_AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/ICommand_AsyncValueCommand_Tests.cs
@@ -190,6 +190,19 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		}
 
 		[Fact]
+		public void ICommand_NoParameter_NoCanExecute_Test()
+		{
+			// Arrange
+			Func<bool> canExecute = null;
+			ICommand command = new AsyncValueCommand(NoParameterTask, canExecute);
+
+			// Act
+
+			// Assert
+			Assert.True(command.CanExecute(null));
+		}
+
+		[Fact]
 		public void ICommand_Parameter_CanExecuteDynamic_Test()
 		{
 			// Arrange

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/ICommand_AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/ICommand_AsyncValueCommand_Tests.cs
@@ -190,19 +190,6 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		}
 
 		[Fact]
-		public void ICommand_NoParameter_NoCanExecute_Test()
-		{
-			// Arrange
-			Func<bool> canExecute = null;
-			ICommand command = new AsyncValueCommand(NoParameterTask, canExecute);
-
-			// Act
-
-			// Assert
-			Assert.True(command.CanExecute(null));
-		}
-
-		[Fact]
 		public void ICommand_Parameter_CanExecuteDynamic_Test()
 		{
 			// Arrange

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/BaseAsyncCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/BaseAsyncCommand.shared.cs
@@ -51,9 +51,15 @@ namespace Xamarin.CommunityToolkit.ObjectModel.Internals
 		/// <summary>
 		/// Converts `Func<bool>` to `Func<object, bool>`
 		/// </summary>
-		/// <param name="execute"></param>
-		/// <returns>The CanExecute parameter required for ICommand </returns>
-		private protected static Func<object, bool> ConvertCanExecute(Func<bool> execute) => _ => execute();
+		/// <param name="canExecute"></param>
+		/// <returns>The CanExecute parameter required for ICommand</returns>
+		private protected static Func<object, bool> ConvertCanExecute(Func<bool> canExecute)
+		{
+			if (canExecute == null)
+				return null;
+
+			return _ => canExecute();
+		}
 
 		/// <summary>
 		/// Executes the Command as a Task

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/BaseAsyncValueCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/BaseAsyncValueCommand.shared.cs
@@ -51,9 +51,15 @@ namespace Xamarin.CommunityToolkit.ObjectModel.Internals
 		/// <summary>
 		/// Converts `Func<bool>` to `Func<object, bool>`
 		/// </summary>
-		/// <param name="execute"></param>
+		/// <param name="canExecute"></param>
 		/// <returns>The CanExecute parameter required for ICommand</returns>
-		private protected static Func<object, bool> ConvertCanExecute(Func<bool> execute) => _ => execute();
+		private protected static Func<object, bool> ConvertCanExecute(Func<bool> canExecute)
+		{
+			if (canExecute == null)
+				return null;
+
+			return _ => canExecute();
+		}
 
 		/// <summary>
 		/// Executes the Command as a Task


### PR DESCRIPTION
### Description of Change ###

Tried using new constructors introduced by #782 and got `Null reference exception`.
`canExecute` is mandatory there, but it still can be passed as `null` is some circumstances (see added tests)

### API Changes ###

None

### Behavioral Changes ###

New AsyncCommand constructors can be called with `canExecute` as `null`

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [x] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
