### PR TITLE
Merge `Grouping` classes from Refractored.MvvmHelpers

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/Grouping_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/Grouping_Tests.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+using Xamarin.CommunityToolkit.ObjectModel;
+using Xunit;
+
+namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
+{
+	public sealed class Grouping_Tests
+	{
+		readonly Person[] people;
+
+		public Grouping_Tests()
+		{
+			people = new[]
+			{
+				new Person { FirstName = "Joseph", LastName = "Hill" },
+				new Person { FirstName = "James", LastName = "Montemagno" },
+				new Person { FirstName = "Pierce", LastName = "Boggan" },
+			};
+		}
+
+		[Fact]
+		public void Grouping()
+		{
+			var sorted = from person in people
+				orderby person.FirstName
+				group person by person.Group
+				into personGroup
+				select new Grouping<string, Person>(personGroup.Key, personGroup);
+			var grouped = new ObservableRangeCollection<Grouping<string, Person>>();
+			grouped.AddRange(sorted);
+
+			Assert.Equal(2, grouped.Count);
+			Assert.Equal("J", grouped[0].Key);
+			Assert.Equal(2, grouped[0].Count);
+			Assert.Single(grouped[1]);
+			Assert.Equal(2, grouped[0].Items.Count);
+			Assert.Single(grouped[1].Items);
+		}
+
+		[Fact]
+		public void GroupingSubKey()
+		{
+			var sorted = from person in people
+				orderby person.FirstName
+				group person by person.Group
+				into personGroup
+				select new Grouping<string, string, Person>(personGroup.Key, personGroup.Key, personGroup);
+			var grouped = new ObservableRangeCollection<Grouping<string, string, Person>>();
+			grouped.AddRange(sorted);
+
+			Assert.Equal(2, grouped.Count);
+			Assert.Equal("J", grouped[0].SubKey);
+			Assert.Equal("J", grouped[0].Key);
+			Assert.Equal(2, grouped[0].Count);
+			Assert.Single(grouped[1]);
+			Assert.Equal(2, grouped[0].Items.Count);
+			Assert.Single(grouped[1].Items);
+		}
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableObject_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableObject_Tests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
-using Xamarin.CommunityToolkit.ObjectModel;
 using Xunit;
 
 namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
@@ -125,30 +124,6 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 			});
 
 			Assert.NotNull(result);
-		}
-
-		public class Person : ObservableObject
-		{
-			string firstName;
-			string lastName;
-
-			public Action Changed { get; set; }
-
-			public Action Changing { get; set; }
-
-			public Func<string, string, bool> Validate { get; set; }
-
-			public string FirstName
-			{
-				get => firstName;
-				set => SetProperty(ref firstName, value, onChanged: Changed, onChanging: Changing, validateValue: Validate);
-			}
-
-			public string LastName
-			{
-				get => lastName;
-				set => SetProperty(ref lastName, value, onChanged: Changed, onChanging: Changing, validateValue: Validate);
-			}
 		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/Person.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/Person.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Xamarin.CommunityToolkit.ObjectModel;
+
+namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
+{
+	class Person : ObservableObject
+	{
+		string firstName;
+		string lastName;
+
+		public Action Changed { get; set; }
+
+		public Action Changing { get; set; }
+
+		public Func<string, string, bool> Validate { get; set; }
+
+		public string FirstName
+		{
+			get => firstName;
+			set => SetProperty(ref firstName, value, onChanged: Changed, onChanging: Changing, validateValue: Validate);
+		}
+
+		public string LastName
+		{
+			get => lastName;
+			set => SetProperty(ref lastName, value, onChanged: Changed, onChanging: Changing, validateValue: Validate);
+		}
+
+		public string Group => FirstName[0].ToString().ToUpperInvariant();
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Grouping.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/ObjectModel/Grouping.shared.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+
+#nullable enable
+
+namespace Xamarin.CommunityToolkit.ObjectModel
+{
+	/// <summary>
+	/// Grouping of items by key into ObservableRange
+	/// </summary>
+	public class Grouping<TKey, TItem> : ObservableRangeCollection<TItem>
+	{
+		/// <summary>
+		/// Gets the key.
+		/// </summary>
+		/// <value>The key.</value>
+		public TKey Key { get; }
+
+		/// <summary>
+		/// Returns list of items in the grouping.
+		/// </summary>
+		public new IList<TItem> Items => base.Items;
+
+		/// <summary>
+		/// Initializes a new instance of the Grouping class.
+		/// </summary>
+		/// <param name="key">Key.</param>
+		/// <param name="items">Items.</param>
+		public Grouping(TKey key, IEnumerable<TItem> items)
+		{
+			Key = key;
+			AddRange(items);
+		}
+	}
+
+	/// <summary>
+	/// Grouping of items by key and subkey into ObservableRange
+	/// </summary>
+	public class Grouping<TKey, TSubKey, TItem> : ObservableRangeCollection<TItem>
+	{
+		/// <summary>
+		/// Gets the key.
+		/// </summary>
+		/// <value>The key.</value>
+		public TKey Key { get; }
+
+		/// <summary>
+		/// Gets the subkey of the grouping
+		/// </summary>
+		public TSubKey SubKey { get; }
+
+		/// <summary>
+		/// Returns list of items in the grouping.
+		/// </summary>
+		public new IList<TItem> Items => base.Items;
+
+		/// <summary>
+		/// Initializes a new instance of the Grouping class.
+		/// </summary>
+		/// <param name="key">Key.</param>
+		/// <param name="subkey">Subkey</param>
+		/// <param name="items">Items.</param>
+		public Grouping(TKey key, TSubKey subkey, IEnumerable<TItem> items)
+		{
+			Key = key;
+			SubKey = subkey;
+			AddRange(items);
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Merge the `Grouping` classes from Refractored.MvvmHelpers (from James Montemagno).

### Bugs Fixed ###

Issue https://github.com/xamarin/XamarinCommunityToolkit/issues/786

### API Changes ###

Added:
- `class Grouping<TKey, TItem> : ObservableRangeCollection<TItem>`
- `class Grouping<TKey, TSubKey, TItem> : ObservableRangeCollection<TItem>`

### Behavioral Changes ###

No behavioral change, only additions.

### PR Checklist ###

- [x] Has tests
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
