### PR TITLE
View is stuck in pressed state when fast click (if PressedAnimationDuration is set)

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/GestureManager.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/GestureManager.shared.cs
@@ -360,6 +360,7 @@ namespace Xamarin.CommunityToolkit.Effects
 
 			if (duration <= 0)
 			{
+				element.AbortAnimations();
 				element.BackgroundColor = color;
 				return Task.FromResult(true);
 			}
@@ -388,6 +389,7 @@ namespace Xamarin.CommunityToolkit.Effects
 			var element = sender.Element;
 			if (duration <= 0)
 			{
+				element.AbortAnimations();
 				element.Opacity = opacity;
 				return Task.FromResult(true);
 			}
@@ -416,12 +418,13 @@ namespace Xamarin.CommunityToolkit.Effects
 			var element = sender.Element;
 			if (duration <= 0)
 			{
+				element.AbortAnimations(nameof(SetScale));
 				element.Scale = scale;
 				return Task.FromResult(true);
 			}
 
 			var animationCompletionSource = new TaskCompletionSource<bool>();
-			element.Animate($"{nameof(SetScale)}{element.Id}", v =>
+			element.Animate(nameof(SetScale), v =>
 			{
 				if (double.IsNaN(v))
 					return;
@@ -469,6 +472,7 @@ namespace Xamarin.CommunityToolkit.Effects
 			var element = sender.Element;
 			if (duration <= 0)
 			{
+				element.AbortAnimations();
 				element.TranslationX = translationX;
 				element.TranslationY = translationY;
 				return Task.FromResult(true);
@@ -498,6 +502,7 @@ namespace Xamarin.CommunityToolkit.Effects
 			var element = sender.Element;
 			if (duration <= 0)
 			{
+				element.AbortAnimations();
 				element.Rotation = rotation;
 				return Task.FromResult(true);
 			}
@@ -526,6 +531,7 @@ namespace Xamarin.CommunityToolkit.Effects
 			var element = sender.Element;
 			if (duration <= 0)
 			{
+				element.AbortAnimations();
 				element.RotationX = rotationX;
 				return Task.FromResult(true);
 			}
@@ -554,6 +560,7 @@ namespace Xamarin.CommunityToolkit.Effects
 			var element = sender.Element;
 			if (duration <= 0)
 			{
+				element.AbortAnimations();
 				element.RotationY = rotationY;
 				return Task.FromResult(true);
 			}


### PR DESCRIPTION
### Description of Change ###
We should cancel previous animations if set value without running new animation. 

### Bugs Fixed ###
- Fixes #974

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
