### PR TITLE
[Breaking Changes] ValidationBehavior Async checks support

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/CharactersValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/CharactersValidationBehavior.shared.cs
@@ -65,7 +65,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			set => SetValue(MaximumCharacterCountProperty, value);
 		}
 
-		protected override async Task<bool> ValidateAsync(object value, CancellationToken token)
+		protected override async ValueTask<bool> ValidateAsync(object value, CancellationToken token)
 			=> await base.ValidateAsync(value, token) && Validate(value?.ToString());
 
 		static void OnCharacterTypePropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/CharactersValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/CharactersValidationBehavior.shared.cs
@@ -66,7 +66,8 @@ namespace Xamarin.CommunityToolkit.Behaviors
 		}
 
 		protected override async ValueTask<bool> ValidateAsync(object value, CancellationToken token)
-			=> await base.ValidateAsync(value, token) && Validate(value?.ToString());
+			=> await base.ValidateAsync(value, token).ConfigureAwait(false)
+				&& Validate(value?.ToString());
 
 		static void OnCharacterTypePropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/CharactersValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/CharactersValidationBehavior.shared.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Behaviors
@@ -39,8 +41,8 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			set => SetValue(MaximumCharacterCountProperty, value);
 		}
 
-		protected override bool Validate(object value)
-			=> base.Validate(value) && Validate(value?.ToString());
+		protected override async Task<bool> ValidateAsync(object value, CancellationToken token)
+			=> await base.ValidateAsync(value, token) && Validate(value?.ToString());
 
 		static void OnCharacterTypePropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/EmailValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/EmailValidationBehavior.shared.cs
@@ -18,14 +18,14 @@ namespace Xamarin.CommunityToolkit.Behaviors
 
 		protected override RegexOptions DefaultRegexOptions => RegexOptions.IgnoreCase;
 
-		protected override object DecorateValue()
+		protected override object Decorate(object value)
 		{
-			var value = base.DecorateValue()?.ToString();
+			var stringValue = base.Decorate(value)?.ToString();
 #if NETSTANDARD1_0
-			return value;
+			return stringValue;
 #else
-			if (string.IsNullOrWhiteSpace(value))
-				return value;
+			if (string.IsNullOrWhiteSpace(stringValue))
+				return stringValue;
 
 			try
 			{
@@ -40,11 +40,11 @@ namespace Xamarin.CommunityToolkit.Behaviors
 				}
 
 				// Normalize the domain
-				return normalizerRegex.Replace(value, DomainMapper);
+				return normalizerRegex.Replace(stringValue, DomainMapper);
 			}
 			catch (ArgumentException)
 			{
-				return value;
+				return stringValue;
 			}
 #endif
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/MultiValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/MultiValidationBehavior.shared.cs
@@ -64,12 +64,12 @@ namespace Xamarin.CommunityToolkit.Behaviors
 		public static void SetError(BindableObject bindable, object value)
 			=> bindable.SetValue(ErrorProperty, value);
 
-		protected override async Task<bool> ValidateAsync(object value, CancellationToken token)
+		protected override async ValueTask<bool> ValidateAsync(object value, CancellationToken token)
 		{
 			await Task.WhenAll(children.Select(c =>
 			{
 				c.Value = value;
-				return c.ValidateNestedAsync(token);
+				return c.ValidateNestedAsync(token).AsTask();
 			}));
 
 			if (token.IsCancellationRequested)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/MultiValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/MultiValidationBehavior.shared.cs
@@ -70,7 +70,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			{
 				c.Value = value;
 				return c.ValidateNestedAsync(token).AsTask();
-			}));
+			})).ConfigureAwait(false);
 
 			if (token.IsCancellationRequested)
 				return IsValid;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/NumericValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/NumericValidationBehavior.shared.cs
