### PR TITLE
Make the BadgeView round

### DIFF
--- a/samples/XCT.Sample/Pages/Views/BadgeViewPage.xaml
+++ b/samples/XCT.Sample/Pages/Views/BadgeViewPage.xaml
@@ -1,182 +1,146 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+<pages:BasePage x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.BadgeViewPage"
+                xmlns="http://xamarin.com/schemas/2014/forms"
                 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                 xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
                 xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
                 xmlns:viewmodels="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.Views"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.BadgeViewPage"
                 Title="BadgeView">
     <pages:BasePage.Resources>
         <ResourceDictionary>
 
-            <Style x:Key="SectionStyle" TargetType="Label">
-                <Setter Property="FontSize" Value="Medium" />
-                <Setter Property="FontAttributes" Value="Bold" />
-                <Setter Property="Margin" Value="0, 12" />
+            <Style x:Key="SectionStyle"
+                   TargetType="Label">
+                <Setter Property="FontSize" Value="Medium"/>
+                <Setter Property="FontAttributes" Value="Bold"/>
+                <Setter Property="Margin" Value="0, 12"/>
             </Style>
 
         </ResourceDictionary>
     </pages:BasePage.Resources>
     <pages:BasePage.BindingContext>
-        <viewmodels:BadgeViewViewModel />
+        <viewmodels:BadgeViewViewModel/>
     </pages:BasePage.BindingContext>
     <ContentPage.Content>
         <ScrollView>
-            <StackLayout
-                Padding="12">
-                <Label
-                    Text="Getting started"
-                    Style="{StaticResource SectionStyle}"/>
-                <xct:BadgeView
-                    BackgroundColor="Red"
-                    TextColor="White"
-                    Text="1">
-                    <Label
-                        Text="BadgeView"/>
+            <StackLayout Padding="12">
+                <Label Text="Getting started"
+                       Style="{StaticResource SectionStyle}"/>
+                <xct:BadgeView BadgeBackgroundColor="Red"
+                               TextColor="White"
+                               Text="1">
+                    <Label Text="BadgeView"/>
                 </xct:BadgeView>
-                <Label
-                    Text="Customization options"
-                    Style="{StaticResource SectionStyle}"/>
-                <xct:BadgeView
-                    BackgroundColor="Blue"
-                    TextColor="White"
-                    Text="1003">
-                    <Label
-                        Text="Long Text"/>
+                <Label Text="Customization options"
+                       Style="{StaticResource SectionStyle}"/>
+                <xct:BadgeView BadgeBackgroundColor="Blue"
+                               TextColor="White"
+                               Text="1003">
+                    <Label Text="Long Text"/>
                 </xct:BadgeView>
-                <xct:BadgeView
-                    BackgroundColor="Red"
-                    FontAttributes="Bold"
-                    FontSize="8"
-                    TextColor="White"
-                    Text="1">
-                    <Label
-                        Text="Font Customization"/>
+                <xct:BadgeView BadgeBackgroundColor="Red"
+                               FontAttributes="Bold"
+                               FontSize="8"
+                               TextColor="White"
+                               Text="1">
+                    <Label Text="Font Customization"/>
                 </xct:BadgeView>
-                <xct:BadgeView
-                    BackgroundColor="Red"
-                    FontAttributes="Bold"
-                    FontSize="Medium"
-                    TextColor="White"
-                    Text="1">
-                    <Label
-                        Text="Named Font Size"/>
+                <xct:BadgeView BadgeBackgroundColor="Red"
+                               FontAttributes="Bold"
+                               FontSize="Medium"
+                               TextColor="White"
+                               Text="1">
+                    <Label Text="Named Font Size"/>
                 </xct:BadgeView>
-                <xct:BadgeView
-                    BackgroundColor="Red"
-                    BorderColor="Orange"
-                    TextColor="White"
-                    Text="1">
-                    <Label
-                        Text="Border Customization"/>
+                <xct:BadgeView BadgeBackgroundColor="Red"
+                               BorderColor="Orange"
+                               TextColor="White"
+                               Text="1">
+                    <Label Text="Border Customization"/>
                 </xct:BadgeView>
-                <xct:BadgeView
-                    BackgroundColor="Red"
-                    BorderColor="Orange"
-                    HasShadow="True"
-                    TextColor="White"
-                    Text="1">
-                    <Label
-                        Text="Shadow Customization"/>
+                <xct:BadgeView BadgeBackgroundColor="Red"
+                               BorderColor="Orange"
+                               HasShadow="True"
+                               TextColor="White"
+                               Text="1">
+                    <Label Text="Shadow Customization"/>
                 </xct:BadgeView>
