### PR TITLE
[Android] Fix SideMenuView + Slider issue

### DIFF
--- a/samples/XCT.Sample/Pages/Views/SideMenuViewPage.xaml
+++ b/samples/XCT.Sample/Pages/Views/SideMenuViewPage.xaml
@@ -16,29 +16,32 @@
 
     <xct:SideMenuView x:Name="SideMenuView">
         <!-- MainView -->
-        <StackLayout
-            Orientation="Horizontal"
-            BackgroundColor="Gold">
+        <StackLayout BackgroundColor="Gold">
+            <StackLayout
+                Orientation="Horizontal">
 
-            <Button Style="{StaticResource BaseMenuButtonStyle}"
-                    Clicked="OnLeftButtonClicked" />
+                <Button Style="{StaticResource BaseMenuButtonStyle}"
+                        Clicked="OnLeftButtonClicked" />
 
-            <Button Style="{StaticResource BaseMenuButtonStyle}"
-                    HorizontalOptions="EndAndExpand"
-                    Clicked="OnRightButtonClicked" />
+                <Button Style="{StaticResource BaseMenuButtonStyle}"
+                        HorizontalOptions="EndAndExpand"
+                        Clicked="OnRightButtonClicked" />
+
+            </StackLayout>
+            <Slider />
         </StackLayout>
 
         <!-- LeftMenu -->
         <BoxView
-            BackgroundColor="Orange"
             xct:SideMenuView.Position="LeftMenu"
-            xct:SideMenuView.MenuWidthPercentage=".5" />
+            xct:SideMenuView.MenuWidthPercentage=".5"
+            BackgroundColor="Orange"/>
 
         <!-- RightMenu -->
         <BoxView
-            BackgroundColor="LightGreen"
             xct:SideMenuView.Position="RightMenu"
-            xct:SideMenuView.MenuWidthPercentage=".3" />
+            xct:SideMenuView.MenuWidthPercentage=".3"
+            BackgroundColor="LightGreen" />
 
     </xct:SideMenuView>
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
@@ -94,7 +94,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				_ = new Xamarin.CommunityToolkit.Android.UI.Views.SideMenuViewRenderer(null);
 #elif __IOS__
 			if (System.DateTime.Now.Ticks < 0)
-				_ = new Xamarin.CommunityToolkit.iOS.UI.Views.SideMenuViewRenderer(null);
+				_ = new Xamarin.CommunityToolkit.iOS.UI.Views.SideMenuViewRenderer();
 #endif
 		}
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
@@ -67,7 +67,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			= BindableProperty.Create(nameof(CurrentGestureShift), typeof(double), typeof(SideMenuView), 0.0, BindingMode.OneWayToSource);
 
 		public static readonly BindableProperty GestureThresholdProperty
-			= BindableProperty.Create(nameof(GestureThreshold), typeof(double), typeof(SideMenuView), 7.0);
+			= BindableProperty.Create(nameof(GestureThreshold), typeof(double), typeof(SideMenuView), -1.0);
 
 		public static readonly BindableProperty CancelVerticalGestureThresholdProperty
 			= BindableProperty.Create(nameof(CancelVerticalGestureThreshold), typeof(double), typeof(SideMenuView), 1.0);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
@@ -72,9 +72,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		public static readonly BindableProperty CancelVerticalGestureThresholdProperty
 			= BindableProperty.Create(nameof(CancelVerticalGestureThreshold), typeof(double), typeof(SideMenuView), 1.0);
 
-		public static readonly BindableProperty AllowInterceptGestureProperty
-			= BindableProperty.Create(nameof(AllowInterceptGesture), typeof(bool), typeof(SideMenuView), false);
-
 		public static readonly BindableProperty StateProperty
 			= BindableProperty.Create(nameof(State), typeof(SideMenuState), typeof(SideMenuView), SideMenuState.MainViewShown, BindingMode.TwoWay, propertyChanged: OnStatePropertyChanged);
 
