### PR TITLE
[Housekeeping] remove XamlCompilation from code-behind

### DIFF
--- a/samples/XCT.Sample/Pages/AboutPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/AboutPage.xaml.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Linq;
-using Octokit;
 using Xamarin.CommunityToolkit.Sample.ViewModels;
-using Xamarin.Essentials;
-using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Sample.Pages
 {

--- a/samples/XCT.Sample/Pages/Behaviors/ImpliedOrderGridBehaviorPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Behaviors/ImpliedOrderGridBehaviorPage.xaml.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Linq;
 using Xamarin.Forms;
-using Xamarin.Forms.Xaml;
 
 namespace Xamarin.CommunityToolkit.Sample.Pages.Behaviors
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class ImpliedOrderGridBehaviorPage
 	{
 		public ImpliedOrderGridBehaviorPage() => InitializeComponent();

--- a/samples/XCT.Sample/Pages/Behaviors/MaxLengthReachedBehaviorPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Behaviors/MaxLengthReachedBehaviorPage.xaml.cs
@@ -1,9 +1,7 @@
 ﻿using Xamarin.CommunityToolkit.Behaviors;
-using Xamarin.Forms.Xaml;
 
 namespace Xamarin.CommunityToolkit.Sample.Pages.Behaviors
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class MaxLengthReachedBehaviorPage : BasePage
 	{
 		public MaxLengthReachedBehaviorPage()

--- a/samples/XCT.Sample/Pages/Behaviors/RequiredStringValidationBehaviorPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Behaviors/RequiredStringValidationBehaviorPage.xaml.cs
@@ -1,8 +1,5 @@
-﻿using Xamarin.Forms.Xaml;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Behaviors
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Behaviors
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class RequiredStringValidationBehaviorPage : BasePage
 	{
 		public RequiredStringValidationBehaviorPage()

--- a/samples/XCT.Sample/Pages/Behaviors/UserStoppedTypingBehaviorPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Behaviors/UserStoppedTypingBehaviorPage.xaml.cs
@@ -1,8 +1,5 @@
-﻿using Xamarin.Forms.Xaml;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Behaviors
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Behaviors
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class UserStoppedTypingBehaviorPage : BasePage
 	{
 		public UserStoppedTypingBehaviorPage() => InitializeComponent();

--- a/samples/XCT.Sample/Pages/Converters/DateTimeOffsetConverterPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/DateTimeOffsetConverterPage.xaml.cs
@@ -1,8 +1,5 @@
-﻿using Xamarin.Forms.Xaml;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class DateTimeOffsetConverterPage : BasePage
 	{
 		public DateTimeOffsetConverterPage()

--- a/samples/XCT.Sample/Pages/Effects/EffectsGalleryPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Effects/EffectsGalleryPage.xaml.cs
@@ -1,8 +1,5 @@
-﻿using Xamarin.Forms.Xaml;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class EffectsGalleryPage
 	{
 		public EffectsGalleryPage() => InitializeComponent();

--- a/samples/XCT.Sample/Pages/Effects/IconTintColorEffectPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Effects/IconTintColorEffectPage.xaml.cs
@@ -1,8 +1,5 @@
-﻿using Xamarin.Forms.Xaml;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class IconTintColorEffectPage : BasePage
 	{
 		public IconTintColorEffectPage()

--- a/samples/XCT.Sample/Pages/Effects/RemoveBorderEffectPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Effects/RemoveBorderEffectPage.xaml.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Xamarin.Forms;
-using Xamarin.Forms.Xaml;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class RemoveBorderEffectPage
 	{
 		public RemoveBorderEffectPage() => InitializeComponent();

--- a/samples/XCT.Sample/Pages/Effects/SafeAreaEffectPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Effects/SafeAreaEffectPage.xaml.cs
@@ -1,9 +1,7 @@
 ﻿using Xamarin.CommunityToolkit.Effects;
-using Xamarin.Forms.Xaml;
 
 namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class SafeAreaEffectPage
 	{
 		public SafeAreaEffectPage() => InitializeComponent();

--- a/samples/XCT.Sample/Pages/Effects/SelectAllTextEffectPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Effects/SelectAllTextEffectPage.xaml.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Xamarin.Forms;
-using Xamarin.Forms.Xaml;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class SelectAllTextEffectPage
 	{
 		public SelectAllTextEffectPage() => InitializeComponent();

--- a/samples/XCT.Sample/Pages/Effects/TouchEffectPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Effects/TouchEffectPage.xaml.cs
@@ -1,10 +1,8 @@
 ﻿using System.Windows.Input;
 using Xamarin.Forms;
-using Xamarin.Forms.Xaml;
 
 namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class TouchEffectPage
 	{
 		public TouchEffectPage()


### PR DESCRIPTION
### Description of Change ###

`[XamlCompilation(XamlCompilationOptions.Compile)]` from Sample project code-behind pages, and keep only `[assembly: XamlCompilation(XamlCompilationOptions.Compile)]` in AssemblyInfo.cs

### Bugs Fixed ###
- Fixes #896

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
