### PR TITLE
Sort BaseGalleryViewModel.Items by Title

### DIFF
--- a/samples/XCT.Sample/ViewModels/Base/BaseGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Base/BaseGalleryViewModel.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Input;
-using Xamarin.CommunityToolkit.ObjectModel;
 using Xamarin.CommunityToolkit.Sample.Models;
 using Xamarin.Forms;
 
@@ -12,15 +11,21 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 	{
 		ICommand filterCommand;
 
-		public BaseGalleryViewModel() => Filter();
-
-		public abstract IEnumerable<SectionModel> Items { get; }
-
-		public IEnumerable<SectionModel> FilteredItems { get; private set; }
+		protected BaseGalleryViewModel()
+		{
+			Items = CreateItems().OrderBy(x => x.Title).ToList();
+			Filter();
+		}
 
 		public ICommand FilterCommand => filterCommand ??= new Command(Filter);
 
+		public IReadOnlyList<SectionModel> Items { get; }
+
+		public IEnumerable<SectionModel> FilteredItems { get; private set; }
+
 		public string FilterValue { private get; set; }
+
+		protected abstract IEnumerable<SectionModel> CreateItems();
 
 		void Filter()
 		{

--- a/samples/XCT.Sample/ViewModels/Behaviors/BehaviorsGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Behaviors/BehaviorsGalleryViewModel.cs
@@ -7,7 +7,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 {
 	public class BehaviorsGalleryViewModel : BaseGalleryViewModel
 	{
-		public override IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		protected override IEnumerable<SectionModel> CreateItems() => new[]
 		{
 			new SectionModel(
 				typeof(EmailValidationBehaviorPage),

--- a/samples/XCT.Sample/ViewModels/Converters/ConvertersGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Converters/ConvertersGalleryViewModel.cs
@@ -8,7 +8,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 {
 	public class ConvertersGalleryViewModel : BaseGalleryViewModel
 	{
-		public override IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		protected override IEnumerable<SectionModel> CreateItems() => new[]
 		{
 			new SectionModel(
 				typeof(ItemTappedEventArgsPage),

--- a/samples/XCT.Sample/ViewModels/Effects/EffectsGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Effects/EffectsGalleryViewModel.cs
@@ -7,7 +7,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Effects
 {
 	public class EffectsGalleryViewModel : BaseGalleryViewModel
 	{
-		public override IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		protected override IEnumerable<SectionModel> CreateItems() => new[]
 		{
 			new SectionModel(
 				typeof(SafeAreaEffectPage),

--- a/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
@@ -6,7 +6,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases
 {
 	public class TestCasesGalleryViewModel : BaseGalleryViewModel
 	{
-		public override IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		protected override IEnumerable<SectionModel> CreateItems() => new[]
 		{
 			new SectionModel(
 				typeof(TouchEffectButtonPage),

--- a/samples/XCT.Sample/ViewModels/Views/TabViewViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/TabViewViewModel.cs
@@ -6,7 +6,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 {
 	public class TabViewViewModel : BaseGalleryViewModel
 	{
-		public override IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		protected override IEnumerable<SectionModel> CreateItems() => new[]
 		{
 			new SectionModel(typeof(GettingStartedPage), "Getting Started",
 				"TabView basic use case"),

--- a/samples/XCT.Sample/ViewModels/Views/ViewsGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/ViewsGalleryViewModel.cs
@@ -6,7 +6,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 {
 	public class ViewsGalleryViewModel : BaseGalleryViewModel
 	{
-		public override IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		protected override IEnumerable<SectionModel> CreateItems() => new[]
 		{
 			new SectionModel(typeof(AvatarViewPage), "AvatarView",
 				"The AvatarView represents a user's name by using the initials and a generated background color"),

--- a/samples/XCT.Sample/ViewModels/WelcomeViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/WelcomeViewModel.cs
@@ -10,9 +10,9 @@ using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels
 {
-	public class WelcomeViewModel : BaseViewModel
+	public class WelcomeViewModel : BaseGalleryViewModel
 	{
-		public IEnumerable<SectionModel> Items { get; } = new List<SectionModel>
+		protected override IEnumerable<SectionModel> CreateItems() => new[]
 		{
 			new SectionModel(typeof(BehaviorsGalleryPage), "Behaviors", Color.FromHex("#8E8CD8"),
 				"Behaviors lets you add functionality to user interface controls without having to subclass them. Behaviors are written in code and added to controls in XAML or code"),


### PR DESCRIPTION
### Description of Change ###

Updates `BaseGalleryViewModel` to always sort `Items` by their `Title`, making the samples galleries easier to navigate.

This only affects `Xamarin.CommunityToolkit.Sample`.

### Bugs Fixed ###

Ensures the Gallery lists are always ordered by their Title.

Here is an example where the `Popup` view appeared at the bottom of the list:

![Simulator Screen Shot - iPhone 12 Pro - 2021-01-29 at 12 03 22](https://user-images.githubusercontent.com/13558917/106323040-9f42c100-622b-11eb-9d62-fa266677631a.png)


### API Changes ###

None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