@@ -74,26 +74,26 @@ namespace Xamarin.CommunityToolkit.Behaviors
 		protected override object Decorate(object value)
 			=> base.Decorate(value)?.ToString()?.Trim();
 
-		protected override Task<bool> ValidateAsync(object value, CancellationToken token)
+		protected override ValueTask<bool> ValidateAsync(object value, CancellationToken token)
 		{
 			var valueString = value as string;
 			if (!(double.TryParse(valueString, out var numeric)
 				&& numeric >= MinimumValue
 				&& numeric <= MaximumValue))
-				return Task.FromResult(false);
+				return new ValueTask<bool>(false);
 
 			var decimalDelimeterIndex = valueString.IndexOf(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
 			var hasDecimalDelimeter = decimalDelimeterIndex >= 0;
 
 			// If MaximumDecimalPlaces equals zero, ".5" or "14." should be considered as invalid inputs.
 			if (hasDecimalDelimeter && MaximumDecimalPlaces == 0)
-				return Task.FromResult(false);
+				return new ValueTask<bool>(false);
 
 			var decimalPlaces = hasDecimalDelimeter
 				? valueString.Substring(decimalDelimeterIndex + 1, valueString.Length - decimalDelimeterIndex - 1).Length
 				: 0;
 
-			return Task.FromResult(
+			return new ValueTask<bool>(
 				decimalPlaces >= MinimumDecimalPlaces &&
 				decimalPlaces <= MaximumDecimalPlaces);
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/NumericValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/NumericValidationBehavior.shared.cs
@@ -1,4 +1,6 @@
 ﻿using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
 using Xamarin.CommunityToolkit.Behaviors.Internals;
 using Xamarin.Forms;
 
@@ -42,30 +44,31 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			set => SetValue(MaximumDecimalPlacesProperty, value);
 		}
 
-		protected override object DecorateValue()
-			=> base.DecorateValue()?.ToString()?.Trim();
+		protected override object Decorate(object value)
+			=> base.Decorate(value)?.ToString()?.Trim();
 
-		protected override bool Validate(object value)
+		protected override Task<bool> ValidateAsync(object value, CancellationToken token)
 		{
 			var valueString = value as string;
 			if (!(double.TryParse(valueString, out var numeric)
 				&& numeric >= MinimumValue
 				&& numeric <= MaximumValue))
-				return false;
+				return Task.FromResult(false);
 
 			var decimalDelimeterIndex = valueString.IndexOf(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
 			var hasDecimalDelimeter = decimalDelimeterIndex >= 0;
 
 			// If MaximumDecimalPlaces equals zero, ".5" or "14." should be considered as invalid inputs.
 			if (hasDecimalDelimeter && MaximumDecimalPlaces == 0)
-				return false;
+				return Task.FromResult(false);
 
 			var decimalPlaces = hasDecimalDelimeter
 				? valueString.Substring(decimalDelimeterIndex + 1, valueString.Length - decimalDelimeterIndex - 1).Length
 				: 0;
 
-			return decimalPlaces >= MinimumDecimalPlaces
-				&& decimalPlaces <= MaximumDecimalPlaces;
+			return Task.FromResult(
+				decimalPlaces >= MinimumDecimalPlaces &&
+				decimalPlaces <= MaximumDecimalPlaces);
 		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/RequiredStringValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/RequiredStringValidationBehavior.shared.cs
@@ -1,4 +1,6 @@
-﻿using Xamarin.CommunityToolkit.Behaviors.Internals;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Xamarin.CommunityToolkit.Behaviors.Internals;
 using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Behaviors
@@ -14,7 +16,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			set => SetValue(RequiredStringProperty, value);
 		}
 
-		protected override bool Validate(object value)
-			=> value?.ToString() == RequiredString;
+		protected override Task<bool> ValidateAsync(object value, CancellationToken token)
+			=> Task.FromResult(value?.ToString() == RequiredString);
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/RequiredStringValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/RequiredStringValidationBehavior.shared.cs
@@ -25,7 +25,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			set => SetValue(RequiredStringProperty, value);
 		}
 
-		protected override Task<bool> ValidateAsync(object value, CancellationToken token)
-			=> Task.FromResult(value?.ToString() == RequiredString);
+		protected override ValueTask<bool> ValidateAsync(object value, CancellationToken token)
+			=> new ValueTask<bool>(value?.ToString() == RequiredString);
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/TextValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/TextValidationBehavior.shared.cs
@@ -121,10 +121,10 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			return stringValue;
 		}
 
-		protected override Task<bool> ValidateAsync(object value, CancellationToken token)
+		protected override ValueTask<bool> ValidateAsync(object value, CancellationToken token)
 		{
 			var text = value?.ToString();
-			return Task.FromResult(
+			return new ValueTask<bool>(
 				text != null &&
 				text.Length >= MinimumLength &&
 				text.Length <= MaximumLength &&

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/TextValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/TextValidationBehavior.shared.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Xamarin.CommunityToolkit.Behaviors.Internals;
 using Xamarin.Forms;
 
@@ -63,39 +65,37 @@ namespace Xamarin.CommunityToolkit.Behaviors
 
 		protected virtual RegexOptions DefaultRegexOptions => RegexOptions.None;
 
-		protected override object DecorateValue()
+		protected override object Decorate(object value)
 		{
-			var value = base.DecorateValue()?.ToString();
+			var stringValue = base.Decorate(value)?.ToString();
 			var flags = DecorationFlags;
 
 			if (flags.HasFlag(TextDecorationFlags.NullToEmpty))
-				value ??= string.Empty;
+				stringValue ??= string.Empty;
 
-			if (value == null)
+			if (stringValue == null)
 				return null;
 
 			if (flags.HasFlag(TextDecorationFlags.TrimStart))
-				value = value.TrimStart();
+				stringValue = stringValue.TrimStart();
 
 			if (flags.HasFlag(TextDecorationFlags.TrimEnd))
-				value = value.TrimEnd();
+				stringValue = stringValue.TrimEnd();
 
 			if (flags.HasFlag(TextDecorationFlags.NormalizeWhiteSpace))
-				value = NormalizeWhiteSpace(value);
+				stringValue = NormalizeWhiteSpace(stringValue);
 
-			return value;
+			return stringValue;
 		}
 
-		protected override bool Validate(object value)
+		protected override Task<bool> ValidateAsync(object value, CancellationToken token)
 		{
 			var text = value?.ToString();
-			if (text == null)
-				return false;
-
-			var length = text.Length;
-			return length >= MinimumLength &&
-				length <= MaximumLength &&
-				(regex?.IsMatch(text) ?? false);
+			return Task.FromResult(
+				text != null &&
+				text.Length >= MinimumLength &&
+				text.Length <= MaximumLength &&
+				(regex?.IsMatch(text) ?? false));
 		}
 
 		static void OnRegexPropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/UriValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/UriValidationBehavior.shared.cs
@@ -25,7 +25,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			set => SetValue(UriKindProperty, value);
 		}
 
-		protected override async Task<bool> ValidateAsync(object value, CancellationToken token)
+		protected override async ValueTask<bool> ValidateAsync(object value, CancellationToken token)
 			=> await base.ValidateAsync(value, token)
 				&& Uri.IsWellFormedUriString(value?.ToString(), UriKind);
 	}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/UriValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/UriValidationBehavior.shared.cs
@@ -26,7 +26,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 		}
 
 		protected override async ValueTask<bool> ValidateAsync(object value, CancellationToken token)
-			=> await base.ValidateAsync(value, token)
+			=> await base.ValidateAsync(value, token).ConfigureAwait(false)
 				&& Uri.IsWellFormedUriString(value?.ToString(), UriKind);
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/UriValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/UriValidationBehavior.shared.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Behaviors
@@ -14,8 +16,8 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			set => SetValue(UriKindProperty, value);
 		}
 
