### PR TITLE
Make parameters in CommandFactory class consistent

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_Command_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_Command_Tests.cs
@@ -94,7 +94,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 			Assert.True(command.CanExecute(string.Empty));
 			Assert.True(command.CanExecute(0));
 
-			Assert.IsType<Forms.Command>(command);
+			Assert.IsType<Forms.Command<object>>(command);
 			Assert.IsAssignableFrom<ICommand>(command);
 		}
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_Command_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_Command_Tests.cs
@@ -42,18 +42,19 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void Action_NullCanExecuteParameter()
 		{
 			// Arrange
+			Func<bool> canExecute = null;
 
 			// Act
 
 			// Assert
-			Assert.Throws<ArgumentNullException>(() => CommandFactory.Create(NoParameterAction, null));
+			Assert.Throws<ArgumentNullException>(() => CommandFactory.Create(NoParameterAction, canExecute));
 		}
 
 		[Fact]
 		public void Action_ValidCanExecuteParameter()
 		{
 			// Arrange
-			var command = CommandFactory.Create(NoParameterAction, CanExecuteTrue);
+			var command = CommandFactory.Create(NoParameterAction, () => true);
 
 			// Act
 			command.Execute(null);
@@ -83,7 +84,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void ActionObject_ValidExecuteParameter()
 		{
 			// Arrange
-			var command = CommandFactory.Create(ObjectParameterAction);
+			var command = CommandFactory.Create<object>(ObjectParameterAction);
 
 			// Act
 			command.Execute(null);
@@ -105,14 +106,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 			// Act
 
 			// Assert
-			Assert.Throws<ArgumentNullException>(() => CommandFactory.Create(ObjectParameterAction, null));
+			Assert.Throws<ArgumentNullException>(() => CommandFactory.Create<object, object>(ObjectParameterAction, null));
 		}
 
 		[Fact]
 		public void ActionObject_ValidCanExecuteParameter()
 		{
 			// Arrange
-			var command = CommandFactory.Create(ObjectParameterAction, _ => true);
+			var command = CommandFactory.Create<object>(ObjectParameterAction, _ => true);
 
 			// Act
 			command.Execute(1);
@@ -137,25 +138,26 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 			// Act
 
 			// Assert
-			Assert.Throws<ArgumentNullException>(() => CommandFactory.Create<int>(execute, CanExecuteTrue));
+			Assert.Throws<ArgumentNullException>(() => CommandFactory.Create<int>(execute, () => true));
 		}
 
 		[Fact]
 		public void ActionInt_NullCanExecuteParameter()
 		{
 			// Arrange
+			Func<bool> canExecute = null;
 
 			// Act
 
 			// Assert
-			Assert.Throws<ArgumentNullException>(() => CommandFactory.Create<int>(IntParameterAction, null));
+			Assert.Throws<ArgumentNullException>(() => CommandFactory.Create<int>(IntParameterAction, canExecute));
 		}
 
 		[Fact]
 		public void ActionInt_ValidCanExecuteParameter()
 		{
 			// Arrange
-			var command = CommandFactory.Create<int>(IntParameterAction, CanExecuteTrue);
+			var command = CommandFactory.Create<int, int>(IntParameterAction, CanExecuteTrue);
 
 			// Act
 
@@ -164,8 +166,25 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 			Assert.False(command.CanExecute(null));
 			Assert.False(command.CanExecute(string.Empty));
 
-			Assert.IsType<Forms.Command<int>>(command);
+			Assert.IsType<Forms.Command>(command);
 			Assert.IsAssignableFrom<ICommand>(command);
+		}
+
+		[Fact]
+		public void ActionInt_ValidExecuteParameter()
+		{
+			// Arrange
+			var executeResult = -1;
+			var executeParameter = 0;
+			var command = CommandFactory.Create<int>(parameter => executeResult = parameter);
+
+			// Act
+			command.Execute(executeParameter);
+			command.Execute(null);
+			command.Execute(string.Empty);
+
+			// Assert
+			Assert.Equal(executeParameter, executeResult);
 		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.Command.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.Command.shared.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.ObjectModel
@@ -20,6 +21,16 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// Initializes Xamarin.Forms.Command
 		/// </summary>
 		/// <param name="execute">The Function executed when Execute is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="canExecute">The Function that verifies whether or not Command should execute.</param>
+		/// <returns>Xamarin.Forms.Command</returns>
+		public static Command Create(Action execute, Func<object, bool> canExecute) =>
+			new Command(ConvertExecute(execute), canExecute);
+
+		/// <summary>
+		/// Initializes Xamarin.Forms.Command
+		/// </summary>
+		/// <param name="execute">The Function executed when Execute is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="canExecute">The Function that verifies whether or not Command should execute.</param>
 		/// <returns>Xamarin.Forms.Command</returns>
 		public static Command Create(Action execute, Func<bool> canExecute) =>
 			new Command(execute, canExecute);
@@ -29,31 +40,95 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// </summary>
 		/// <param name="execute">The Function executed when Execute is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <returns>Xamarin.Forms.Command</returns>
-		public static Command Create(Action<object> execute) =>
-			new Command(execute);
+		public static Command Create<TExecute>(Action<TExecute> execute) =>
+			new Command(ConvertExecute(execute));
 
 		/// <summary>
 		/// Initializes Xamarin.Forms.Command
 		/// </summary>
 		/// <param name="execute">The Function executed when Execute is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="canExecute">The Function that verifies whether or not Command should execute.</param>
 		/// <returns>Xamarin.Forms.Command</returns>
-		public static Command Create(Action<object> execute, Func<object, bool> canExecute) =>
-			new Command(execute, canExecute);
+		public static Command Create<TExecute>(Action<TExecute> execute, Func<object, bool> canExecute) =>
+			new Command(ConvertExecute(execute), canExecute);
 
 		/// <summary>
-		/// Initializes Xamarin.Forms.Command<typeparamref name="T"/>
+		/// Initializes Xamarin.Forms.Command
 		/// </summary>
 		/// <param name="execute">The Function executed when Execute is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
-		/// <returns>Xamarin.Forms.Command<typeparamref name="T"/></returns>
-		public static Command<T> Create<T>(Action<T> execute) =>
-			new Command<T>(execute);
+		/// <param name="canExecute">The Function that verifies whether or not Command should execute.</param>
+		/// <returns>Xamarin.Forms.Command</returns>
+		public static Command Create<TExecute>(Action<TExecute> execute, Func<bool> canExecute) =>
+			new Command(ConvertExecute(execute), ConvertCanExecute(canExecute));
 
 		/// <summary>
-		/// Initializes Xamarin.Forms.Command<typeparamref name="T"/>
+		/// Initializes Xamarin.Forms.Command
 		/// </summary>
 		/// <param name="execute">The Function executed when Execute is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
-		/// <returns>Xamarin.Forms.Command<typeparamref name="T"/></returns>
-		public static Command<T> Create<T>(Action<T> execute, Func<T, bool> canExecute) =>
-			new Command<T>(execute, canExecute);
+		/// <param name="canExecute">The Function that verifies whether or not Command should execute.</param>
+		/// <returns>Xamarin.Forms.Command</returns>
+		public static Command Create<TExecute, TCanExecute>(Action<TExecute> execute, Func<TCanExecute, bool> canExecute) =>
+			new Command(ConvertExecute(execute), ConvertCanExecute(canExecute));
+
+		#region Helper methods to ensure Command behaviour is consistent with other commands
+
+		static Action<object> ConvertExecute(Action execute)
+		{
+			if (execute == null)
+				return null;
+
+			return p => execute();
+		}
+
+		static Action<object> ConvertExecute<T>(Action<T> execute)
+		{
+			if (execute == null)
+				return null;
+
+			return p => Execute(execute, p);
+		}
+
+		static void Execute<T>(Action<T> execute, object parameter)
+		{
+			switch (parameter)
+			{
+				case T validParameter:
+					execute(validParameter);
+					break;
+
+				case null when !typeof(T).GetTypeInfo().IsValueType:
+					execute((T)parameter);
+					break;
+
+				case null:
+				default:
+					return;
+			}
+		}
+
+		static Func<object, bool> ConvertCanExecute(Func<bool> canExecute)
+		{
+			if (canExecute == null)
+				return null;
+
+			return _ => canExecute();
+		}
+
+		static Func<object, bool> ConvertCanExecute<T>(Func<T, bool> canExecute)
+		{
+			if (canExecute == null)
+				return null;
+
+			return p => CanExecute(canExecute, p);
+		}
+
+		static bool CanExecute<T>(Func<T, bool> canExecute, object parameter) => parameter switch
+		{
+			T validParameter => canExecute(validParameter),
+			null when !typeof(T).GetTypeInfo().IsValueType => canExecute((T)parameter),
+			_ => false,
+		};
+
+		#endregion
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.Command.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.Command.shared.cs
@@ -36,12 +36,12 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 			new Command(execute, canExecute);
 
 		/// <summary>
-		/// Initializes Xamarin.Forms.Command
+		/// Initializes Xamarin.Forms.Command<typeparamref name="TExecute"/>
 		/// </summary>
 		/// <param name="execute">The Function executed when Execute is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
-		/// <returns>Xamarin.Forms.Command</returns>
-		public static Command Create<TExecute>(Action<TExecute> execute) =>
-			new Command(ConvertExecute(execute));
+		/// <returns>Xamarin.Forms.Command<typeparamref name="TExecute"/></returns>
+		public static Command<TExecute> Create<TExecute>(Action<TExecute> execute) =>
+			new Command<TExecute>(execute);
 
 		/// <summary>
 		/// Initializes Xamarin.Forms.Command

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.IAsyncCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.IAsyncCommand.shared.cs
@@ -11,151 +11,145 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncCommand</returns>
 		public static IAsyncCommand Create(
-			Func<Task> execute,
+			Func<Task> executeTask,
 			Func<object, bool> canExecute = null,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncCommand(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncCommand(executeTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncCommand</returns>
 		public static IAsyncCommand Create(
-			Func<Task> execute,
+			Func<Task> executeTask,
 			Func<bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncCommand(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncCommand(executeTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncCommand<typeparamref name="TExecute"/></returns>
 		public static IAsyncCommand<TExecute> Create<TExecute>(
-			Func<TExecute, Task> execute,
+			Func<TExecute, Task> executeTask,
 			Func<object, bool> canExecute = null,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncCommand<TExecute>(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncCommand<TExecute>(executeTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncCommand<typeparamref name="TExecute"/></returns>
 		public static IAsyncCommand<TExecute> Create<TExecute>(
-			Func<TExecute, Task> execute,
+			Func<TExecute, Task> executeTask,
 			Func<bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncCommand<TExecute>(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncCommand<TExecute>(executeTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncCommand</returns>
 		public static IAsyncCommand<TExecute, TCanExecute> Create<TExecute, TCanExecute>(
-			Func<TExecute, Task> execute,
-			Func<TCanExecute, bool> canExecute = null,
+			Func<TExecute, Task> executeTask,
+			Func<TCanExecute, bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncCommand<TExecute, TCanExecute>(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncCommand<TExecute, TCanExecute>(executeTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		#region Helper Methods to Prevent Ambiguous Method Error When Using Anonymous Async Methods
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand Create(Func<Task> execute)
-		{
-			Func<object, bool> canExecute = null;
-			return Create(execute, canExecute, null, false, true);
-		}
+		public static IAsyncCommand Create(Func<Task> executeTask) =>
+			Create(executeTask, (Func<object, bool>)null, null, false, true);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand Create(Func<Task> execute, Func<object, bool> canExecute) =>
-			Create(execute, canExecute, null, false, true);
+		public static IAsyncCommand Create(Func<Task> executeTask, Func<object, bool> canExecute) =>
+			Create(executeTask, canExecute, null, false, true);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand Create(Func<Task> execute, Func<bool> canExecute) =>
-			Create(execute, canExecute, null, false, true);
+		public static IAsyncCommand Create(Func<Task> executeTask, Func<bool> canExecute) =>
+			Create(executeTask, canExecute, null, false, true);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand<TExecute> Create<TExecute>(Func<TExecute, Task> execute)
-		{
-			Func<object, bool> canExecute = null;
-			return Create(execute, canExecute, null, false, true);
-		}
+		public static IAsyncCommand<TExecute> Create<TExecute>(Func<TExecute, Task> executeTask) =>
+			Create(executeTask, (Func<object, bool>)null, null, false, true);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand<TExecute> Create<TExecute>(Func<TExecute, Task> execute, Func<object, bool> canExecute) =>
-			Create(execute, canExecute, null, false, true);
+		public static IAsyncCommand<TExecute> Create<TExecute>(Func<TExecute, Task> executeTask, Func<object, bool> canExecute) =>
+			Create(executeTask, canExecute, null, false, true);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand<TExecute> Create<TExecute>(Func<TExecute, Task> execute, Func<bool> canExecute) =>
-			Create(execute, canExecute, null, false, true);
+		public static IAsyncCommand<TExecute> Create<TExecute>(Func<TExecute, Task> executeTask, Func<bool> canExecute) =>
+			Create(executeTask, canExecute, null, false, true);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand<TExecute, TCanExecute> Create<TExecute, TCanExecute>(Func<TExecute, Task> execute, Func<TCanExecute, bool> canExecute) =>
-			Create(execute, canExecute, null, false, true);
+		public static IAsyncCommand<TExecute, TCanExecute> Create<TExecute, TCanExecute>(Func<TExecute, Task> executeTask, Func<TCanExecute, bool> canExecute) =>
+			Create(executeTask, canExecute, null, false, true);
 		#endregion
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.IAsyncValueCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.IAsyncValueCommand.shared.cs
@@ -11,81 +11,81 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// <summary>
 		/// Initializes a new instance of AsyncValueCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeValueTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncValueCommand</returns>
 		public static IAsyncValueCommand Create(
-			Func<ValueTask> execute,
+			Func<ValueTask> executeValueTask,
 			Func<object, bool> canExecute = null,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncValueCommand(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncValueCommand(executeValueTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of AsyncValueCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeValueTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncValueCommand</returns>
 		public static IAsyncValueCommand Create(
-			Func<ValueTask> execute,
+			Func<ValueTask> executeValueTask,
 			Func<bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncValueCommand(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncValueCommand(executeValueTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of AsyncValueCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeValueTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncValueCommand<typeparamref name="TExecute"/></returns>
 		public static IAsyncValueCommand<TExecute> Create<TExecute>(
-			Func<TExecute, ValueTask> execute,
+			Func<TExecute, ValueTask> executeValueTask,
 			Func<object, bool> canExecute = null,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncValueCommand<TExecute>(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncValueCommand<TExecute>(executeValueTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of AsyncValueCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeValueTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncValueCommand<typeparamref name="TExecute"/></returns>
 		public static IAsyncValueCommand<TExecute> Create<TExecute>(
-			Func<TExecute, ValueTask> execute,
+			Func<TExecute, ValueTask> executeValueTask,
 			Func<bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncValueCommand<TExecute>(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncValueCommand<TExecute>(executeValueTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of AsyncValueCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeValueTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncValueCommand></returns>
 		public static IAsyncValueCommand<TExecute, TCanExecute> Create<TExecute, TCanExecute>(
-			Func<TExecute, ValueTask> execute,
-			Func<TCanExecute, bool> canExecute = null,
+			Func<TExecute, ValueTask> executeValueTask,
+			Func<TCanExecute, bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncValueCommand<TExecute, TCanExecute>(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncValueCommand<TExecute, TCanExecute>(executeValueTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 	}
 }


### PR DESCRIPTION
### Description of Change ###

`CommandFactory` that was merged in #797 is not quite one that is described in issue or PR description.
When @brminnick separated `CommandFactory` into partial classes some changes to its API were made. 
This PR is intended to restore some of them.

- Main issue: All overloads for `Command` were changed to accept the same parameters that `Command` constructors do which ruins the point of this class a little, since now some overloads of `CommandFactory.Create` accept different parameters from those that return `AsyncCommand` or `AsyncValueCommand`. Main benefit of this class is that it can automatically switch between `ICommand` implementations basically based on whether `execute` returns `void` or `Task` (or `ValueTask`)
- First parameter was renamed to `execute` in all overloads for all commands, which reintroduces ambiguity between async commands if more then two parameters are specified.

#### What was done:
- Made overloads of `CommandFactory.Create` for `Command` accept exactly the same parameters as overloads for async command do (except `execute` doesn't return task). This implementation of those overloads is different from ones that were in previous PR. Current behavior mimics `Cammnd` behavior for type validation (do nothing if `execute` type is not correct, and return `false` if `canExecute` type is not correct) instead of `AsyncCommand` behaviour (throw exception if type id not correct).
- Rename `execute` parameter for `AsyncCommand` to `executeTask` and `AsyncValueCommand` to `executeValueTask`. This is helpful to resolve ambiguity between them `CommandFactory.Create(executeTask: async () => {}, null, null)`
- Made `canExecute` parameter for `Create<TExecute, TCanExecute>` mandatory. It doesn't make sense to specify type for a parameter and not provide it. 

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #798

### Behavioral Changes ###

`CommandFactory.Create` accepts the same parameters for all command types (except async execute for commands returns tasks, and nothing for regular one).

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