-                <Grid
-                    RowDefinitions="auto,auto"
-                    ColumnDefinitions="*,*"
-                    ColumnSpacing="30">
-                    <xct:BadgeView
-                        Grid.Row="0"
-                        Grid.Column="0"
-                        HorizontalOptions="Start"
-                        BadgePosition="TopLeft"
-                        BackgroundColor="Red"
-                        Text="7"
-                        TextColor="White">
-                        <Grid
-                            HeightRequest="48"
-                            WidthRequest="150"
-                            BackgroundColor="LightGray">
-                            <Label
-                                Padding="12"
-                                HorizontalOptions="Center"
-                                VerticalOptions="Center"
-                                Text="TopLeft"/>
+                <Grid RowDefinitions="auto,auto"
+                      ColumnDefinitions="*,*"
+                      ColumnSpacing="30">
+                    <xct:BadgeView Grid.Row="0" Grid.Column="0"
+                                   HorizontalOptions="Start"
+                                   BadgePosition="TopLeft"
+                                   BadgeBackgroundColor="Red"
+                                   Text="7"
+                                   TextColor="White">
+                        <Grid HeightRequest="48"
+                              WidthRequest="150"
+                              BackgroundColor="LightGray">
+                            <Label Padding="12"
+                                   HorizontalOptions="Center"
+                                   VerticalOptions="Center"
+                                   Text="TopLeft"/>
                         </Grid>
                     </xct:BadgeView>
-                    <xct:BadgeView
-                        Grid.Row="0"
-                        Grid.Column="1"
-                        HorizontalOptions="Start"
-                        BadgePosition="TopRight"
-                        BackgroundColor="Red"
-                        Text="7"
-                        TextColor="White">
-                        <Grid
-                            HeightRequest="48"
-                            WidthRequest="150"
-                            BackgroundColor="LightGray">
-                            <Label
-                                Padding="12"
-                                HorizontalOptions="Center"
-                                VerticalOptions="Center"
-                                Text="TopRight"/>
+                    <xct:BadgeView Grid.Row="0" Grid.Column="1"
+                                   HorizontalOptions="Start"
+                                   BadgePosition="TopRight"
+                                   BadgeBackgroundColor="Red"
+                                   Text="7"
+                                   TextColor="White">
+                        <Grid HeightRequest="48"
+                              WidthRequest="150"
+                              BackgroundColor="LightGray">
+                            <Label Padding="12"
+                                   HorizontalOptions="Center"
+                                   VerticalOptions="Center"
+                                   Text="TopRight"/>
                         </Grid>
                     </xct:BadgeView>
-                    <xct:BadgeView
-                        Grid.Row="1"
-                        Grid.Column="0"
-                        HorizontalOptions="Start"
-                        BadgePosition="BottomLeft"
-                        BackgroundColor="Red"
-                        Text="7"
-                        TextColor="White">
-                        <Grid
-                            HeightRequest="48"
-                            WidthRequest="150"
-                            BackgroundColor="LightGray">
-                            <Label
-                                Padding="12"
-                                HorizontalOptions="Center"
-                                VerticalOptions="Center"
-                                Text="BottomLeft"/>
+                    <xct:BadgeView Grid.Row="1" Grid.Column="0"
+                                   HorizontalOptions="Start"
+                                   BadgePosition="BottomLeft"
+                                   BadgeBackgroundColor="Red"
+                                   Text="7"
+                                   TextColor="White">
+                        <Grid HeightRequest="48"
+                              WidthRequest="150"
+                              BackgroundColor="LightGray">
+                            <Label Padding="12"
+                                   HorizontalOptions="Center"
+                                   VerticalOptions="Center"
+                                   Text="BottomLeft"/>
                         </Grid>
                     </xct:BadgeView>
-                    <xct:BadgeView
-                        Grid.Row="1"
-                        Grid.Column="1"
-                        HorizontalOptions="Start"
-                        BadgePosition="BottomRight"
-                        BackgroundColor="Red"
-                        Text="7"
-                        TextColor="White">
-                        <Grid
-                            HeightRequest="48"
-                            WidthRequest="150"
-                            BackgroundColor="LightGray">
-                            <Label
-                                Padding="12"
-                                HorizontalOptions="Center"
-                                VerticalOptions="Center"
-                                Text="BottomRight"/>
+                    <xct:BadgeView Grid.Row="1" Grid.Column="1"
+                                   HorizontalOptions="Start"
+                                   BadgePosition="BottomRight"
+                                   BadgeBackgroundColor="Red"
+                                   Text="7"
+                                   TextColor="White">
+                        <Grid HeightRequest="48"
+                              WidthRequest="150"
+                              BackgroundColor="LightGray">
+                            <Label Padding="12"
+                                   HorizontalOptions="Center"
+                                   VerticalOptions="Center"
+                                   Text="BottomRight"/>
                         </Grid>
                     </xct:BadgeView>
                 </Grid>
