### PR TITLE
Add null checks to first extension method argument

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Extensions/PageExtension.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Extensions/PageExtension.shared.cs
@@ -12,6 +12,8 @@ namespace Xamarin.CommunityToolkit.Extensions
 	{
 		public static Task DisplayToastAsync(this Page page, string message, int durationMilliseconds = 3000)
 		{
+			_ = page ?? throw new ArgumentNullException(nameof(page));
+
 			var messageOptions = new MessageOptions { Message = message };
 			var args = new SnackBarOptions
 			{
@@ -30,6 +32,8 @@ namespace Xamarin.CommunityToolkit.Extensions
 
 		public static Task DisplayToastAsync(this Page page, ToastOptions toastOptions)
 		{
+			_ = page ?? throw new ArgumentNullException(nameof(page));
+
 			var snackBar = new SnackBar();
 			var arguments = toastOptions ?? new ToastOptions();
 			var options = new SnackBarOptions
@@ -45,6 +49,8 @@ namespace Xamarin.CommunityToolkit.Extensions
 
 		public static Task<bool> DisplaySnackBarAsync(this Page page, string message, string actionButtonText, Func<Task> action, int durationMilliseconds = 3000)
 		{
+			_ = page ?? throw new ArgumentNullException(nameof(page));
+
 			var messageOptions = new MessageOptions { Message = message };
 			var actionOptions = new List<SnackBarActionOptions>
 			{
@@ -71,6 +77,8 @@ namespace Xamarin.CommunityToolkit.Extensions
 
 		public static Task<bool> DisplaySnackBarAsync(this Page page, SnackBarOptions snackBarOptions)
 		{
+			_ = page ?? throw new ArgumentNullException(nameof(page));
+
 			var snackBar = new SnackBar();
 			var arguments = snackBarOptions ?? new SnackBarOptions();
 			snackBar.Show(page, arguments);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Extensions/VisualElementExtension.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Extensions/VisualElementExtension.shared.cs
@@ -8,6 +8,8 @@ namespace Xamarin.CommunityToolkit.Extensions
 	{
 		public static Task<bool> ColorTo(this VisualElement element, Color color, uint length = 250u, Easing easing = null)
 		{
+			_ = element ?? throw new ArgumentNullException(nameof(element));
+
 			var animationCompletionSource = new TaskCompletionSource<bool>();
 			new Animation
 			{
@@ -21,6 +23,8 @@ namespace Xamarin.CommunityToolkit.Extensions
 
 		public static void AbortAnimations(this VisualElement element, params string[] otherAnimationNames)
 		{
+			_ = element ?? throw new ArgumentNullException(nameof(element));
+
 			ViewExtensions.CancelAnimations(element);
 			element.AbortAnimation(nameof(ColorTo));
 
@@ -33,6 +37,8 @@ namespace Xamarin.CommunityToolkit.Extensions
 
 		internal static bool TryFindParentElementWithParentOfType<T>(this VisualElement element, out VisualElement result, out T parent) where T : VisualElement
 		{
+			_ = element ?? throw new ArgumentNullException(nameof(element));
+
 			result = null;
 			parent = null;
 			while (element.Parent != null)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/WeakEventManager.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/WeakEventManager.shared.cs
@@ -121,6 +121,11 @@ namespace Xamarin.CommunityToolkit.Helpers
 		/// <param name="sender">Sender</param>
 		/// <param name="eventArgs">Event arguments</param>
 		/// <param name="eventName">Event name</param>
-		public static void RaiseEvent(this Forms.WeakEventManager weakEventManager, object sender, object eventArgs, string eventName) => weakEventManager.HandleEvent(sender, eventArgs, eventName);
+		public static void RaiseEvent(this Forms.WeakEventManager weakEventManager, object sender, object eventArgs, string eventName)
+		{
+			_ = weakEventManager ?? throw new ArgumentNullException(nameof(weakEventManager));
+
+			weakEventManager.HandleEvent(sender, eventArgs, eventName);
+		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/WeakEventManagerService.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/WeakEventManagerService.shared.cs
@@ -171,6 +171,8 @@ namespace Xamarin.CommunityToolkit.Helpers
 
 		static bool IsLightweightMethod(this MethodBase method)
 		{
+			_ = method ?? throw new ArgumentNullException(nameof(method));
+
 			var typeInfoRTDynamicMethod = typeof(DynamicMethod).GetTypeInfo().GetDeclaredNestedType("RTDynamicMethod");
 			return method is DynamicMethod || (typeInfoRTDynamicMethod?.IsAssignableFrom(method.GetType().GetTypeInfo()) ?? false);
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/TabView/LayoutExtensions.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/TabView/LayoutExtensions.shared.cs
@@ -1,10 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.UI.Views
 {
 	public static class LayoutExtensions
 	{
-		public static IReadOnlyList<Element> GetChildren(this ILayoutController source) => source.Children;
+		public static IReadOnlyList<Element> GetChildren(this ILayoutController source)
+		{
+			_ = source ?? throw new ArgumentNullException(nameof(source));
+
+			return source.Children;
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This is more a preference thing, so feel free to reject this PR.
Checking all arguments would be better, but I think at least first one should be checked.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #944

### API Changes ###

None

### Behavioral Changes ###

Extension methods will throw `ArgumentNullException` instead of `NullReferenceException` if first argument is null

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
