### PR TITLE
Enable Nullable

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Behaviors/MaxLengthReachedBehavior_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Behaviors/MaxLengthReachedBehavior_Tests.cs
@@ -144,8 +144,8 @@ namespace Xamarin.CommunityToolkit.UnitTests.Behaviors
 
 		Entry CreateEntry(int? maxLength = 2,
 						  bool shouldDismissKeyboardAutomatically = false,
-						  ICommand command = null,
-						  EventHandler<MaxLengthReachedEventArgs> eventHandler = null)
+						  ICommand? command = null,
+						  EventHandler<MaxLengthReachedEventArgs>? eventHandler = null)
 		{
 			var behavior = new MaxLengthReachedBehavior
 			{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Behaviors/UserStoppedTypingBehavior_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Behaviors/UserStoppedTypingBehavior_Tests.cs
@@ -160,8 +160,8 @@ namespace Xamarin.CommunityToolkit.UnitTests.Behaviors
 		public Entry CreateEntryWithBehavior(int timeThreshold = defaultTimeThreshold,
 											 int lengthThreshold = defaultLengthThreshold,
 											 bool shouldDismissKeyboardAutomatically = false,
-											 ICommand command = null,
-											 object commandParameter = null)
+											 ICommand? command = null,
+											 object? commandParameter = null)
 		{
 			var entry = new Entry
 			{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/DoubleToIntConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/DoubleToIntConverter_Tests.cs
@@ -12,7 +12,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 		[InlineData(2.55, 3)]
 		[InlineData(2.555, 3)]
 		[InlineData(2.555, 652, 255)]
-		public void DoubleToIntConverter(double value, int expectedResult, object ratio = null)
+		public void DoubleToIntConverter(double value, int expectedResult, object? ratio = null)
 		{
 			var doubleToIntConverter = new DoubleToIntConverter();
 
@@ -23,7 +23,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 
 		[Theory]
 		[InlineData(2, 2)]
-		public void DoubleToIntConverterBack(int value, double expectedResult, object ratio = null)
+		public void DoubleToIntConverterBack(int value, double expectedResult, object? ratio = null)
 		{
 			var doubleToIntConverter = new DoubleToIntConverter();
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/EnumToBoolConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/EnumToBoolConverter_Tests.cs
@@ -80,68 +80,68 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 			Assert.Equal(expectedResult, result);
 		}
 
-		public static IEnumerable<object[]> ConvertTestData()
+		public static IEnumerable<object?[]> ConvertTestData()
 		{
 			// Simple enum
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Five, true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six, false
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six, true
+				new object?[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six, true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.Six, null, true
+				new object?[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.Six, null, true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.One, TestEnumForEnumToBoolConverter.Five, false
+				new object?[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.One, TestEnumForEnumToBoolConverter.Five, false
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.Two, null, false
+				new object?[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.Two, null, false
 			};
 
 			// Flagged enum
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.One, null, true
+				new object?[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.One, null, true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.Two, null, true
+				new object?[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.Two, null, true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.Three, null, true
+				new object?[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.Three, null, true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.Four, null, false
+				new object?[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.Four, null, false
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, TestFlaggedEnumForEnumToBoolConverter.One, (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, TestFlaggedEnumForEnumToBoolConverter.Three, (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, TestFlaggedEnumForEnumToBoolConverter.Two, (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), false
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Two | TestFlaggedEnumForEnumToBoolConverter.Three), (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), false
 			};

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ItemSelectedEventArgsConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ItemSelectedEventArgsConverter_Tests.cs
@@ -9,14 +9,16 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 {
 	public class ItemSelectedEventArgsConverter_Tests
 	{
-		static object expectedValue = 100;
+		static readonly object expectedValue = 100;
 
 		public static IEnumerable<object[]> GetData() => new List<object[]>
 		{
             // We know it's deprecated, still good to test it
 #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
             new object[] { new SelectedItemChangedEventArgs(expectedValue), expectedValue },
-			new object[] { null, null },
+            new object?[] { null, null },
+#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
 #pragma warning restore CS0618 // Type or member is obsolete
 		};
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ItemTappedEventArgsConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ItemTappedEventArgsConverter_Tests.cs
@@ -15,8 +15,10 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 			{
             // We know it's deprecated, still good to test it
 #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
                 new object[] { new ItemTappedEventArgs(null, expectedValue), expectedValue },
                 new object[] { new ItemTappedEventArgs(null, null), null },
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 #pragma warning restore CS0618 // Type or member is obsolete
 			};
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ListIsNotNullOrEmptyConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ListIsNotNullOrEmptyConverter_Tests.cs
@@ -9,16 +9,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 {
 	public class ListIsNotNullOrEmptyConverter_Tests
 	{
-		public static IEnumerable<object[]> GetData()
+		public static IEnumerable<object?[]> GetData() => new List<object?[]>
 		{
-			return new List<object[]>
-			{
-				new object[] { new List<string>(), false},
-				new object[] { new List<string>() { "TestValue"}, true},
-				new object[] { null, false},
-				new object[] { Enumerable.Range(1, 3), true},
-			};
-		}
+			new object[] { new List<string>(), false},
+			new object[] { new List<string>() { "TestValue"}, true},
+			new object?[] { null, false},
+			new object[] { Enumerable.Range(1, 3), true},
+		};
 
 		[Theory]
 		[MemberData(nameof(GetData))]

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ListIsNullOrEmptyConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ListIsNullOrEmptyConverter_Tests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -9,16 +9,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 {
 	public class ListIsNullOrEmptyConverter_Tests
 	{
-		public static IEnumerable<object[]> GetData()
-		{
-			return new List<object[]>
+		public static IEnumerable<object?[]> GetData() => new List<object?[]>
 			{
 				new object[] { new List<string>(), true},
-				new object[] { new List<string>() { "TestValue"}, false},
-				new object[] { null, true},
-				new object[] { Enumerable.Range(1, 3), false},
+				new object[] { new List<string>() { "TestValue" }, false},
+				new object?[] { null, true },
+				new object[] { Enumerable.Range(1, 3), false },
 			};
-		}
 
 		[Theory]
 		[MemberData(nameof(GetData))]

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ListToStringConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ListToStringConverter_Tests.cs
@@ -7,17 +7,16 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 {
 	public class ListToStringConverter_Tests
 	{
-		public static IEnumerable<object[]> GetData()
-			=> new List<object[]>
-			{
-				new object[] { new string[] { "A", "B", "C" }, "+_+", "A+_+B+_+C" },
-				new object[] { new string[] { "A", string.Empty, "C" }, ",", "A,C" },
-				new object[] { new string[] { "A", null, "C" }, ",", "A,C" },
-				new object[] { new string[] { "A" }, ":-:", "A" },
-				new object[] { new string[] { }, ",", string.Empty },
-				new object[] { null, ",", string.Empty },
-				new object[] { new string[] { "A", "B", "C" }, null, "ABC" },
-			};
+		public static IEnumerable<object?[]> GetData() => new List<object?[]>
+		{
+			new object[] { new string[] { "A", "B", "C" }, "+_+", "A+_+B+_+C" },
+			new object[] { new string[] { "A", string.Empty, "C" }, ",", "A,C" },
+			new object?[] { new string?[] { "A", null, "C" }, ",", "A,C" },
+			new object[] { new string[] { "A" }, ":-:", "A" },
+			new object[] { new string[] { }, ",", string.Empty },
+			new object?[] { null, ",", string.Empty },
+			new object?[] { new string[] { "A", "B", "C" }, null, "ABC" },
+		};
 
 		[Theory]
 		[MemberData(nameof(GetData))]

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/EnableInitOnlyProperties.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/EnableInitOnlyProperties.cs
@@ -1,0 +1,4 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    public record IsExternalInit;
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizationResourceManagerTests/LocalizationResourceManagerTests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizationResourceManagerTests/LocalizationResourceManagerTests.cs
@@ -48,7 +48,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.LocalizationResourceManager
 			// Arrange
 			var culture2 = new CultureInfo("en");
 			localizationManager.CurrentCulture = culture2;
-			CultureInfo changedCulture = null;
+			CultureInfo? changedCulture = null;
 			localizationManager.PropertyChanged += (s, e) => changedCulture = localizationManager.CurrentCulture;
 
 			// Act, Assert

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizedStringTests/LocalizedStringTests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizedStringTests/LocalizedStringTests.cs
@@ -20,7 +20,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.LocalizedStringTests
 		readonly CultureInfo initialCulture = CultureInfo.InvariantCulture;
 		readonly ResourceManager resourceManager;
 
-		LocalizedString localizedString;
+		LocalizedString? localizedString;
 
 		[Fact]
 		public void LocalizedStringTests_Localized_ValidImplementation()
@@ -30,7 +30,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.LocalizedStringTests
 			var culture2 = new CultureInfo("en");
 			localizedString = new LocalizedString(localizationManager, () => localizationManager[testString]);
 
-			string responceOnCultureChanged = null;
+			string? responceOnCultureChanged = null;
 			localizedString.PropertyChanged += (sender, args) => responceOnCultureChanged = localizedString.Localized;
 
 			// Act

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/WeakEventManagerTests/WeakEventManager_ActionT_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/WeakEventManagerTests/WeakEventManager_ActionT_Tests.cs
@@ -135,14 +135,12 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 		public void WeakEventManagerActionT_AddEventHandler_NullHandler()
 		{
 			// Arrange
-			Action<string> nullAction = null;
+			Action<string>? nullAction = null;
 
 			// Act
 
 			// Assert
-#pragma warning disable CS8604 //Possible null reference argument for parameter
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.AddEventHandler(nullAction, nameof(ActionEvent)));
-#pragma warning restore CS8604 //Possible null reference argument for parameter
 
 		}
 
@@ -154,23 +152,19 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.AddEventHandler(s => { var temp = s; }, null));
-#pragma warning restore CS8625
 		}
 
 		[Fact]
 		public void WeakEventManagerActionT_AddEventHandler_EmptyEventName()
 		{
 			// Arrange
-			Action<string> nullAction = null;
+			Action<string>? nullAction = null;
 
 			// Act
 
 			// Assert
-#pragma warning disable CS8604 //Possible null reference argument for parameter
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.AddEventHandler(nullAction, string.Empty));
-#pragma warning restore CS8604 //Possible null reference argument for parameter
 		}
 
 		[Fact]
@@ -181,23 +175,19 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.AddEventHandler(s => { var temp = s; }, " "));
-#pragma warning restore CS8625
 		}
 
 		[Fact]
 		public void WeakEventManagerActionT_RemoveEventHandler_NullHandler()
 		{
 			// Arrange
-			Action<string> nullAction = null;
+			Action<string>? nullAction = null;
 
 			// Act
 
 			// Assert
-#pragma warning disable CS8604 //Possible null reference argument for parameter
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.RemoveEventHandler(nullAction));
-#pragma warning restore CS8604
 		}
 
 		[Fact]
@@ -208,9 +198,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.RemoveEventHandler(s => { var temp = s; }, null));
-#pragma warning restore CS8625
 		}
 
 		[Fact]
@@ -221,9 +209,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.RemoveEventHandler(s => { var temp = s; }, string.Empty));
-#pragma warning restore CS8625
 		}
 
 		[Fact]
@@ -234,9 +220,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.RemoveEventHandler(s => { var temp = s; }, " "));
-#pragma warning restore CS8625
 		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/WeakEventManagerTests/WeakEventManager_EventHandlerT_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/WeakEventManagerTests/WeakEventManager_EventHandlerT_Tests.cs
@@ -17,7 +17,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			const string stringEventArg = "Test";
 			var didEventFire = false;
 
-			void HandleTestEvent(object sender, string? e)
+			void HandleTestEvent(object? sender, string? e)
 			{
 				if (sender == null || e == null)
 					throw new ArgumentNullException(nameof(sender));
@@ -49,7 +49,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 
 			var didEventFire = false;
 
-			void HandleTestEvent(object sender, string e)
+			void HandleTestEvent(object? sender, string e)
 			{
 				Assert.Null(sender);
 
@@ -74,7 +74,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			TestStringEvent += HandleTestEvent;
 			var didEventFire = false;
 
-			void HandleTestEvent(object sender, string e)
+			void HandleTestEvent(object? sender, string e)
 			{
 				if (sender == null)
 					throw new ArgumentNullException(nameof(sender));
@@ -105,7 +105,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 
 			var didEventFire = false;
 
-			void HandleTestEvent(object sender, string e) => didEventFire = true;
+			void HandleTestEvent(object? sender, string e) => didEventFire = true;
 
 			// Act
 			TestStringWeakEventManager.RaiseEvent(this, "Test", nameof(TestEvent));
@@ -119,13 +119,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 		public void WeakEventManager_NullEventManager()
 		{
 			// Arrange
-			WeakEventManager<string> unassignedEventManager = null;
+			WeakEventManager<string>? unassignedEventManager = null;
 
 			// Act
 
 			// Assert
 #pragma warning disable CS8602 //Dereference of a possible null reference
-			Assert.Throws<NullReferenceException>(() => unassignedEventManager.RaiseEvent(null, null, nameof(TestEvent)));
+			Assert.Throws<NullReferenceException>(() => unassignedEventManager.RaiseEvent(null, string.Empty, nameof(TestEvent)));
 #pragma warning restore CS8602
 		}
 
@@ -137,7 +137,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			var didEventFire = false;
 
 			TestStringEvent += HandleTestEvent;
-			void HandleTestEvent(object sender, string e) => didEventFire = true;
+			void HandleTestEvent(object? sender, string e) => didEventFire = true;
 
 			// Act
 #pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
@@ -157,7 +157,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 
 			TestStringEvent += HandleTestEvent;
 			TestStringEvent -= HandleTestEvent;
-			void HandleTestEvent(object sender, string e) => didEventFire = true;
+			void HandleTestEvent(object? sender, string e) => didEventFire = true;
 
 			// Act
 			TestStringWeakEventManager.RaiseEvent(this, "Test", nameof(TestStringEvent));
@@ -174,9 +174,9 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
 			Assert.Throws<ArgumentNullException>(() => TestStringWeakEventManager.AddEventHandler((EventHandler<string>)null));
-#pragma warning restore CS8625
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 		}
 
 		[Fact]
@@ -187,9 +187,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference
 			Assert.Throws<ArgumentNullException>(() => TestStringWeakEventManager.AddEventHandler(s => { var temp = s; }, null));
-#pragma warning restore CS8625
 		}
 
 		[Fact]
@@ -222,9 +220,9 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
 			Assert.Throws<ArgumentNullException>(() => TestStringWeakEventManager.RemoveEventHandler((EventHandler<string>)null));
-#pragma warning restore CS8625
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 		}
 
 		[Fact]
@@ -235,9 +233,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference
 			Assert.Throws<ArgumentNullException>(() => TestStringWeakEventManager.AddEventHandler(s => { var temp = s; }, null));
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference
 		}
 
 		[Fact]
@@ -269,12 +265,12 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			TestStringEvent += HandleTestStringEvent;
 			var didEventFire = false;
 
-			void HandleTestStringEvent(object sender, string e) => didEventFire = true;
+			void HandleTestStringEvent(object? sender, string e) => didEventFire = true;
 
 			// Act
 
 			// Assert
-			Assert.Throws<InvalidHandleEventException>(() => TestStringWeakEventManager.RaiseEvent("", nameof(TestStringEvent)));
+			Assert.Throws<InvalidHandleEventException>(() => TestStringWeakEventManager.RaiseEvent(string.Empty, nameof(TestStringEvent)));
 			Assert.False(didEventFire);
 			TestStringEvent -= HandleTestStringEvent;
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Mocks/MockPlatformServices.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Mocks/MockPlatformServices.cs
@@ -31,7 +31,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Mocks
 
 		public OSAppTheme RequestedTheme => OSAppTheme.Unspecified;
 
-		public string RuntimePlatform { get; set; }
+		public string RuntimePlatform { get; set; } = string.Empty;
 
 		public void BeginInvokeOnMainThread(Action action)
 			=> action();
@@ -49,7 +49,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Mocks
 		public Assembly[] GetAssemblies()
 			=> new Assembly[0];
 
-		public IIsolatedStorageFile GetUserStoreForApplication()
+		public IIsolatedStorageFile? GetUserStoreForApplication()
 			=> null;
 
 		Assembly[] IPlatformServices.GetAssemblies()

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Mocks/MockResourceManager.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Mocks/MockResourceManager.cs
@@ -5,6 +5,6 @@ namespace Xamarin.CommunityToolkit.UnitTests.Mocks
 {
 	class MockResourceManager : ResourceManager
 	{
-		public override string GetString(string name, CultureInfo culture) => culture.EnglishName;
+		public override string GetString(string name, CultureInfo? culture) => culture?.EnglishName ?? string.Empty;
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Namespace_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Namespace_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Reflection;
 using Xamarin.CommunityToolkit.Behaviors.Internals;
 using Xamarin.CommunityToolkit.Converters;
@@ -15,62 +16,72 @@ namespace Xamarin.CommunityToolkit.UnitTests
 		[Fact]
 		public void MakeSureConvertersAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(InvertedBoolConverter)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(InvertedBoolConverter))?.GetTypes();
+			if (allTheTypes is null)
+				throw new NullReferenceException();
 
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Converter") && t.GetInterface(nameof(IValueConverter)) != null))
 			{
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Converters"),
-					$"{type.FullName} not in Xamarin.CommunityToolkit.Converters namespace");
+				Assert.True(type?.Namespace?.Equals("Xamarin.CommunityToolkit.Converters"),
+					$"{type?.FullName} not in Xamarin.CommunityToolkit.Converters namespace");
 			}
 		}
 
 		[Fact]
 		public void MakeSureEffectsAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(SafeAreaEffect)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(SafeAreaEffect))?.GetTypes();
+			if (allTheTypes is null)
+				throw new NullReferenceException();
 
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Effect") && t.IsClass && t.IsSealed && t.IsAbstract))
 			{
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Effects"),
-					$"{type.FullName} not in Xamarin.CommunityToolkit.Effects namespace");
+				Assert.True(type?.Namespace?.Equals("Xamarin.CommunityToolkit.Effects"),
+					$"{type?.FullName} not in Xamarin.CommunityToolkit.Effects namespace");
 			}
 		}
 
 		[Fact]
 		public void MakeSureMarkupExtensionsAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(TranslateExtension)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(TranslateExtension))?.GetTypes();
+			if (allTheTypes is null)
+				throw new NullReferenceException();
 
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Extension") && t.GetInterface("IMarkupExtension") != null))
 			{
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Extensions") ||
-					type.Namespace.Equals("Xamarin.CommunityToolkit.Extensions.Internals"),
-					$"{type.FullName} not in nameof(Xamarin.CommunityToolkit.Extensions namespace");
+				Assert.True(type?.Namespace?.Equals("Xamarin.CommunityToolkit.Extensions") is true ||
+					type?.Namespace?.Equals("Xamarin.CommunityToolkit.Extensions.Internals") is true,
+					$"{type?.FullName} not in nameof(Xamarin.CommunityToolkit.Extensions namespace");
 			}
 		}
 
 		[Fact]
 		public void MakeSureBehaviorsAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior<>)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior<>))?.GetTypes();
