### PR TITLE
Changed TabView SelectedIndex property to use TwoWay binding mode

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/TabView/TabView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/TabView/TabView.shared.cs
@@ -207,7 +207,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		}
 
 		public static readonly BindableProperty SelectedIndexProperty =
-			BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(TabView), -1,
+			BindableProperty.Create(nameof(SelectedIndex), typeof(int), typeof(TabView), -1, BindingMode.TwoWay,
 				propertyChanged: OnSelectedIndexChanged);
 
 		public int SelectedIndex


### PR DESCRIPTION
### Description of Change ###

Changed TabView SelectedIndex property to use TwoWay binding mode

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #870

### API Changes ###

Changed:

 - `int SelectedIndex` now use TwoWay Binding
 
### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
