### PR TITLE
Fix camera media rotation android issue

### DIFF
--- a/samples/XCT.Sample/Pages/Views/CameraViewPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Views/CameraViewPage.xaml.cs
@@ -75,6 +75,7 @@ namespace Xamarin.CommunityToolkit.Sample.Pages.Views
 				case CameraCaptureMode.Default:
 				case CameraCaptureMode.Photo:
 					previewPicture.IsVisible = true;
+					previewPicture.Rotation = e.Rotation;
 					previewPicture.Source = e.Image;
 					doCameraThings.Text = "Snap Picture";
 					break;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/MediaCapturedEventArgs.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/MediaCapturedEventArgs.shared.cs
@@ -13,10 +13,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		internal MediaCapturedEventArgs(
 			string path = null,
-			byte[] imageData = null)
+			byte[] imageData = null,
+			double rotation = 0)
 		{
 			// Path = path;
 			this.path = path;
+			Rotation = rotation;
 			ImageData = imageData;
 			imageSource = new Lazy<ImageSource>(GetImageSource);
 			mediaSource = new Lazy<XCT.FileMediaSource>(GetMediaSource);
@@ -34,6 +36,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		/// Raw image data, only filled when taking a picture and SavePhotoToFile is false
 		/// </summary>
 		public byte[] ImageData { get; }
+
+		/// <summary>
+		/// Applied image rotation for correct orientation on Android devices
+		/// </summary>
+		public double Rotation { get; }
 
 		public ImageSource Image => imageSource.Value;
 


### PR DESCRIPTION
### Description of Change ###

This should fix issue with incorrectly rotated media capture on some Android devices. As [this](https://medium.com/@kenodoggy/solving-image-rotation-on-android-using-camera2-api-7b3ed3518ab6) article implies. The JPEG_ORIENTATION flag in CaptureRequest is effectively ignored in some devices and the Android docs also imply it will have varying effects across devices. 

See [Android docs](https://developer.android.com/reference/android/hardware/camera2/CaptureRequest.html#JPEG_ORIENTATION)
There are two points about the implementation I would like to elaborate on. Firstly the removal or the JPEG_ORIENTATION flag. I wasn't able to reliably determine (in code) across various devices (some with rotation issue some not) if the addition of the flag had rotated the capture data or modified the Exif info. I don't believe this flag is needed at all now. As we now calculate the correct rotation upon capture. If the JPEG_ORIENTATION flag has modified the capture data by rotation. Then we will be applying another rotation on top of that. If it hasn't then only our rotation will be applied. Either way I can't see an easy way to determine that. Setting any rotation value for this flag on certain devices will have **no effect**.
So with those assumptions, if the only purpose now of the JPEG_ORIENTATION flag is to modify the Exif orientation info. Then we can remove it and set the Exif information using the ExifInterface class when the SaveToFile implementation has been completed.

Secondly, the correct point to apply the capture rotation. I tried several methods of applying the rotation to the capture data (byte array) all with sub optimal performance. E.g. ByteArray -> Bitmap -> CreateBitmapRotateWithMatrix -> ByteArray. Also copying the pixel data to a ByteBuffer and looking at methods to rotate a Jpeg byte array. With the Forms side needing the data in ByteArray format I believe I have provided the best solution by passing the rotation in degrees with the MediaCaptureEventArgs. This allows the ImageView to handle the rotation in a performant way. Citing a post from StackOverflow. It is not the job of the camera view to change the orientation of the capture data (camera2 api) and I believe this to be true.

No samples or test changes required.

### Bugs Fixed ###
https://github.com/xamarin/XamarinCommunityToolkit/issues/751

### API Changes ###

None

Added: 
 
- `double MediaCapturedEventArgs.Rotation { get; }`
- `int CameraFragment.GetRotationCompensation();`

Changed:

 - `void CameraFragment.OnPhoto(object sender, Tuple<string, byte[]> tuple)` => `void CameraFragment.OnPhoto(object sender, Tuple<string, byte[], int> tuple)`



### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
