### PR TITLE
CommandFactory fixes for existing overloads

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.Command.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.Command.shared.cs
@@ -20,6 +20,7 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// Initializes Xamarin.Forms.Command
 		/// </summary>
 		/// <param name="execute">The Function executed when Execute is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="canExecute">The Function that verifies whether or not Command should execute.</param>
 		/// <returns>Xamarin.Forms.Command</returns>
 		public static Command Create(Action execute, Func<bool> canExecute) =>
 			new Command(execute, canExecute);
@@ -36,6 +37,7 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// Initializes Xamarin.Forms.Command
 		/// </summary>
 		/// <param name="execute">The Function executed when Execute is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="canExecute">The Function that verifies whether or not Command should execute.</param>
 		/// <returns>Xamarin.Forms.Command</returns>
 		public static Command Create(Action<object> execute, Func<object, bool> canExecute) =>
 			new Command(execute, canExecute);
@@ -52,6 +54,7 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// Initializes Xamarin.Forms.Command<typeparamref name="T"/>
 		/// </summary>
 		/// <param name="execute">The Function executed when Execute is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="canExecute">The Function that verifies whether or not Command should execute.</param>
 		/// <returns>Xamarin.Forms.Command<typeparamref name="T"/></returns>
 		public static Command<T> Create<T>(Action<T> execute, Func<T, bool> canExecute) =>
 			new Command<T>(execute, canExecute);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.IAsyncCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.IAsyncCommand.shared.cs
