### PR TITLE
Added inline docs for MaxLengthReachedBehavior

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/MaxLengthReachedBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/MaxLengthReachedBehavior.shared.cs
@@ -7,20 +7,35 @@ using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Behaviors
 {
+	/// <summary>
+	/// The <see cref="MaxLengthReachedBehavior"/> is a behavior that allows the user to trigger an action when a user has reached the maximum length allowed on an <see cref="InputView"/>. It can either trigger a <see cref="ICommand"/> or an event depending on the user's preferred scenario.
+	/// </summary>
 	public class MaxLengthReachedBehavior : BaseBehavior<InputView>
 	{
+		/// <summary>
+		/// Backing BindableProperty for the <see cref="Command"/> property.
+		/// </summary>
 		public static readonly BindableProperty CommandProperty
 			= BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(MaxLengthReachedBehavior));
 
+		/// <summary>
+		/// Command that is triggered when the value configured in <see cref="InputView.MaxLength" /> is reached. Both the <see cref="MaxLengthReached"/> event and this command are triggered. This is a bindable property.
+		/// </summary>
 		public ICommand Command
 		{
 			get => (ICommand)GetValue(CommandProperty);
 			set => SetValue(CommandProperty, value);
 		}
 
+		/// <summary>
+		/// Backing BindableProperty for the <see cref="ShouldDismissKeyboardAutomatically"/> property.
+		/// </summary>
 		public static readonly BindableProperty ShouldDismissKeyboardAutomaticallyProperty
 			= BindableProperty.Create(nameof(ShouldDismissKeyboardAutomatically), typeof(bool), typeof(MaxLengthReachedBehavior), false);
 
+		/// <summary>
+		/// Indicates whether or not the keyboard should be dismissed automatically after the maximum length is reached. This is a bindable property.
+		/// </summary>
 		public bool ShouldDismissKeyboardAutomatically
 		{
 			get => (bool)GetValue(ShouldDismissKeyboardAutomaticallyProperty);
@@ -29,6 +44,9 @@ namespace Xamarin.CommunityToolkit.Behaviors
 
 		readonly WeakEventManager<MaxLengthReachedEventArgs> maxLengthReachedEventManager = new WeakEventManager<MaxLengthReachedEventArgs>();
 
+		/// <summary>
+		/// Event that is triggered when the value configured in <see cref="InputView.MaxLength" /> is reached. Both the <see cref="Command"/> and this event are triggered. This is a bindable property.
+		/// </summary>
 		public event EventHandler<MaxLengthReachedEventArgs> MaxLengthReached
 		{
 			add => maxLengthReachedEventManager.AddEventHandler(value);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/MaxLengthReachedEventArgs.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/MaxLengthReachedEventArgs.shared.cs
@@ -2,10 +2,20 @@
 
 namespace Xamarin.CommunityToolkit.Behaviors
 {
+	/// <summary>
+	/// Container object for the event arguments that are provided when the <see cref="MaxLengthReachedBehavior.MaxLengthReached"/> event is triggered.
+	/// </summary>
 	public class MaxLengthReachedEventArgs : EventArgs
 	{
+		/// <summary>
+		/// The new text value as determined by the <see cref="MaxLengthReachedBehavior"/>
+		/// </summary>
 		public string Text { get; }
 
+		/// <summary>
+		/// Constructor to create a new instance of <see cref="MaxLengthReachedEventArgs"/>.
+		/// </summary>
+		/// <param name="text">The new text value as determined by the <see cref="MaxLengthReachedBehavior"/></param>
 		public MaxLengthReachedEventArgs(string text)
 			=> Text = text;
 	}


### PR DESCRIPTION
### Description of Change ###

Added comments/docs for MaxLengthReachedBehavior and MaxLengthReachedEventArgs

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Related #76 

### API Changes ###

NA

### Behavioral Changes ###

People will be able to enjoy the marvellous inline IntelliSense!

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