-                <Label
-                    Text="Badge animations"
-                    Style="{StaticResource SectionStyle}"/>
-                <xct:BadgeView
-                    BackgroundColor="Red"
-                    Text="{Binding Counter}"
-                    TextColor="White">
-                    <StackLayout
-                        BackgroundColor="LightGray">
-                        <Button
-                            BackgroundColor="DarkGray"
-                            Command="{Binding IncreaseCommand}"
-                            Text="Increase"/>
-                        <Button
-                            BackgroundColor="DarkGray"
-                            Command="{Binding DecreaseCommand}"
-                            Text="Decrease"/>
+                <Label Text="Badge animations"
+                       Style="{StaticResource SectionStyle}"/>
+                <xct:BadgeView BadgeBackgroundColor="Red"
+                               Text="{Binding Counter}"
+                               TextColor="White">
+                    <StackLayout BackgroundColor="LightGray">
+                        <Button BackgroundColor="DarkGray"
+                                Command="{Binding IncreaseCommand}"
+                                Text="Increase"/>
+                        <Button BackgroundColor="DarkGray"
+                                Command="{Binding DecreaseCommand}"
+                                Text="Decrease"/>
                     </StackLayout>
                 </xct:BadgeView>
             </StackLayout>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BadgeView/BadgeView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BadgeView/BadgeView.shared.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Xamarin.CommunityToolkit.UI.Views.Internals;
 using Xamarin.Forms;
+using Xamarin.Forms.Shapes;
 using PropertyChangedEventArgs = System.ComponentModel.PropertyChangedEventArgs;
 
 namespace Xamarin.CommunityToolkit.UI.Views
@@ -103,14 +104,14 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		/// Backing BindableProperty for the <see cref="BackgroundColor"/> property.
 		/// </summary>
 		public static new BindableProperty BackgroundColorProperty =
-			BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(BadgeView), defaultValue: Color.Default);
+			BindableProperty.Create(nameof(BackgroundColor), typeof(Brush), typeof(BadgeView), defaultValue: Brush.Default);
 
 		/// <summary>
 		/// Gets or sets the background <see cref="Color"/> of the badge. This is a bindable property.
 		/// </summary>
-		public new Color BackgroundColor
+		public new Brush BackgroundColor
 		{
-			get => (Color)GetValue(BackgroundColorProperty);
+			get => (Brush)GetValue(BackgroundColorProperty);
 			set => SetValue(BackgroundColorProperty, value);
 		}
 
@@ -118,15 +119,15 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		/// Backing BindableProperty for the <see cref="BorderColor"/> property.
 		/// </summary>
 		public static readonly BindableProperty BorderColorProperty =
-			BindableProperty.Create(nameof(BorderColor), typeof(Color), typeof(BadgeView), Color.Default,
+			BindableProperty.Create(nameof(BorderColor), typeof(Brush), typeof(BadgeView), Brush.Default,
 				propertyChanged: OnLayoutPropertyChanged);
 
 		/// <summary>
 		/// Gets or sets the border <see cref="Color"/> of the badge. This is a bindable property.
 		/// </summary>
-		public Color BorderColor
+		public Brush BorderColor
 		{
-			get => (Color)GetValue(BorderColorProperty);
+			get => (Brush)GetValue(BorderColorProperty);
 			set => SetValue(BorderColorProperty, value);
 		}
 
@@ -242,21 +243,24 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		Grid BadgeIndicatorContainer { get; } = CreateIndicatorContainerElement();
 
-		Frame BadgeIndicatorBackground { get; } = CreateIndicatorBackgroundElement();
-
 		Label BadgeText { get; } = CreateTextElement();
+
+		Ellipse BadgeIndicatorBackground { get; } = CreateIndicatorBackgroundElement();
+
 
 		protected override void OnControlInitialized(Grid control)
 		{
-			BadgeIndicatorBackground.Content = BadgeText;
-
 			BadgeIndicatorContainer.Children.Add(BadgeIndicatorBackground);
+			BadgeIndicatorContainer.Children.Add(BadgeText);
 			BadgeIndicatorContainer.PropertyChanged += OnBadgeIndicatorContainerPropertyChanged;
 			BadgeText.SizeChanged += OnBadgeTextSizeChanged;
 
 			control.Children.Add(BadgeContent);
 			control.Children.Add(BadgeIndicatorContainer);
 		}
+
+		static Ellipse CreateIndicatorBackgroundElement()
+			=> new Ellipse();
 
 		static ContentPresenter CreateContentElement()
 			=> new ContentPresenter
@@ -273,12 +277,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			   IsVisible = false
 		   };
 