+			if (allTheTypes is null)
+				throw new NullReferenceException();
 
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Behavior") && t.IsSubclassOf(typeof(BaseBehavior<>))))
 			{
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Behaviors"),
-					$"{type.FullName} not in Xamarin.CommunityToolkit.Behaviors namespace");
+				Assert.True(type?.Namespace?.Equals("Xamarin.CommunityToolkit.Behaviors"),
+					$"{type?.FullName} not in Xamarin.CommunityToolkit.Behaviors namespace");
 			}
 		}
 
 		[Fact]
 		public void MakeSureViewsAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(AvatarView)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(AvatarView))?.GetTypes();
+			if (allTheTypes is null)
+				throw new NullReferenceException();
 
 			foreach (var type in allTheTypes.Where(t => t.IsSubclassOf(typeof(View))))
 			{
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.UI.Views") ||
-					type.Namespace.Equals("Xamarin.CommunityToolkit.UI.Views.Internals"),
-					$"{type.FullName} not in Xamarin.CommunityToolkit.UI.Views namespace");
+				Assert.True(type?.Namespace?.Equals("Xamarin.CommunityToolkit.UI.Views") is true ||
+					type?.Namespace?.Equals("Xamarin.CommunityToolkit.UI.Views.Internals") is true,
+					$"{type?.FullName} not in Xamarin.CommunityToolkit.UI.Views namespace");
 			}
 		}
 	}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/AsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/AsyncCommand_Tests.cs
