### PR TITLE
Don't thrown when tap/selected is null, return null. For deselect.

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ItemSelectedEventArgsConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ItemSelectedEventArgsConverter_Tests.cs
@@ -15,9 +15,10 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 		{
             // We know it's deprecated, still good to test it
 #pragma warning disable CS0618 // Type or member is obsolete
-            new object[] { new SelectedItemChangedEventArgs(expectedValue), expectedValue},
+            new object[] { new SelectedItemChangedEventArgs(expectedValue), expectedValue },
+			new object[] { null, null },
 #pragma warning restore CS0618 // Type or member is obsolete
-        };
+		};
 
 		[Theory]
 		[MemberData(nameof(GetData))]

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ItemTappedEventArgsConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ItemTappedEventArgsConverter_Tests.cs
@@ -15,9 +15,10 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 			{
             // We know it's deprecated, still good to test it
 #pragma warning disable CS0618 // Type or member is obsolete
-                new object[] { new ItemTappedEventArgs(null, expectedValue), expectedValue},
+                new object[] { new ItemTappedEventArgs(null, expectedValue), expectedValue },
+                new object[] { new ItemTappedEventArgs(null, null), null },
 #pragma warning restore CS0618 // Type or member is obsolete
-            };
+			};
 
 		[Theory]
 		[MemberData(nameof(GetData))]

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/ItemSelectedEventArgsConverter.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/ItemSelectedEventArgsConverter.shared.cs
@@ -19,9 +19,14 @@ namespace Xamarin.CommunityToolkit.Converters
 		/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
 		/// <returns>A <see cref="SelectedItemChangedEventArgs.SelectedItem"/> object from object of type <see cref="SelectedItemChangedEventArgs"/>.</returns>
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-		   => value is SelectedItemChangedEventArgs selectedItemChangedEventArgs
+		{
+			if (value == null)
+				return null;
+
+			return value is SelectedItemChangedEventArgs selectedItemChangedEventArgs
 			   ? selectedItemChangedEventArgs.SelectedItem
 			   : throw new ArgumentException("Expected value to be of type SelectedItemChangedEventArgs", nameof(value));
+		}
 
 		/// <summary>
 		/// This method is not implemented and will throw a <see cref="NotImplementedException"/>.

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/ItemTappedEventArgsConverter.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/ItemTappedEventArgsConverter.shared.cs
@@ -19,9 +19,14 @@ namespace Xamarin.CommunityToolkit.Converters
 		/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
 		/// <returns>A <see cref="ItemTappedEventArgs.Item"/> object from object of type <see cref="ItemTappedEventArgs"/>.</returns>
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-			=> value is ItemTappedEventArgs itemTappedEventArgs
+		{
+			if (value == null)
+				return null;
+
+			return value is ItemTappedEventArgs itemTappedEventArgs
 				? itemTappedEventArgs.Item
 				: throw new ArgumentException("Expected value to be of type ItemTappedEventArgs", nameof(value));
+		}
 
 		/// <summary>
 		/// This method is not implemented and will throw a <see cref="NotImplementedException"/>.


### PR DESCRIPTION
<!-- 
Hey there friend! First of all, thank you so much for this PR!
Some things that you should be aware of before opening this amazing PR❣

1. Please check if you are targeting the correct branch, we work on two branches and you should target the:
**main**: If you are fixing a bug and this bug doesn't change our public APIs
**develop**: If you are fixing a bug that introduces an API change, for example when you are implementing a new feature.
If you are not sure what branch target, ping one of the team directly or ask in the PR/issue and we will get back to you ASAP!

2. Before doing a lot of work, please check if there's an open issue for this chang, If not, please open an issue first so we can discuss upfront.

Also make sure you've read our Contribution guide here: https://github.com/xamarin/XamarinCommunityToolkit/blob/pj/update-pr-template/CONTRIBUTING.md
-->

### Description of Change ###
For example I want to write this in my VM:

```csharp
        Coffee selectedCoffee;
        public Coffee SelectedCoffee
        {
            get => selectedCoffee;
            set => SetProperty(ref selectedCoffee, value);
        }

        async Task Selected(Coffee coffee)
        {
            if (coffee == null)
                return;

            await Application.Current.MainPage.DisplayAlert("Selected", coffee.Name, "OK");
            SelectedCoffee = null;
        }
```

And this in my XAML:
```xml
    <ListView
        SelectedItem="{Binding SelectedCoffee, Mode=TwoWay}"
>
        <ListView.Behaviors>
            <xct:EventToCommandBehavior
                Command="{Binding SelectedCommand}"
                EventArgsConverter="{StaticResource ItemSelectedEventArgsConverter}"
                EventName="ItemSelected" />
        </ListView.Behaviors>
```

Today, this will throw an exception because it it null and is not of the type it is expecting, but that should be allowed.


The only work around is to do something like `AsyncCommand<object>` instead of `AsyncCommand<Coffee>`

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #

### API Changes ###

<!-- List all API changes here (or just put None), example:

Added: 
 
- `string Class.Property { get; set; }`
- `void Class.Method();`

Changed:

 - `object Cell.OldPropertyName` => `object Cell.NewPropertyName`
 
If there is an entirely new API, then you can use a more verbose style:

```csharp
public static class NewClass {
    public static int SomeProperty { get; set; }
    public static void SomeMethod(string value);
}
``` -->

### Behavioral Changes ###

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [x] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
