### PR TITLE
Make WeakSubscribe<T>(this INotifyPropertyChanged target..) EventArgs parameter type more specific

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/INotifyPropertyChangedEx.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Extensions/INotifyPropertyChangedEx.shared.cs
@@ -5,7 +5,7 @@ namespace Xamarin.CommunityToolkit.ObjectModel.Extensions
 {
 	public static class INotifyPropertyChangedEx
 	{
-		public static void WeakSubscribe<T>(this INotifyPropertyChanged target, T subscriber, Action<T, object, EventArgs> action)
+		public static void WeakSubscribe<T>(this INotifyPropertyChanged target, T subscriber, Action<T, object, PropertyChangedEventArgs> action)
 		{
 			_ = target ?? throw new ArgumentNullException(nameof(target));
 			if (subscriber == null || action == null)


### PR DESCRIPTION
### Description of Change ###

Made WeakSubscribe<T>(this INotifyPropertyChanged target..) EventArgs parameter type more specific (`EventArgs` -> `PropertyChangedEventArgs`).
It was `PropertyChangedEventArgs` from the beginning, but got upcasted by mistake. 

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #917

### API Changes ###

Was `WeakSubscribe<T>(this INotifyPropertyChanged target, T subscriber, Action<T, object, EventArgs> action)`
Now `WeakSubscribe<T>(this INotifyPropertyChanged target, T subscriber, Action<T, object, PropertyChangedEventArgs> action)`

### Behavioral Changes ###

Users can now reference `PropertyName` when using `WeakSubscribe`

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