@@ -152,7 +152,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 		public void AsyncCommand_NoParameter_NoCanExecute_Test()
 		{
 			// Arrange
-			Func<bool> canExecute = null;
+			Func<bool>? canExecute = null;
 			var command = new AsyncCommand(NoParameterTask, canExecute);
 
 			// Act
@@ -189,7 +189,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(didCanExecuteChangeFire);
 			Assert.True(command.CanExecute(null));
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => didCanExecuteChangeFire = true;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => didCanExecuteChangeFire = true;
 		}
 
 		[Fact]
@@ -222,7 +222,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(didCanExecuteChangeFire);
 			Assert.True(command.CanExecute(null));
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => didCanExecuteChangeFire = true;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => didCanExecuteChangeFire = true;
 		});
 
 		[Fact]
@@ -258,14 +258,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 				Assert.True(command.CanExecute(null));
 			});
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => didCanExecuteChangeFire = true;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => didCanExecuteChangeFire = true;
 		}
 
 		[Fact]
 		public async Task AsyncCommand_RaiseCanExecuteChanged_BackgroundThreadCreation_MainThreadExecution_Test()
 		{
 			// Arrange
-			AsyncCommand command = null;
+			AsyncCommand? command = null;
 			var didCanExecuteChangeFire = false;
 			var canCommandExecute = false;
 
@@ -289,20 +289,23 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			}).ConfigureAwait(true);
 
 			// Act
