### PR TITLE
Add null-check to prevent NRE on MediaElement for iOS

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
@@ -351,7 +351,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		void SeekComplete(bool finished)
 		{
 			if (finished)
-				Controller.OnSeekCompleted();
+				Controller?.OnSeekCompleted();
 		}
 
 		void MediaElementPositionRequested(object sender, EventArgs e) => Controller.Position = Position;


### PR DESCRIPTION
### Description of Change ###

Adding a defensive null-check to see if we can prevent a NRE with `SeekComplete` for `MediaElement` on iOS

### Bugs Fixed ###

- Fixes #976 

### API Changes ###

NA

### Behavioral Changes ###

Before would (sometimes) crash on navigating away from the page, now no crash

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