@@ -89,6 +86,63 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		public static readonly BindableProperty MenuGestureEnabledProperty
 			= BindableProperty.CreateAttached(nameof(GetMenuGestureEnabled), typeof(bool), typeof(SideMenuView), true);
+
+		public new ISideMenuList<View> Children
+			=> children;
+
+		public double Shift
+		{
+			get => (double)GetValue(ShiftProperty);
+			set => SetValue(ShiftProperty, value);
+		}
+
+		public double CurrentGestureShift
+		{
+			get => (double)GetValue(CurrentGestureShiftProperty);
+			set => SetValue(CurrentGestureShiftProperty, value);
+		}
+
+		public double GestureThreshold
+		{
+			get => (double)GetValue(GestureThresholdProperty);
+			set => SetValue(GestureThresholdProperty, value);
+		}
+
+		public double CancelVerticalGestureThreshold
+		{
+			get => (double)GetValue(CancelVerticalGestureThresholdProperty);
+			set => SetValue(CancelVerticalGestureThresholdProperty, value);
+		}
+
+		public SideMenuState State
+		{
+			get => (SideMenuState)GetValue(StateProperty);
+			set => SetValue(StateProperty, value);
+		}
+
+		public SideMenuState CurrentGestureState
+		{
+			get => (SideMenuState)GetValue(CurrentGestureStateProperty);
+			set => SetValue(CurrentGestureStateProperty, value);
+		}
+
+		public static SideMenuPosition GetPosition(BindableObject bindable)
+			=> (SideMenuPosition)bindable.GetValue(PositionProperty);
+
+		public static void SetPosition(BindableObject bindable, SideMenuPosition value)
+			=> bindable.SetValue(PositionProperty, value);
+
+		public static double GetMenuWidthPercentage(BindableObject bindable)
+			=> (double)bindable.GetValue(MenuWidthPercentageProperty);
+
+		public static void SetMenuWidthPercentage(BindableObject bindable, double value)
+			=> bindable.SetValue(MenuWidthPercentageProperty, value);
+
+		public static bool GetMenuGestureEnabled(BindableObject bindable)
+			=> (bool)bindable.GetValue(MenuGestureEnabledProperty);
+
+		public static void SetMenuGestureEnabled(BindableObject bindable, bool value)
+			=> bindable.SetValue(MenuGestureEnabledProperty, value);
 
 		internal void OnPanUpdated(object sender, PanUpdatedEventArgs e)
 		{
@@ -122,68 +176,13 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			UpdateState(state, true);
 		}
 
-		public new ISideMenuList<View> Children
-			=> children;
-
-		public double Shift
-		{
-			get => (double)GetValue(ShiftProperty);
-			set => SetValue(ShiftProperty, value);
-		}
-
-		public double CurrentGestureShift
-		{
-			get => (double)GetValue(CurrentGestureShiftProperty);
-			set => SetValue(CurrentGestureShiftProperty, value);
-		}
-
-		public double GestureThreshold
-		{
-			get => (double)GetValue(GestureThresholdProperty);
-			set => SetValue(GestureThresholdProperty, value);
-		}
-
-		public double CancelVerticalGestureThreshold
-		{
-			get => (double)GetValue(CancelVerticalGestureThresholdProperty);
-			set => SetValue(CancelVerticalGestureThresholdProperty, value);
-		}
-
-		public bool AllowInterceptGesture
-		{
-			get => (bool)GetValue(AllowInterceptGestureProperty);
-			set => SetValue(AllowInterceptGestureProperty, value);
-		}
-
-		public SideMenuState State
-		{
-			get => (SideMenuState)GetValue(StateProperty);
-			set => SetValue(StateProperty, value);
-		}
-
-		public SideMenuState CurrentGestureState
-		{
-			get => (SideMenuState)GetValue(CurrentGestureStateProperty);
-			set => SetValue(CurrentGestureStateProperty, value);
-		}
-
-		public static SideMenuPosition GetPosition(BindableObject bindable)
-			=> (SideMenuPosition)bindable.GetValue(PositionProperty);
-
-		public static void SetPosition(BindableObject bindable, SideMenuPosition value)
-			=> bindable.SetValue(PositionProperty, value);
-
-		public static double GetMenuWidthPercentage(BindableObject bindable)
-			=> (double)bindable.GetValue(MenuWidthPercentageProperty);
-
-		public static void SetMenuWidthPercentage(BindableObject bindable, double value)
-			=> bindable.SetValue(MenuWidthPercentageProperty, value);
-
-		public static bool GetMenuGestureEnabled(BindableObject bindable)
-			=> (bool)bindable.GetValue(MenuGestureEnabledProperty);
-
-		public static void SetMenuGestureEnabled(BindableObject bindable, bool value)
-			=> bindable.SetValue(MenuGestureEnabledProperty, value);
+		internal bool CheckGestureEnabled(SideMenuPosition menuPosition)
+			=> menuPosition switch
+			{
+				SideMenuPosition.LeftMenu => CheckMenuGestureEnabled(leftMenu),
+				SideMenuPosition.RightMenu => CheckMenuGestureEnabled(rightMenu),
+				_ => true
+			};
 
 		protected override void OnControlInitialized(AbsoluteLayout control)
 		{
@@ -548,5 +547,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			Control.RaiseChild(mainView);
 			Control.RaiseChild(overlayView);
 		}
