### PR TITLE
Avoid ImageButtonRenderer ObjectDisposedException on Android

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.android.cs
@@ -1,7 +1,10 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using Android.Graphics;
 using Android.Widget;
+using AndroidX.AppCompat.Widget;
 using Xamarin.CommunityToolkit.Effects;
 using Xamarin.Forms.Platform.Android;
 using Effects = Xamarin.CommunityToolkit.Android.Effects;
@@ -50,17 +53,27 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 
 		void ClearTintColor()
 		{
-			switch (Control)
+			//var isDisposed = (bool) ((ImageButtonRenderer)Control).GetType().GetInterface("IDisposedState")?.GetProperty("IsDisposed")?.GetValue((ImageButtonRenderer)Control);
+
+			try
 			{
-				case ImageView image:
-					image.ClearColorFilter();
-					break;
-				case Button button:
-					var drawables = button.GetCompoundDrawables().Where(d => d != null);
-					foreach (var img in drawables)
-						img.ClearColorFilter();
-					break;
+				switch (Control)
+				{
+					case ImageView image:
+						image.ClearColorFilter();
+						//if (!isDisposed)
+						//{
+						//	image.ClearColorFilter();
+						//}
+						break;
+					case Button button:
+						var drawables = button.GetCompoundDrawables().Where(d => d != null);
+						foreach (var img in drawables)
+							img.ClearColorFilter();
+						break;
+				}
 			}
+			catch (ObjectDisposedException ex) { }
 		}
 
 		void SetImageViewTintColor(ImageView image, Forms.Color color)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.android.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
 using Android.Graphics;
 using Android.Widget;
-using AndroidX.AppCompat.Widget;
 using Xamarin.CommunityToolkit.Effects;
 using Xamarin.Forms.Platform.Android;
 using Effects = Xamarin.CommunityToolkit.Android.Effects;
@@ -53,27 +51,22 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 
 		void ClearTintColor()
 		{
-			//var isDisposed = (bool) ((ImageButtonRenderer)Control).GetType().GetInterface("IDisposedState")?.GetProperty("IsDisposed")?.GetValue((ImageButtonRenderer)Control);
-
 			try
 			{
 				switch (Control)
 				{
 					case ImageView image:
 						image.ClearColorFilter();
-						//if (!isDisposed)
-						//{
-						//	image.ClearColorFilter();
-						//}
 						break;
 					case Button button:
-						var drawables = button.GetCompoundDrawables().Where(d => d != null);
-						foreach (var img in drawables)
-							img.ClearColorFilter();
+						foreach (var drawable in button.GetCompoundDrawables())
+							drawable?.ClearColorFilter();
 						break;
 				}
 			}
-			catch (ObjectDisposedException ex) { }
+			catch (ObjectDisposedException) {
+				// We ignore ObjectDisposedException as a workaround of XF issue https://github.com/xamarin/Xamarin.Forms/issues/13889
+			}
 		}
 
 		void SetImageViewTintColor(ImageView image, Forms.Color color)


### PR DESCRIPTION
### Description of Change ###
Catching `ObjectDisposedException` and ignoring it to avoid a crash.

### Bugs Fixed ###
- Fixes #994

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