-		protected override bool Validate(object value)
-			=> base.Validate(value)
+		protected override async Task<bool> ValidateAsync(object value, CancellationToken token)
+			=> await base.ValidateAsync(value, token)
 				&& Uri.IsWellFormedUriString(value?.ToString(), UriKind);
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/ValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/ValidationBehavior.shared.cs
@@ -25,7 +25,7 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 
 		/// <summary>
 		/// Backing BindableProperty for the <see cref="IsRunning"/> property.
-		/// </summary>			
+		/// </summary>
 		public static readonly BindableProperty IsRunningProperty =
 			BindableProperty.Create(nameof(IsRunning), typeof(bool), typeof(ValidationBehavior), false, BindingMode.OneWayToSource);
 
@@ -163,11 +163,11 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 		/// </summary>
 		public void ForceValidate() => _ = UpdateStateAsync(true);
 
-		internal Task ValidateNestedAsync(CancellationToken token) => UpdateStateAsync(true, token);
+		internal ValueTask ValidateNestedAsync(CancellationToken token) => UpdateStateAsync(true, token);
 
 		protected virtual object Decorate(object value) => value;
 
-		protected abstract Task<bool> ValidateAsync(object value, CancellationToken token);
+		protected abstract ValueTask<bool> ValidateAsync(object value, CancellationToken token);
 
 		protected override void OnAttachedTo(VisualElement bindable)
 		{
@@ -253,7 +253,7 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 			SetBinding(ValueProperty, defaultValueBinding);
 		}
 
