### PR TITLE
[Enhancement] Add Scale support for SideMenuView

### DIFF
--- a/samples/XCT.Sample/Pages/Views/SideMenuViewPage.xaml
+++ b/samples/XCT.Sample/Pages/Views/SideMenuViewPage.xaml
@@ -35,6 +35,7 @@
         <BoxView
             xct:SideMenuView.Position="LeftMenu"
             xct:SideMenuView.MenuWidthPercentage=".5"
+            xct:SideMenuView.MainViewScaleFactor=".95"
             BackgroundColor="Orange"/>
 
         <!-- RightMenu -->

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
@@ -396,7 +396,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			using (mainView.Batch())
 			{
-				var scale = 1 - ((1 - GetMainViewScaleFactor(activeMenu)) * shift / activeMenuWidth);
+				var scale = 1 - ((1 - GetMainViewScaleFactor(activeMenu)) * animationEasing.Ease(shift / activeMenuWidth));
 				mainView.Scale = scale;
 				mainView.TranslationX = shift - (Sign(shift) * mainViewWidth * 0.5 * (1 - scale));
 			}


### PR DESCRIPTION
### Description of Change ###
Make it possible to scale the main view during the interaction.

### Bugs Fixed ###
- Fixes #1007

### API Changes ###
Added: 
 - `double SideMenuView.MainViewScaleFactor` (attached property)

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
