### PR TITLE
Fixed crash in Popup sample

### DIFF
--- a/samples/XCT.Sample/Pages/Views/Popups/PopupAnchorPage.xaml
+++ b/samples/XCT.Sample/Pages/Views/Popups/PopupAnchorPage.xaml
@@ -46,7 +46,7 @@
             </Label>
             <Button Text="Show Popup"
                     Command="{Binding ShowPopup}"
-                    CommandParameter="{x:Reference indicator}"/>
+                    CommandParameter="{x:Reference Indicator}"/>
         </StackLayout>
     </ContentPage.Content>
 


### PR DESCRIPTION
### Description of Change ###

While going through the samples of our shiny new popups, the anchor one crashed at runtime. This because there was a mismatch in casing. Fixed it by changing a whopping 1 character.

### Bugs Fixed ###
NA

### API Changes ###
NA

### Behavioral Changes ###

Anchor Popup sample now works!

### PR Checklist ###
NA