@@ -82,7 +82,7 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// <returns>IAsyncCommand</returns>
 		public static IAsyncCommand<TExecute, TCanExecute> Create<TExecute, TCanExecute>(
 			Func<TExecute, Task> execute,
-			Func<TCanExecute, bool> canExecute = null,
+			Func<TCanExecute, bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.IAsyncCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.IAsyncCommand.shared.cs
@@ -11,133 +11,127 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncCommand</returns>
 		public static IAsyncCommand Create(
-			Func<Task> execute,
+			Func<Task> executeTask,
 			Func<object, bool> canExecute = null,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncCommand(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncCommand(executeTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncCommand</returns>
 		public static IAsyncCommand Create(
-			Func<Task> execute,
+			Func<Task> executeTask,
 			Func<bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncCommand(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncCommand(executeTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncCommand<typeparamref name="TExecute"/></returns>
 		public static IAsyncCommand<TExecute> Create<TExecute>(
-			Func<TExecute, Task> execute,
+			Func<TExecute, Task> executeTask,
 			Func<object, bool> canExecute = null,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncCommand<TExecute>(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncCommand<TExecute>(executeTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncCommand<typeparamref name="TExecute"/></returns>
 		public static IAsyncCommand<TExecute> Create<TExecute>(
-			Func<TExecute, Task> execute,
+			Func<TExecute, Task> executeTask,
 			Func<bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncCommand<TExecute>(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncCommand<TExecute>(executeTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncCommand</returns>
 		public static IAsyncCommand<TExecute, TCanExecute> Create<TExecute, TCanExecute>(
-			Func<TExecute, Task> execute,
+			Func<TExecute, Task> executeTask,
 			Func<TCanExecute, bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncCommand<TExecute, TCanExecute>(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncCommand<TExecute, TCanExecute>(executeTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		#region Helper Methods to Prevent Ambiguous Method Error When Using Anonymous Async Methods
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand Create(Func<Task> execute)
-		{
-			Func<object, bool> canExecute = null;
-			return Create(execute, canExecute, null, false, true);
-		}
+		public static IAsyncCommand Create(Func<Task> executeTask) =>
+			Create(executeTask, (Func<object, bool>)null, null, false, true);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand Create(Func<Task> execute, Func<object, bool> canExecute) =>
-			Create(execute, canExecute, null, false, true);
+		public static IAsyncCommand Create(Func<Task> executeTask, Func<object, bool> canExecute) =>
+			Create(executeTask, canExecute, null, false, true);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand Create(Func<Task> execute, Func<bool> canExecute) =>
-			Create(execute, canExecute, null, false, true);
+		public static IAsyncCommand Create(Func<Task> executeTask, Func<bool> canExecute) =>
+			Create(executeTask, canExecute, null, false, true);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand<TExecute> Create<TExecute>(Func<TExecute, Task> execute)
-		{
-			Func<object, bool> canExecute = null;
-			return Create(execute, canExecute, null, false, true);
-		}
+		public static IAsyncCommand<TExecute> Create<TExecute>(Func<TExecute, Task> executeTask) =>
+			Create(executeTask, (Func<object, bool>)null, null, false, true);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand<TExecute> Create<TExecute>(Func<TExecute, Task> execute, Func<object, bool> canExecute) =>
-			Create(execute, canExecute, null, false, true);
+		public static IAsyncCommand<TExecute> Create<TExecute>(Func<TExecute, Task> executeTask, Func<object, bool> canExecute) =>
+			Create(executeTask, canExecute, null, false, true);
 
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
@@ -151,11 +145,11 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// <summary>
 		/// Initializes a new instance of IAsyncCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <returns>IAsyncCommand</returns>
-		public static IAsyncCommand<TExecute, TCanExecute> Create<TExecute, TCanExecute>(Func<TExecute, Task> execute, Func<TCanExecute, bool> canExecute) =>
-			Create(execute, canExecute, null, false, true);
+		public static IAsyncCommand<TExecute, TCanExecute> Create<TExecute, TCanExecute>(Func<TExecute, Task> executeTask, Func<TCanExecute, bool> canExecute) =>
+			Create(executeTask, canExecute, null, false, true);
 		#endregion
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.IAsyncValueCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.IAsyncValueCommand.shared.cs
@@ -11,81 +11,81 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// <summary>
 		/// Initializes a new instance of AsyncValueCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeValueTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncValueCommand</returns>
 		public static IAsyncValueCommand Create(
-			Func<ValueTask> execute,
+			Func<ValueTask> executeValueTask,
 			Func<object, bool> canExecute = null,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncValueCommand(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncValueCommand(executeValueTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of AsyncValueCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeValueTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncValueCommand</returns>
 		public static IAsyncValueCommand Create(
-			Func<ValueTask> execute,
+			Func<ValueTask> executeValueTask,
 			Func<bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncValueCommand(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncValueCommand(executeValueTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of AsyncValueCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeValueTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncValueCommand<typeparamref name="TExecute"/></returns>
 		public static IAsyncValueCommand<TExecute> Create<TExecute>(
-			Func<TExecute, ValueTask> execute,
+			Func<TExecute, ValueTask> executeValueTask,
 			Func<object, bool> canExecute = null,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncValueCommand<TExecute>(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncValueCommand<TExecute>(executeValueTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of AsyncValueCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeValueTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncValueCommand<typeparamref name="TExecute"/></returns>
 		public static IAsyncValueCommand<TExecute> Create<TExecute>(
-			Func<TExecute, ValueTask> execute,
+			Func<TExecute, ValueTask> executeValueTask,
 			Func<bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncValueCommand<TExecute>(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncValueCommand<TExecute>(executeValueTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 
 		/// <summary>
 		/// Initializes a new instance of AsyncValueCommand
 		/// </summary>
-		/// <param name="execute">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
+		/// <param name="executeValueTask">The Function executed when Execute or ExecuteAsync is called. This does not check canExecute before executing and will execute even if canExecute is false</param>
 		/// <param name="canExecute">The Function that verifies whether or not AsyncCommand should execute.</param>
 		/// <param name="onException">If an exception is thrown in the Task, <c>onException</c> will execute. If onException is null, the exception will be re-thrown</param>
 		/// <param name="continueOnCapturedContext">If set to <c>true</c> continue on captured context; this will ensure that the Synchronization Context returns to the calling thread. If set to <c>false</c> continue on a different context; this will allow the Synchronization Context to continue on a different thread</param>
 		/// <returns>IAsyncValueCommand></returns>
 		public static IAsyncValueCommand<TExecute, TCanExecute> Create<TExecute, TCanExecute>(
-			Func<TExecute, ValueTask> execute,
+			Func<TExecute, ValueTask> executeValueTask,
 			Func<TCanExecute, bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>
-			new AsyncValueCommand<TExecute, TCanExecute>(execute, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
+			new AsyncValueCommand<TExecute, TCanExecute>(executeValueTask, canExecute, onException, continueOnCapturedContext, allowsMultipleExecutions);
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.IAsyncValueCommand.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/CommandFactory.IAsyncValueCommand.shared.cs
@@ -82,7 +82,7 @@ namespace Xamarin.CommunityToolkit.ObjectModel
 		/// <returns>IAsyncValueCommand></returns>
 		public static IAsyncValueCommand<TExecute, TCanExecute> Create<TExecute, TCanExecute>(
 			Func<TExecute, ValueTask> execute,
-			Func<TCanExecute, bool> canExecute = null,
+			Func<TCanExecute, bool> canExecute,
 			Action<Exception> onException = null,
 			bool continueOnCapturedContext = false,
 			bool allowsMultipleExecutions = true) =>


### PR DESCRIPTION
### Description of Change ###

I found two edge case issues with existing overloads in `CommandFactory`:
1) 
![image](https://user-images.githubusercontent.com/6609929/106353220-987e8180-62f1-11eb-8db4-118c08c3d4d5.png)
This call is failing with "Ambiguous between `Task` and `ValueTask` error", since we don't have 
` IAsyncCommand<TExecute, TCanExecute> Create<TExecute, TCanExecute>(Func<TExecute, Task> executeTask)` overload.
Solution is to either add it or make `canExecute` parameter for `Create<TExecute, TCanExecute>` mandatory. It doesn't make sense to specify type for a parameter and not provide it. I decided to go with second option.
2) 
![image](https://user-images.githubusercontent.com/6609929/106353322-543fb100-62f2-11eb-9d42-a070a2b4e3e1.png)
If user provides some argument except `execute` and `canExecute` to `Create` with `execute` being async lambda, call becomes ambiguous. Solution is to either create another 20 overloads to cover all possible parameter combinations or to rename `execute` parameter for `IAsyncCommand` and `IAsyncValueCommand` to have two different names, so that user could do this:
![image](https://user-images.githubusercontent.com/6609929/106353399-fbbce380-62f2-11eb-9b8d-e0e412368d59.png)

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #798

### API Changes ###

- Made `canExecute` parameter for `Create<TExecute, TCanExecute>` mandatory
- Renamed `execute` parameter for `IAsyncCommand` and `IAsyncValueCommand`

### Behavioral Changes ###

Less ambiguity warnings when calling `CommandFactory.Create`

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
