### PR TITLE
[Android] TouchEffect NativeAnimation triggered twice

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
@@ -74,24 +74,23 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			View.LongClickable = true;
 			CreateRipple();
 
-			if (Group != null)
+			if (Group == null)
 			{
-				rippleView = new FrameLayout(Group.Context)
-				{
-					LayoutParameters = new ViewGroup.LayoutParams(-1, -1),
-					Clickable = false,
-					Focusable = false,
-				};
-				View.LayoutChange += OnLayoutChange;
-				rippleView.Background = ripple;
-				Group.AddView(rippleView);
-				rippleView.BringToFront();
+				View.Foreground = ripple;
+				return;
 			}
-			else if (Build.VERSION.SdkInt >= BuildVersionCodes.M)
+
+			rippleView = new FrameLayout(Group.Context)
 			{
-				rippleView = View;
-				rippleView.Foreground = ripple;
-			}
+				LayoutParameters = new ViewGroup.LayoutParams(-1, -1),
+				Clickable = false,
+				Focusable = false,
+				Enabled = false,
+			};
+			View.LayoutChange += OnLayoutChange;
+			rippleView.Background = ripple;
+			Group.AddView(rippleView);
+			rippleView.BringToFront();
 		}
 
 		protected override void OnDetached()
@@ -115,6 +114,9 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 					View.LayoutChange -= OnLayoutChange;
 					View.Touch -= OnTouch;
 					View.Click -= OnClick;
+
+					if (View.Foreground == ripple)
+						View.Foreground = null;
 				}
 
 				effect.Element = null;
@@ -123,16 +125,14 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 				if (rippleView != null)
 				{
 					rippleView.Pressed = false;
-					rippleView.Foreground = null;
 					rippleView.Background = null;
-					if (rippleView != View)
-					{
-						Group?.RemoveView(rippleView);
-						rippleView.Dispose();
-					}
+					Group?.RemoveView(rippleView);
+					rippleView.Dispose();
 					rippleView = null;
-					ripple?.Dispose();
 				}
+
+				ripple?.Dispose();
+				ripple = null;
 			}
 			catch (ObjectDisposedException)
 			{
@@ -295,10 +295,8 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			if (effect.CanExecute && effect.NativeAnimation && rippleView != null)
 			{
 				UpdateRipple();
-
-				if (rippleView != View)
-					rippleView.BringToFront();
-
+				rippleView.Enabled = true;
+				rippleView.BringToFront();
 				ripple.SetHotspot(x, y);
 				rippleView.Pressed = true;
 			}
@@ -310,21 +308,22 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 				return;
 
 			if (rippleView?.Pressed ?? false)
+			{
 				rippleView.Pressed = false;
+				rippleView.Enabled = false;
+			}
 		}
 
 		void CreateRipple()
 		{
-			var background = View?.Background;
+			var drawable = Group != null ? View?.Background : View?.Foreground;
+			var isEmptyDrawable = Element is Layout || drawable == null;
 
-			if (background is RippleDrawable)
-			{
-				ripple = (RippleDrawable)background.GetConstantState().NewDrawable();
-				return;
-			}
+			if (drawable is RippleDrawable)
+				ripple = (RippleDrawable)drawable.GetConstantState().NewDrawable();
+			else
+				ripple = new RippleDrawable(GetColorStateList(), isEmptyDrawable ? null : drawable, isEmptyDrawable ? new ColorDrawable(Color.White) : null);
 
-			var noBackground = Element is Layout || background == null;
-			ripple = new RippleDrawable(GetColorStateList(), noBackground ? null : background, noBackground ? new ColorDrawable(Color.White) : null);
 			UpdateRipple();
 		}
 
@@ -339,7 +338,7 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			rippleColor = effect.NativeAnimationColor;
 			rippleRadius = effect.NativeAnimationRadius;
 			ripple.SetColor(GetColorStateList());
-			if (AndroidOS.Build.VERSION.SdkInt >= AndroidOS.BuildVersionCodes.M)
+			if (Build.VERSION.SdkInt >= BuildVersionCodes.M)
 				ripple.Radius = (int)(View.Context.Resources.DisplayMetrics.Density * effect.NativeAnimationRadius);
 		}
 
@@ -357,14 +356,11 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 		void OnLayoutChange(object sender, AView.LayoutChangeEventArgs e)
 		{
 			var group = (ViewGroup)sender;
-			if (group == null || (Group as IVisualElementRenderer)?.Element == null)
+			if (group == null || (Group as IVisualElementRenderer)?.Element == null || rippleView == null)
 				return;
 
-			if (rippleView != null)
-			{
-				rippleView.Right = group.Width;
-				rippleView.Bottom = group.Height;
-			}
+			rippleView.Right = group.Width;
+			rippleView.Bottom = group.Height;
 		}
 
 		sealed class AccessibilityListener : Java.Lang.Object,


### PR DESCRIPTION
### Description of Change ###
We avoid the double "ripple" effect by setting overlay rippleView **Enabled** property to **False**. We set it to **True** only during manual ripple animation.

For those views which have RippleDrawable as Foreground, we don't start/end ripple animation manually anymore. It's done automatically

### Bugs Fixed ###
- Fixes #804 

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)


### Testing
Please try to replicate the bug with the proposed changes.
Also, make sure TouchEffect still works as expected.
