### PR TITLE
Add "Add(IEnumerable<T> collection)" to ObservableRangeCollection<T>

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableRangeCollection_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableRangeCollection_Tests.cs
@@ -180,5 +180,27 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 			// the collection should not be modified if the source items are not found
 			Assert.Equal(6, collection.Count);
 		}
+
+		class CollectionWrapper<T>
+		{
+			public readonly ObservableRangeCollection<T> Collection = new ObservableRangeCollection<T>();
+		}
+
+		[Fact]
+		public void AddCollection()
+		{
+			var toAdd = new[] { 3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 2, 3 };
+
+			var wrapper = new CollectionWrapper<int>()
+			{
+				Collection = { toAdd }
+			};
+
+			Assert.Equal(toAdd.Length, wrapper.Collection.Count);
+			for (var i = 0; i < toAdd.Length; i++)
+			{
+				Assert.Equal(toAdd[i], wrapper.Collection[i]);
+			}
+		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableRangeCollection_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableRangeCollection_Tests.cs
@@ -18,12 +18,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 			{
 				Assert.Equal(NotifyCollectionChangedAction.Add, e.Action);
 				Assert.Null(e.OldItems);
-				Assert.Equal(toAdd.Length, e.NewItems.Count);
-
-				for (var i = 0; i < toAdd.Length; i++)
-				{
-					Assert.Equal(toAdd[i], (int)e.NewItems[i]);
-				}
+				Assert.Equal(toAdd, e.NewItems);
 			};
 			collection.AddRange(toAdd);
 		}
@@ -130,7 +125,6 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 				}
 			};
 			collection.RemoveRange(toRemove, NotifyCollectionChangedAction.Remove);
-
 		}
 
 		[Fact]
@@ -196,11 +190,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 				Collection = { toAdd }
 			};
 
-			Assert.Equal(toAdd.Length, wrapper.Collection.Count);
-			for (var i = 0; i < toAdd.Length; i++)
-			{
-				Assert.Equal(toAdd[i], wrapper.Collection[i]);
-			}
+			Assert.Equal(toAdd, wrapper.Collection);
 		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableRangeCollection_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableRangeCollection_Tests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using Xamarin.CommunityToolkit.ObjectModel;
@@ -178,6 +179,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 		class CollectionWrapper<T>
 		{
 			public readonly ObservableRangeCollection<T> Collection = new ObservableRangeCollection<T>();
+			public ObservableRangeCollection<T> NullCollection;
 		}
 
 		[Fact]
@@ -191,6 +193,20 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 			};
 
 			Assert.Equal(toAdd, wrapper.Collection);
+		}
+
+		[Fact]
+		public void AddToNullCollection()
+		{
+			var toAdd = new[] { 3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 2, 3 };
+
+			Assert.Throws<ArgumentNullException>(() =>
+			{
+				var wrapper = new CollectionWrapper<int>()
+				{
+					NullCollection = { toAdd }
+				};
+			});
 		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/INotifyPropertyChangedExtension.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/INotifyPropertyChangedExtension.shared.cs
@@ -5,7 +5,7 @@ namespace Xamarin.CommunityToolkit.ObjectModel.Extensions
 {
 	public static class INotifyPropertyChangedExtension
 	{
-		public static void WeakSubscribe<T>(this INotifyPropertyChanged target, T subscriber, Action<T, object, EventArgs> action)
+		public static void WeakSubscribe<T>(this INotifyPropertyChanged target, T subscriber, Action<T, object, PropertyChangedEventArgs> action)
 		{
 			_ = target ?? throw new ArgumentNullException(nameof(target));
 			if (subscriber == null || action == null)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/INotifyPropertyChangedExtension.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/INotifyPropertyChangedExtension.shared.cs
@@ -5,7 +5,7 @@ namespace Xamarin.CommunityToolkit.ObjectModel.Extensions
 {
 	public static class INotifyPropertyChangedExtension
 	{
-		public static void WeakSubscribe<T>(this INotifyPropertyChanged target, T subscriber, Action<T, object, PropertyChangedEventArgs> action)
+		public static void WeakSubscribe<T>(this INotifyPropertyChanged target, T subscriber, Action<T, object, EventArgs> action)
 		{
 			_ = target ?? throw new ArgumentNullException(nameof(target));
 			if (subscriber == null || action == null)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/INotifyPropertyChangedExtension.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/INotifyPropertyChangedExtension.shared.cs
@@ -3,7 +3,7 @@ using System.ComponentModel;
 
 namespace Xamarin.CommunityToolkit.ObjectModel.Extensions
 {
-	public static class INotifyPropertyChangedEx
+	public static class INotifyPropertyChangedExtension
 	{
 		public static void WeakSubscribe<T>(this INotifyPropertyChanged target, T subscriber, Action<T, object, EventArgs> action)
 		{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/ObservableRangeCollectionEx.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/ObservableRangeCollectionEx.shared.cs
@@ -10,8 +10,6 @@ namespace Xamarin.CommunityToolkit.ObjectModel
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Add<T>(this ObservableRangeCollection<T> source, IEnumerable<T> collection)
-        {
-            source.AddRange(collection);
-        }
+            => source.AddRange(collection);
     }
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/ObservableRangeCollectionEx.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/ObservableRangeCollectionEx.shared.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace Xamarin.CommunityToolkit.ObjectModel
+{
+	public static class ObservableRangeCollectionEx
+    {
+        /// <summary>
+        /// To be used in collection initializer
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Add<T>(this ObservableRangeCollection<T> source, IEnumerable<T> collection)
+        {
+            source.AddRange(collection);
+        }
+    }
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/ObservableRangeCollectionExtension.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/ObservableRangeCollectionExtension.shared.cs
@@ -1,15 +1,20 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Xamarin.CommunityToolkit.ObjectModel
 {
-	public static class ObservableRangeCollectionEx
-    {
+	public static class ObservableRangeCollectionExtension
+	{
         /// <summary>
         /// To be used in collection initializer
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Add<T>(this ObservableRangeCollection<T> source, IEnumerable<T> collection)
-            => source.AddRange(collection);
+        {
+			_ = source ?? throw new ArgumentNullException(nameof(source));
+
+			source.AddRange(collection);
+        }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Added extension method to `ObservableRangeCollection` so that it can be initialized with another collection in collection initializer.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #756

### API Changes ###

`void Add<T>(this ObservableRangeCollection<T> source, IEnumerable<T> collection)`

### Behavioral Changes ###

`ObservableRangeCollection` now can be initialized with another collection in collection initializer:
```cs
EventTypes = new ListViewModel<EventType>()
{
    ItemsSource = { timetableInfo.EventTypes(lessonInfo.Lesson.ID).OrderBy(et => et.Entity.ShortName) }
};
```

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [x] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