-		static Frame CreateIndicatorBackgroundElement()
-		   => new Frame
-		   {
-			   CornerRadius = Device.RuntimePlatform == Device.Android ? 12 : 8,
-			   Padding = 2
-		   };
 
 		static Label CreateTextElement()
 		   => new Label
@@ -312,9 +310,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			BadgeContent.Content = Content;
 
-			BadgeIndicatorBackground.BackgroundColor = BackgroundColor;
-			BadgeIndicatorBackground.BorderColor = BorderColor;
-			BadgeIndicatorBackground.HasShadow = HasShadow;
+			BadgeIndicatorBackground.Fill = BackgroundColor;
+			BadgeIndicatorBackground.Stroke = BorderColor;
+			//BadgeIndicatorBackground.HasShadow = HasShadow; ?
 
 			BadgeText.Text = Text;
 			BadgeText.TextColor = TextColor;
@@ -354,7 +352,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			{
 				const double Padding = 6;
 				var size = Math.Max(BadgeText.Height, BadgeText.Width) + Padding;
-				BadgeIndicatorBackground.HeightRequest = size;
+				BadgeIndicatorBackground.HeightRequest = BadgeIndicatorBackground.WidthRequest = size;
 				var margins = GetMargins(size);
 				containerMargin = margins.Item1;
 				contentMargin = margins.Item2;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BadgeView/BadgeView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BadgeView/BadgeView.shared.cs
@@ -303,6 +303,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		   {
 			   HorizontalOptions = LayoutOptions.Center,
 			   VerticalOptions = LayoutOptions.Center,
+			   LineBreakMode = LineBreakMode.NoWrap,
 			   Margin = new Thickness(4, 0)
 		   };
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BadgeView/BadgeView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BadgeView/BadgeView.shared.cs
@@ -101,19 +101,39 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		}
 
 		/// <summary>
-		/// Backing BindableProperty for the <see cref="BackgroundColor"/> property.
+		/// Backing BindableProperty for the <see cref="BadgeBackgroundColor"/> property.
 		/// </summary>
-		public static new BindableProperty BackgroundColorProperty =
-			BindableProperty.Create(nameof(BackgroundColor), typeof(Brush), typeof(BadgeView), defaultValue: Brush.Default);
+		public static new BindableProperty BadgeBackgroundColorProperty =
+			BindableProperty.Create(nameof(BadgeBackgroundColor), typeof(Brush), typeof(BadgeView), defaultValue: Brush.Default);
 
 		/// <summary>
 		/// Gets or sets the background <see cref="Color"/> of the badge. This is a bindable property.
 		/// </summary>
-		public new Brush BackgroundColor
+		public new Brush BadgeBackgroundColor
 		{
-			get => (Brush)GetValue(BackgroundColorProperty);
+			get => (Brush)GetValue(BadgeBackgroundColorProperty);
+			set => SetValue(BadgeBackgroundColorProperty, value);
+		}
+
+		/// <summary>
+		/// Backing BindableProperty for the <see cref="BadgeBackgroundColor"/> property.
+		/// </summary>
+		public static new BindableProperty BackgroundColorProperty =
+			BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(BadgeView), defaultValue: Color.Default, propertyChanged: OnBackgroundColorChanged);
+
+		/// <summary>
+		/// Gets or sets the background <see cref="Color"/> of the badge. This is a bindable property.
+		/// </summary>
+		[Obsolete("BackgroundColor is obsolete. Please use BadgeBackgroundColor instead")]
+		[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+		public new Color BackgroundColor
+		{
+			get => (Color)GetValue(BackgroundColorProperty);
 			set => SetValue(BackgroundColorProperty, value);
 		}
+
+		static void OnBackgroundColorChanged(BindableObject bindable, object oldValue, object newValue)
+			=> (bindable as BadgeView).BadgeBackgroundColor = new SolidColorBrush((Color)newValue);
 
 		/// <summary>
 		/// Backing BindableProperty for the <see cref="BorderColor"/> property.
@@ -310,7 +330,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			BadgeContent.Content = Content;
 
-			BadgeIndicatorBackground.Fill = BackgroundColor;
+			BadgeIndicatorBackground.Fill = BadgeBackgroundColor;
 			BadgeIndicatorBackground.Stroke = BorderColor;
 			//BadgeIndicatorBackground.HasShadow = HasShadow; ?
 


### PR DESCRIPTION
### Description of Change ###
Make the BadgeView round by replacing Frame by Ellipse

### Bugs Fixed ###
- Fixes #641
- Fixes #692

### API Changes ###

BackgroundColor has conflict upon type change is renamed to BadgeBackgroundColor and set as deprecated.

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
