### PR TITLE
Popup out of the screen horizontally in Android sample

### DIFF
--- a/samples/XCT.Sample/Pages/Views/Popups/PopupSize.cs
+++ b/samples/XCT.Sample/Pages/Views/Popups/PopupSize.cs
@@ -1,17 +1,13 @@
 ﻿using Xamarin.Forms;
-using Xamarin.Essentials;
 
 namespace Xamarin.CommunityToolkit.Sample.Pages.Views.Popups
 {
 	static class PopupSize
 	{
-		public static Size Android => new Size(0.9 * DeviceDisplay.MainDisplayInfo.Width,
-									   0.6 * DeviceDisplay.MainDisplayInfo.Height);
+		public static Size Android => new Size(1000, 1200);
 
-		public static Size iOS => new Size(0.9 * DeviceDisplay.MainDisplayInfo.Width,
-									   0.6 * DeviceDisplay.MainDisplayInfo.Height);
-
-		public static Size UWP => new Size(0.9 * DeviceDisplay.MainDisplayInfo.Width,
-									   0.6 * DeviceDisplay.MainDisplayInfo.Height);
+ 		public static Size iOS => new Size(250, 350);
+		
+		public static Size UWP => new Size(300, 400);
 	}
 }

--- a/samples/XCT.Sample/Pages/Views/Popups/PopupSize.cs
+++ b/samples/XCT.Sample/Pages/Views/Popups/PopupSize.cs
@@ -1,4 +1,5 @@
 ﻿using Xamarin.Forms;
+using Xamarin.Essentials;
 
 namespace Xamarin.CommunityToolkit.Sample.Pages.Views.Popups
 {

--- a/samples/XCT.Sample/Pages/Views/Popups/PopupSize.cs
+++ b/samples/XCT.Sample/Pages/Views/Popups/PopupSize.cs
@@ -4,10 +4,13 @@ namespace Xamarin.CommunityToolkit.Sample.Pages.Views.Popups
 {
 	static class PopupSize
 	{
-		public static Size Android => new Size(1000, 1200);
+		public static Size Android => new Size(0.9 * DeviceDisplay.MainDisplayInfo.Width,
+									   0.6 * DeviceDisplay.MainDisplayInfo.Height);
 
-		public static Size iOS => new Size(250, 350);
+		public static Size iOS => new Size(0.9 * DeviceDisplay.MainDisplayInfo.Width,
+									   0.6 * DeviceDisplay.MainDisplayInfo.Height);
 
-		public static Size UWP => new Size(300, 400);
+		public static Size UWP => new Size(0.9 * DeviceDisplay.MainDisplayInfo.Width,
+									   0.6 * DeviceDisplay.MainDisplayInfo.Height);
 	}
 }

--- a/samples/XCT.Sample/Pages/Views/Popups/PopupSize.cs
+++ b/samples/XCT.Sample/Pages/Views/Popups/PopupSize.cs
@@ -4,7 +4,7 @@ namespace Xamarin.CommunityToolkit.Sample.Pages.Views.Popups
 {
 	static class PopupSize
 	{
-		public static Size Android => new Size(1200, 1000);
+		public static Size Android => new Size(1000, 1200);
 
 		public static Size iOS => new Size(250, 350);
 


### PR DESCRIPTION
https://github.com/xamarin/XamarinCommunityToolkit/pull/653#issuecomment-757399625
Popup was getting out of screen bound horizontally in Android Sample.

### Description of Change ###

Swap Width and Height values of the Android sample.

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