-		async Task UpdateStateAsync(bool isForced, CancellationToken? parentToken = null)
+		async ValueTask UpdateStateAsync(bool isForced, CancellationToken? parentToken = null)
 		{
 			IsRunning = true;
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/ValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/ValidationBehavior.shared.cs
@@ -255,15 +255,16 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 
 		async ValueTask UpdateStateAsync(bool isForced, CancellationToken? parentToken = null)
 		{
-			IsRunning = true;
-
 			if ((View?.IsFocused ?? false) && Flags.HasFlag(ValidationFlags.ForceMakeValidWhenFocused))
 			{
+				IsRunning = true;
 				ResetValidationTokenSource(null);
 				IsValid = true;
+				IsRunning = false;
 			}
 			else if (isForced || (currentStatus != ValidationFlags.None && Flags.HasFlag(currentStatus)))
 			{
+				IsRunning = true;
 				using var tokenSource = new CancellationTokenSource();
 				var token = parentToken ?? tokenSource.Token;
 				ResetValidationTokenSource(tokenSource);
@@ -277,6 +278,7 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 
 					validationTokenSource = null;
 					IsValid = isValid;
+					IsRunning = false;
 				}
 				catch (TaskCanceledException)
 				{
@@ -285,7 +287,6 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 			}
 
 			UpdateStyle();
-			IsRunning = false;
 		}
 
 		void UpdateStyle()

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/ValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/ValidationBehavior.shared.cs
@@ -270,7 +270,7 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 
 				try
 				{
-					var isValid = await ValidateAsync(Decorate(Value), token);
+					var isValid = await ValidateAsync(Decorate(Value), token).ConfigureAwait(false);
 
 					if (token.IsCancellationRequested)
 						return;


### PR DESCRIPTION
### Description of Change ###
We are eager to allow using ValidationBehavior in async validations. (For example, make a request to the Server Side).

### Bugs Fixed ###
- Fixes #857

### API Changes ###

Added:
- ```public bool ValidationBehavior.IsRunning { get; set; }```
- ```protected Task<bool> ValidateAsync(object value, CancellationToken token);```
- ```protected object Decorate (object value);```

Removed:
- ```protected bool Validate (object value);```
- ```protected object DecorateValue ();```


### Behavioral Changes ###
None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