+
+		bool CheckMenuGestureEnabled(View menuView)
+			=> menuView != null && GetMenuGestureEnabled(menuView);
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
@@ -87,6 +87,17 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		public static readonly BindableProperty MenuGestureEnabledProperty
 			= BindableProperty.CreateAttached(nameof(GetMenuGestureEnabled), typeof(bool), typeof(SideMenuView), true);
 
+		public SideMenuView()
+		{
+#if __ANDROID__
+			if (System.DateTime.Now.Ticks < 0)
+				_ = new Xamarin.CommunityToolkit.Android.UI.Views.SideMenuViewRenderer(null);
+#elif __IOS__
+			if (System.DateTime.Now.Ticks < 0)
+				_ = new Xamarin.CommunityToolkit.iOS.UI.Views.SideMenuViewRenderer(null);
+#endif
+		}
+
 		public new ISideMenuList<View> Children
 			=> children;
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuViewRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuViewRenderer.android.cs
@@ -12,7 +12,7 @@ using static System.Math;
 
 namespace Xamarin.CommunityToolkit.Android.UI.Views
 {
-	[Preserve(AllMembers = true)]
+	[Preserve(Conditional = true)]
 	public class SideMenuViewRenderer : VisualElementRenderer<SideMenuView>
 	{
 		const double defaultGestureThreshold = 30.0;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuViewRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuViewRenderer.android.cs
@@ -33,12 +33,6 @@ namespace Xamarin.CommunityToolkit.Android.UI.Views
 
 		public override bool OnInterceptTouchEvent(MotionEvent ev)
 		{
-			if (Element.AllowInterceptGesture)
-			{
-				base.OnInterceptTouchEvent(ev);
-				return false;
-			}
-
 			if (ev.ActionMasked == MotionEventActions.Move)
 			{
 				if (lastTouchHandlerId.HasValue && lastTouchHandlerId != elementId)
@@ -64,7 +58,7 @@ namespace Xamarin.CommunityToolkit.Android.UI.Views
 			}
 
 			HandleDownUpEvents(e);
-			return true;
+			return false;
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<SideMenuView> e)
@@ -81,7 +75,10 @@ namespace Xamarin.CommunityToolkit.Android.UI.Views
 		{
 			var xDeltaAbs = Abs(xDelta);
 			var yDeltaAbs = Abs(yDelta);
-			var isHandled = xDeltaAbs > yDeltaAbs && xDeltaAbs > Element.GestureThreshold;
+			var isHandled = xDeltaAbs > yDeltaAbs
+				&& xDeltaAbs > Element.GestureThreshold
+				&& ((xDelta > 0 && Element.CheckGestureEnabled(SideMenuPosition.LeftMenu))
+				|| (xDelta < 0 && Element.CheckGestureEnabled(SideMenuPosition.RightMenu)));
 
 			Parent?.RequestDisallowInterceptTouchEvent(isHandled);
 			return isHandled;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuViewRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuViewRenderer.android.cs
@@ -15,6 +15,8 @@ namespace Xamarin.CommunityToolkit.Android.UI.Views
 	[Preserve(AllMembers = true)]
 	public class SideMenuViewRenderer : VisualElementRenderer<SideMenuView>
 	{
+		const double defaultGestureThreshold = 30.0;
+
 		static Guid? lastTouchHandlerId;
 
 		readonly float density;
@@ -30,6 +32,10 @@ namespace Xamarin.CommunityToolkit.Android.UI.Views
 		public SideMenuViewRenderer(Context context)
 			: base(context)
 			=> density = context.Resources.DisplayMetrics.Density;
+
+		double GestureThreshold => Element.GestureThreshold >= 0
+			? Element.GestureThreshold
+			: defaultGestureThreshold;
 
 		public override bool OnInterceptTouchEvent(MotionEvent ev)
 		{
@@ -58,7 +64,7 @@ namespace Xamarin.CommunityToolkit.Android.UI.Views
 			}
 
 			HandleDownUpEvents(e);
-			return false;
+			return true;
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<SideMenuView> e)
@@ -76,7 +82,7 @@ namespace Xamarin.CommunityToolkit.Android.UI.Views
 			var xDeltaAbs = Abs(xDelta);
 			var yDeltaAbs = Abs(yDelta);
 			var isHandled = xDeltaAbs > yDeltaAbs
-				&& xDeltaAbs > Element.GestureThreshold
+				&& xDeltaAbs > GestureThreshold
 				&& ((xDelta > 0 && Element.CheckGestureEnabled(SideMenuPosition.LeftMenu))
 				|| (xDelta < 0 && Element.CheckGestureEnabled(SideMenuPosition.RightMenu)));
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuViewRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuViewRenderer.ios.cs
@@ -13,6 +13,8 @@ namespace Xamarin.CommunityToolkit.iOS.UI.Views
 	[Preserve(AllMembers = true)]
 	public class SideMenuViewRenderer : VisualElementRenderer<SideMenuView>
 	{
+		const double defaultGestureThreshold = 7.0;
+
 		UISwipeGestureRecognizer leftSwipeGestureRecognizer;
 
 		UISwipeGestureRecognizer rightSwipeGestureRecognizer;
@@ -32,7 +34,11 @@ namespace Xamarin.CommunityToolkit.iOS.UI.Views
 		}
 
 		bool IsPanGestureHandled
-			=> Abs(Element?.CurrentGestureShift ?? 0) >= Element?.GestureThreshold;
+			=> Element != null && Abs(Element.CurrentGestureShift) >= GestureThreshold;
+
+		double GestureThreshold => Element.GestureThreshold >= 0
+			? Element.GestureThreshold
+			: defaultGestureThreshold;
 
 		public override void AddGestureRecognizer(UIGestureRecognizer gestureRecognizer)
 		{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuViewRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuViewRenderer.ios.cs
@@ -10,7 +10,7 @@ using static System.Math;
 
 namespace Xamarin.CommunityToolkit.iOS.UI.Views
 {
-	[Preserve(AllMembers = true)]
+	[Preserve(Conditional = true)]
 	public class SideMenuViewRenderer : VisualElementRenderer<SideMenuView>
 	{
 		const double defaultGestureThreshold = 7.0;


### PR DESCRIPTION
### Description of Change ###

Fixed the issue when it was impossible to use Slider with SideMenu because SideMenu intercepted all gestures.

Removed redundant property ```public bool AllowInterceptGesture```.
Moved a couple of methods to the appropriate place in the file.
Refactored default gesture threshold value (it's -1.0 by default now. And each platform determines its own default value)


### Bugs Fixed ###
- Fixes #810

### API Changes ###
Removed:
property ```bool AllowInterceptGesture``` (it was not helpful and I am pretty sure was not used).

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