+			if (command is null)
+				throw new NullReferenceException();
+
 			command.RaiseCanExecuteChanged();
 
 			// Assert
 			Assert.True(didCanExecuteChangeFire);
 			Assert.True(command.CanExecute(null));
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => didCanExecuteChangeFire = true;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => didCanExecuteChangeFire = true;
 		}
 
 		[Fact]
 		public async Task AsyncCommand_ChangeCanExecute_Test()
 		{
 			// Arrange
-			var canExecuteChangedTCS = new TaskCompletionSource<object>();
+			var canExecuteChangedTCS = new TaskCompletionSource<object?>();
 
 			var canCommandExecute = false;
 			var didCanExecuteChangeFire = false;
@@ -322,16 +325,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.False(didCanExecuteChangeFire);
 
 			// Act
-#pragma warning disable CS0618 // Type or member is obsolete
 			command.ChangeCanExecute();
 			await canExecuteChangedTCS.Task;
-#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Assert
 			Assert.True(didCanExecuteChangeFire);
 			Assert.True(command.CanExecute(null));
 
-			void handleCanExecuteChanged(object sender, EventArgs e)
+			void handleCanExecuteChanged(object? sender, EventArgs e)
 			{
 				didCanExecuteChangeFire = true;
 				canExecuteChangedTCS.SetResult(null);
@@ -363,14 +364,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(command.CanExecute(null));
 			Assert.Equal(0, canExecuteChangedCount);
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 		}
 
 		[Fact]
 		public async Task AsyncCommand_CanExecuteChanged_DoesNotAllowMultipleExecutions_Test()
 		{
 			// Arrange
-			var canExecuteChangedGreaterThan1TCS = new TaskCompletionSource<object>();
+			var canExecuteChangedGreaterThan1TCS = new TaskCompletionSource<object?>();
 
 			var canExecuteChangedCount = 0;
 
@@ -394,7 +395,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(command.CanExecute(null));
 			Assert.Equal(2, canExecuteChangedCount);
 
-			void handleCanExecuteChanged(object sender, EventArgs e)
+			void handleCanExecuteChanged(object? sender, EventArgs e)
 			{
 				if (++canExecuteChangedCount > 1)
 					canExecuteChangedGreaterThan1TCS.SetResult(null);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/IAsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/IAsyncCommand_Tests.cs
@@ -201,7 +201,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(command.CanExecute(null));
 			Assert.Equal(0, canExecuteChangedCount);
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 		}
 
 		[Fact]
@@ -229,7 +229,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(command.CanExecute(null));
 			Assert.Equal(2, canExecuteChangedCount);
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/ICommand_AsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/ICommand_AsyncCommand_Tests.cs
@@ -43,7 +43,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 		public void ICommand_ExecuteAsync_InvalidValueTypeParameter_Test()
 		{
 			// Arrange
-			InvalidCommandParameterException actualInvalidCommandParameterException = null;
+			InvalidCommandParameterException? actualInvalidCommandParameterException = null;
 			var expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(string), typeof(int));
 
 			ICommand command = new AsyncCommand<string>(StringParameterTask);
@@ -61,7 +61,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 		public void ICommand_ExecuteAsync_InvalidReferenceTypeParameter_Test()
 		{
 			// Arrange
-			InvalidCommandParameterException actualInvalidCommandParameterException = null;
+			InvalidCommandParameterException? actualInvalidCommandParameterException = null;
 			var expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(int), typeof(string));
 
 			ICommand command = new AsyncCommand<int>(IntParameterTask);
@@ -78,7 +78,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 		public void ICommand_ExecuteAsync_ValueTypeParameter_Test()
 		{
 			// Arrange
-			InvalidCommandParameterException actualInvalidCommandParameterException = null;
+			InvalidCommandParameterException? actualInvalidCommandParameterException = null;
 			var expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(int));
 
 			ICommand command = new AsyncCommand<int>(IntParameterTask);
@@ -197,7 +197,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 
 			ICommand command = new AsyncCommand<int>(IntParameterTask);
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(Delay);
@@ -239,7 +239,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(command.CanExecute(null));
 			Assert.Equal(2, canExecuteChangedCount);
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 		}
 
 		[Fact]
@@ -251,7 +251,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			ICommand command = new AsyncCommand(() => IntParameterTask(Delay));
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(null);
@@ -277,7 +277,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			ICommand command = new AsyncCommand(() => IntParameterTask(Delay), allowsMultipleExecutions: false);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(null);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/AsyncValueCommand_Tests.cs
@@ -175,7 +175,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public void AsyncValueCommandNoParameter_NoCanExecute_Test()
 		{
 			// Arrange
-			Func<bool> canExecute = null;
+			Func<bool>? canExecute = null;
 			var command = new AsyncValueCommand(NoParameterTask, canExecute);
 
 			// Act
@@ -188,7 +188,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public async Task AsyncValueCommand_RaiseCanExecuteChanged_Test()
 		{
 			// Arrange
-			var handleCanExecuteChangedTCS = new TaskCompletionSource<object>();
+			var handleCanExecuteChangedTCS = new TaskCompletionSource<object?>();
 
 			var canCommandExecute = false;
 			var didCanExecuteChangeFire = false;
@@ -215,7 +215,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			Assert.True(didCanExecuteChangeFire);
 			Assert.True(command.CanExecute(null));
 
-			void handleCanExecuteChanged(object sender, EventArgs e)
+			void handleCanExecuteChanged(object? sender, EventArgs e)
 			{
 				didCanExecuteChangeFire = true;
 				handleCanExecuteChangedTCS.SetResult(null);
@@ -226,7 +226,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public async Task AsyncValueCommand_ChangeCanExecute_Test()
 		{
 			// Arrange
-			var handleCanExecuteChangedTCS = new TaskCompletionSource<object>();
+			var handleCanExecuteChangedTCS = new TaskCompletionSource<object?>();
 
 			var canCommandExecute = false;
 			var didCanExecuteChangeFire = false;
@@ -255,7 +255,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			Assert.True(didCanExecuteChangeFire);
 			Assert.True(command.CanExecute(null));
 
-			void handleCanExecuteChanged(object sender, EventArgs e)
+			void handleCanExecuteChanged(object? sender, EventArgs e)
 			{
 				didCanExecuteChangeFire = true;
 				handleCanExecuteChangedTCS.SetResult(null);
@@ -271,7 +271,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			var command = new AsyncValueCommand<int>(IntParameterTask);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			Assert.True(command.AllowsMultipleExecutions);
 
@@ -299,7 +299,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			var command = new AsyncValueCommand<int>(IntParameterTask, allowsMultipleExecutions: false);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			Assert.False(command.AllowsMultipleExecutions);
 
@@ -327,7 +327,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			var command = new AsyncValueCommand(() => IntParameterTask(Delay));
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			Assert.True(command.AllowsMultipleExecutions);
 
@@ -355,7 +355,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			var command = new AsyncValueCommand(() => IntParameterTask(Delay), allowsMultipleExecutions: false);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			Assert.False(command.AllowsMultipleExecutions);
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/ICommand_AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/ICommand_AsyncValueCommand_Tests.cs
@@ -43,7 +43,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public async Task ICommand_Execute_InvalidValueTypeParameter_Test()
 		{
 			// Arrange
-			InvalidCommandParameterException actualInvalidCommandParameterException = null;
+			InvalidCommandParameterException? actualInvalidCommandParameterException = null;
 			var expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(string), typeof(int));
 
 			ICommand command = new AsyncValueCommand<string>(StringParameterTask);
@@ -69,7 +69,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public async Task ICommand_Execute_InvalidReferenceTypeParameter_Test()
 		{
 			// Arrange
-			InvalidCommandParameterException actualInvalidCommandParameterException = null;
+			InvalidCommandParameterException? actualInvalidCommandParameterException = null;
 			var expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(int), typeof(string));
 
 			ICommand command = new AsyncValueCommand<int>(IntParameterTask);
@@ -95,7 +95,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public async Task ICommand_Execute_ValueTypeParameter_Test()
 		{
 			// Arrange
-			InvalidCommandParameterException actualInvalidCommandParameterException = null;
+			InvalidCommandParameterException? actualInvalidCommandParameterException = null;
 			var expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(int));
 
 			ICommand command = new AsyncValueCommand<int>(IntParameterTask);
@@ -224,7 +224,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			ICommand command = new AsyncValueCommand<int>(IntParameterTask);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(Delay);
@@ -249,7 +249,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			ICommand command = new AsyncValueCommand<int>(IntParameterTask, allowsMultipleExecutions: false);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(Delay);
@@ -275,7 +275,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			ICommand command = new AsyncValueCommand(() => IntParameterTask(Delay));
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(null);
@@ -301,7 +301,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			ICommand command = new AsyncValueCommand(() => IntParameterTask(Delay), allowsMultipleExecutions: false);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(null);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_AsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_AsyncCommand_Tests.cs
@@ -13,7 +13,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncCommand_NullExecuteParameter()
 		{
 			// Arrange
-			Func<Task> execute = null;
+			Func<Task>? execute = null;
 
 			// Act
 
@@ -61,7 +61,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncCommand_FuncBool_NullExecuteParameter()
 		{
 			// Arrange
-			Func<Task> execute = null;
+			Func<Task>? execute = null;
 
 			// Act
 
@@ -73,7 +73,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public async Task AsyncCommand_FuncBool_NullCanExecuteParameter()
 		{
 			// Arrange
-			Func<bool> canExecute = null;
+			Func<bool>? canExecute = null;
 			var command = CommandFactory.Create(NoParameterTask, canExecute);
 
 			// Act
@@ -112,7 +112,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncCommandT_NullExecuteParameter()
 		{
 			// Arrange
-			Func<int, Task> execute = null;
+			Func<int, Task>? execute = null;
 
 			// Act
 
@@ -162,7 +162,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncCommandT_FuncBool_NullExecuteParameter()
 		{
 			// Arrange
-			Func<int, Task> execute = null;
+			Func<int, Task>? execute = null;
 
 			// Act
 
@@ -174,7 +174,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public async Task AsyncCommandT_FuncBool_NullCanExecuteParameter()
 		{
 			// Arrange
-			Func<bool> canExecute = null;
+			Func<bool>? canExecute = null;
 			var command = CommandFactory.Create<int>(IntParameterTask, canExecute);
 
 			// Act
@@ -213,7 +213,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncCommandTExecuteTCanExecute_NullExecuteParameter()
 		{
 			// Arrange
-			Func<int, Task> execute = null;
+			Func<int, Task>? execute = null;
 
 			// Act
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_AsyncValueCommand_Tests.cs
@@ -14,7 +14,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncValueCommand_NullExecuteParameter()
 		{
 			// Arrange
-			Func<Task> execute = null;
+			Func<Task>? execute = null;
 
 			// Act
 
@@ -62,7 +62,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncValueCommand_FuncBool_NullExecuteParameter()
 		{
 			// Arrange
-			Func<ValueTask> execute = null;
+			Func<ValueTask>? execute = null;
 
 			// Act
 
@@ -74,7 +74,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public async Task AsyncValueCommand_FuncBool_NullCanExecuteParameter()
 		{
 			// Arrange
-			Func<bool> canExecute = null;
+			Func<bool>? canExecute = null;
 			var command = CommandFactory.Create(NoParameterTask, canExecute);
 
 			// Act
@@ -113,7 +113,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncValueCommandT_NullExecuteParameter()
 		{
 			// Arrange
-			Func<int, ValueTask> execute = null;
+			Func<int, ValueTask>? execute = null;
 
 			// Act
 
@@ -163,7 +163,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncValueCommandT_FuncBool_NullExecuteParameter()
 		{
 			// Arrange
-			Func<int, ValueTask> execute = null;
+			Func<int, ValueTask>? execute = null;
 
 			// Act
 
@@ -175,7 +175,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public async Task AsyncValueCommandT_FuncBool_NullCanExecuteParameter()
 		{
 			// Arrange
-			Func<bool> canExecute = null;
+			Func<bool>? canExecute = null;
 			var command = CommandFactory.Create<int>(IntParameterTask, canExecute);
 
 			// Act
@@ -214,7 +214,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncValueCommandTExecuteTCanExecute_NullExecuteParameter()
 		{
 			// Arrange
-			Func<int, ValueTask> execute = null;
+			Func<int, ValueTask>? execute = null;
 
 			// Act
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_Command_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_Command_Tests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows.Input;
-using Xamarin.CommunityToolkit.Exceptions;
 using Xamarin.CommunityToolkit.ObjectModel;
 using Xunit;
 
@@ -12,7 +11,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void Action_NullExecuteParameter()
 		{
 			// Arrange
-			Action execute = null;
+			Action? execute = null;
 
 			// Act
 
@@ -71,7 +70,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void ActionObject_NullExecuteParameter()
 		{
 			// Arrange
-			Action<object> execute = null;
+			Action<object>? execute = null;
 
 			// Act
 
@@ -132,7 +131,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void ActionInt_NullExecuteParameter()
 		{
 			// Arrange
-			Action<int> execute = null;
+			Action<int>? execute = null;
 
 			// Act
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableObject_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableObject_Tests.cs
@@ -7,21 +7,16 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 {
 	public sealed class ObservableObject_Tests
 	{
-		Person person;
-
-		public ObservableObject_Tests()
+		readonly Person person = new Person
 		{
-			person = new Person
-			{
-				FirstName = "James",
-				LastName = "Montemagno"
-			};
-		}
+			FirstName = "James",
+			LastName = "Montemagno"
+		};
 
 		[Fact]
 		public void OnPropertyChanged()
 		{
-			PropertyChangedEventArgs updated = null;
+			PropertyChangedEventArgs? updated = null;
 			person.PropertyChanged += (sender, args) =>
 			{
 				updated = args;
@@ -30,13 +25,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 			person.FirstName = "Motz";
 
 			Assert.NotNull(updated);
-			Assert.Equal(nameof(person.FirstName), updated.PropertyName);
+			Assert.Equal(nameof(person.FirstName), updated?.PropertyName);
 		}
 
 		[Fact]
 		public void OnDidntChange()
 		{
-			PropertyChangedEventArgs updated = null;
+			PropertyChangedEventArgs? updated = null;
 			person.PropertyChanged += (sender, args) =>
 			{
 				updated = args;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableRangeCollection_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableRangeCollection_Tests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using Xamarin.CommunityToolkit.ObjectModel;
 using Xunit;
 using Xunit.Sdk;
@@ -121,7 +122,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 					throw new XunitException("Expected and actual OldItems don't match.");
 				for (var i = 0; i < expected.Length; i++)
 				{
-					if (expected[i] != (int)e.OldItems[i])
+					if (expected[i] != (int?)e.OldItems[i])
 						throw new XunitException("Expected and actual OldItems don't match.");
 				}
 			};
@@ -176,12 +177,6 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 			Assert.Equal(6, collection.Count);
 		}
 
-		class CollectionWrapper<T>
-		{
-			public readonly ObservableRangeCollection<T> Collection = new ObservableRangeCollection<T>();
-			public ObservableRangeCollection<T> NullCollection;
-		}
-
 		[Fact]
 		public void AddCollection()
 		{
@@ -200,6 +195,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 		{
 			var toAdd = new[] { 3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 2, 3 };
 
+#pragma warning disable CS8670 // Object or collection initializer implicitly dereferences possibly null member.
 			Assert.Throws<ArgumentNullException>(() =>
 			{
 				var wrapper = new CollectionWrapper<int>()
@@ -207,6 +203,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 					NullCollection = { toAdd }
 				};
 			});
+#pragma warning restore CS8670 // Object or collection initializer implicitly dereferences possibly null member.
+		}
+
+		class CollectionWrapper<T>
+		{
+			public ObservableRangeCollection<T> Collection { get; } = new ObservableRangeCollection<T>();
+
+			public ObservableRangeCollection<T>? NullCollection { get; init; }
 		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/Person.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/Person.cs
@@ -5,14 +5,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 {
 	class Person : ObservableObject
 	{
-		string firstName;
-		string lastName;
+		string firstName = string.Empty;
+		string lastName = string.Empty;
 
-		public Action Changed { get; set; }
+		public Action? Changed { get; set; }
 
-		public Action Changing { get; set; }
+		public Action? Changing { get; set; }
 
-		public Func<string, string, bool> Validate { get; set; }
+		public Func<string, string, bool>? Validate { get; set; }
 
 		public string FirstName
 		{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Views/MediaSource_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Views/MediaSource_Tests.cs
@@ -32,7 +32,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Views
 		public void TestImplicitFileConversion()
 		{
 			var mediaElement = new UI.Views.MediaElement { Source = "File.mp4" };
-			Assert.True(mediaElement.Source != null);
+			Assert.NotNull(mediaElement.Source);
 			Assert.IsType<Core.FileMediaSource>(mediaElement.Source);
 			Assert.Equal("File.mp4", ((Core.FileMediaSource)mediaElement.Source).File);
 		}
@@ -40,7 +40,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Views
 		[Fact]
 		public void TestImplicitStringConversionWhenNull()
 		{
-			string s = null;
+			string? s = null;
 			var sut = (Core.MediaSource)s;
 			Assert.IsType<Core.FileMediaSource>(sut);
 			Assert.Null(((Core.FileMediaSource)sut).File);
@@ -50,7 +50,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Views
 		public void TestImplicitUriConversion()
 		{
 			var mediaElement = new UI.Views.MediaElement { Source = new Uri("http://xamarin.com/media.mp4") };
-			Assert.True(mediaElement.Source != null);
+			Assert.NotNull(mediaElement.Source);
 			Assert.IsType<Core.UriMediaSource>(mediaElement.Source);
 			Assert.Equal("http://xamarin.com/media.mp4", ((Core.UriMediaSource)mediaElement.Source).Uri.AbsoluteUri);
 		}
@@ -59,7 +59,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Views
 		public void TestImplicitStringUriConversion()
 		{
 			var mediaElement = new UI.Views.MediaElement { Source = "http://xamarin.com/media.mp4" };
-			Assert.True(mediaElement.Source != null);
+			Assert.NotNull(mediaElement.Source);
 			Assert.IsType<Core.UriMediaSource>(mediaElement.Source);
 			Assert.Equal("http://xamarin.com/media.mp4", ((Core.UriMediaSource)mediaElement.Source).Uri.AbsoluteUri);
 		}
@@ -67,7 +67,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Views
 		[Fact]
 		public void TestImplicitUriConversionWhenNull()
 		{
-			Uri u = null;
+			Uri? u = null;
 			var sut = (Core.MediaSource)u;
 			Assert.Null(sut);
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Xamarin.CommunityToolkit.UnitTests.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Xamarin.CommunityToolkit.UnitTests.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net461</TargetFrameworks>
-
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION

### Description of Change ###

This PR enables [Nullability](https://docs.microsoft.com/dotnet/csharp/nullable-references#nullable-contexts&WT.mc_id=mobile-0000-bramin) for Xamarin.Community Toolkit

### Bugs Fixed ###

This PR resolves possible `NullReferenceExceptions`

- Fixes #254 

### API Changes ###

- [x] Enable Nullable on `Xamarin.CommunityToolkit.UnitTests`
- [ ] Enable Nullable on `Xamarin.CommunityToolkit`
- [ ] Enable Nullable on `Xamarin.CommunityToolkit.Markup`
- [ ] Enable Nullable on `Xamarin.CommunityToolkit.Sample`
- [ ] Enable Nullable on `Xamarin.CommunityToolkit.Sample.Android`
- [ ] Enable Nullable on `Xamarin.CommunityToolkit.Samples.GTK`
- [ ] Enable Nullable on `Xamarin.CommunityToolkit.Samples.iOS`
- [ ] Enable Nullable on `Xamarin.CommunityToolkit.Samples.Tizen`
- [ ] Enable Nullable on `Xamarin.CommunityToolkit.Samples.UWP`
- [ ] Enable Nullable on `Xamarin.CommunityToolkit.Samples.WPF`

### Behavioral Changes ###

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

### PR Checklist ###

- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
