### PR TITLE
Fix "App crashes on tap of control with NativeAnimation"

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Extensions/VisualElementExtension.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Extensions/VisualElementExtension.shared.cs
@@ -41,7 +41,7 @@ namespace Xamarin.CommunityToolkit.Extensions
 
 			result = null;
 			parent = null;
-			while (element.Parent != null)
+			while (element?.Parent != null)
 			{
 				if (!(element.Parent is T parentElement))
 				{


### PR DESCRIPTION
### Description of Change ###

Add null check

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #960

### API Changes ###

None

### Behavioral Changes ###

None (app no longer crashes)

### Testing

![xct2](https://user-images.githubusercontent.com/6609929/108737194-086fd880-753b-11eb-8832-fd1cc5a31dc8.gif)

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
