### PR TITLE
Fix NullReferenceException when displaying Toast or SnackBar

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.android.cs
@@ -16,7 +16,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 	{
 		internal void Show(Page sender, SnackBarOptions arguments)
 		{
-			var view = Platform.GetRenderer(sender).View;
+			var view = Platform.GetRenderer(sender)?.View;
+			if (view == null)
+			{
+				return;
+			}
+
 			var snackBar = AndroidSnackBar.Make(view, arguments.MessageOptions.Message, (int)arguments.Duration.TotalMilliseconds);
 			var snackBarView = snackBar.View;
 			if (arguments.BackgroundColor != Forms.Color.Default)


### PR DESCRIPTION
### Description of Change ###

Now instead of an exception, toast/snackbar wouldn't be shown. 
Not perfect, but seems better then the exception.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #

### API Changes ###

None

### Behavioral Changes ###

Toast/snackbar wouldn't be shown in rare cases where previously exception would be thrown.

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
