### PR TITLE
Enable Nullability for Android, GTK, iOS, Tizen, UWP & WPF Sample Projects

### DIFF
--- a/samples/XCT.Sample.Android/SplashActivity.cs
+++ b/samples/XCT.Sample.Android/SplashActivity.cs
@@ -9,7 +9,7 @@ namespace Xamarin.CommunityToolkit.Sample.Droid
 	[Activity(Label = "XamarinCommunityToolkitSample", Icon = "@mipmap/icon", Theme = "@style/SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
 	public class SplashActivity : AppCompatActivity
 	{
-		protected override void OnCreate(Bundle savedInstanceState)
+		protected override void OnCreate(Bundle? savedInstanceState)
 		{
 			base.OnCreate(savedInstanceState);
 			var intent = new Intent(this, typeof(MainActivity));

--- a/samples/XCT.Sample.Android/Xamarin.CommunityToolkit.Sample.Android.csproj
+++ b/samples/XCT.Sample.Android/Xamarin.CommunityToolkit.Sample.Android.csproj
@@ -22,6 +22,9 @@
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/XCT.Sample.GTK/Xamarin.CommunityToolkit.Sample.GTK.csproj
+++ b/samples/XCT.Sample.GTK/Xamarin.CommunityToolkit.Sample.GTK.csproj
@@ -13,6 +13,9 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/XCT.Sample.Tizen/Xamarin.CommunityToolkit.Sample.Tizen.csproj
+++ b/samples/XCT.Sample.Tizen/Xamarin.CommunityToolkit.Sample.Tizen.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen40</TargetFramework>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/XCT.Sample.UWP/Xamarin.CommunityToolkit.Sample.UWP.csproj
+++ b/samples/XCT.Sample.UWP/Xamarin.CommunityToolkit.Sample.UWP.csproj
@@ -18,6 +18,9 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/XCT.Sample.WPF/Xamarin.CommunityToolkit.Sample.WPF.csproj
+++ b/samples/XCT.Sample.WPF/Xamarin.CommunityToolkit.Sample.WPF.csproj
@@ -16,6 +16,9 @@
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/samples/XCT.Sample.iOS/Renderers/NoLineNavigationRenderer.cs
+++ b/samples/XCT.Sample.iOS/Renderers/NoLineNavigationRenderer.cs
@@ -25,8 +25,11 @@ namespace Xamarin.CommunityToolkit.Sample.iOS.Renderers
 			// Newest iOS version fix - trycatch isn't optimal
 			try
 			{
-				NavigationBar.ScrollEdgeAppearance.ShadowImage = new UIKit.UIImage();
-				NavigationBar.ScrollEdgeAppearance.ShadowColor = null;
+				if (NavigationBar.ScrollEdgeAppearance != null)
+				{
+					NavigationBar.ScrollEdgeAppearance.ShadowImage = new UIKit.UIImage();
+					NavigationBar.ScrollEdgeAppearance.ShadowColor = null;
+				}
 			}
 			catch (Exception)
 			{

--- a/samples/XCT.Sample.iOS/Xamarin.CommunityToolkit.Sample.iOS.csproj
+++ b/samples/XCT.Sample.iOS/Xamarin.CommunityToolkit.Sample.iOS.csproj
@@ -15,6 +15,9 @@
     <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <ProvisioningType>automatic</ProvisioningType>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/XCT.Sample/Helpers/XLog.cs
+++ b/samples/XCT.Sample/Helpers/XLog.cs
@@ -13,7 +13,7 @@ namespace Xamarin.CommunityToolkit.Sample
 	/// </summary>
 	public static class XLog
 	{
-		static string rootFolderPattern = null;
+		static string? rootFolderPattern = null;
 #if WINDOWS_UWP
         static LoggingChannel loggingChannel;
 #endif
@@ -22,7 +22,7 @@ namespace Xamarin.CommunityToolkit.Sample
 		/// Call this before logging starts.
 		/// </summary>
 		/// <param name="rootFolderPattern">Should match the top folder name(s) within the source control repository, e.g. @"\MobileRealtimePush\MobileRealtimePush\". Any folders before the first match of this pattern are omitted from the logged source file paths</param>
-		public static void Init(string rootFolderPattern = null)
+		public static void Init(string? rootFolderPattern = null)
 		{
 			XLog.rootFolderPattern = rootFolderPattern;
 #if WINDOWS_UWP
@@ -46,10 +46,10 @@ namespace Xamarin.CommunityToolkit.Sample
 		/// <param name="sourceLineNumber">supplied by compiler, no need to specify in code unless you want to pass a deeper call context</param>
 		[Conditional("DEBUG")]
 		public static void Debug(
-			object data = null,
-			string tag = null,
-			[CallerMemberName] string memberName = null,
-			[CallerFilePath] string sourceFilePath = null,
+			object? data = null,
+			string? tag = null,
+			[CallerMemberName] string? memberName = null,
+			[CallerFilePath] string? sourceFilePath = null,
 			[CallerLineNumber] int sourceLineNumber = -1)
 		{
 			var message = FormatLogString(data, tag, memberName, sourceFilePath, sourceLineNumber);
@@ -75,10 +75,10 @@ namespace Xamarin.CommunityToolkit.Sample
 		/// <param name="sourceLineNumber">supplied by compiler, no need to specify in code unless you want to pass a deeper call context</param>
 		[Conditional("TRACE")]
 		public static void Trace(
-			object data = null,
-			string tag = null,
-			[CallerMemberName] string memberName = null,
-			[CallerFilePath] string sourceFilePath = null,
+			object? data = null,
+			string? tag = null,
+			[CallerMemberName] string? memberName = null,
+			[CallerFilePath] string? sourceFilePath = null,
 			[CallerLineNumber] int sourceLineNumber = -1)
 		{
 			var message = FormatLogString(data, tag, memberName, sourceFilePath, sourceLineNumber);
@@ -90,9 +90,9 @@ namespace Xamarin.CommunityToolkit.Sample
 #endif
 		}
 
-		public static string TruncateAt(this string s, int maxLength, string truncatedSuffix = "...") => s?.Length <= maxLength ? s : s.Substring(0, maxLength) + truncatedSuffix;
+		public static string TruncateAt(this string? s, int maxLength, string truncatedSuffix = "...") => s?.Length <= maxLength ? s : s?.Substring(0, maxLength) + truncatedSuffix;
 
-		static string FormatLogString(object data = null, string tag = null, string memberName = null, string sourceFilePath = null, int sourceLineNumber = -1)
+		static string FormatLogString(object? data, string? tag, string? memberName, string? sourceFilePath, int sourceLineNumber)
 		{
 			var line = new StringBuilder();
 
@@ -121,7 +121,7 @@ namespace Xamarin.CommunityToolkit.Sample
 				line.Append(dataString);
 			}
 
-			if (!string.IsNullOrEmpty(sourceFilePath))
+			if (sourceFilePath != null && !string.IsNullOrEmpty(sourceFilePath))
 			{
 				if (!string.IsNullOrEmpty(rootFolderPattern))
 				{

--- a/samples/XCT.Sample/Pages/Converters/BoolToObjectConverterPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/BoolToObjectConverterPage.xaml.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Xamarin.Forms;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
-	public partial class BoolToObjectConverterPage 
+	public partial class BoolToObjectConverterPage
 	{
-		public BoolToObjectConverterPage()
-		{
-			InitializeComponent();
-		}
+		public BoolToObjectConverterPage() => InitializeComponent();
 	}
 }

--- a/samples/XCT.Sample/Pages/Converters/DoubleToIntConverterPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/DoubleToIntConverterPage.xaml.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Xamarin.Forms;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
-	public partial class DoubleToIntConverterPage 
+	public partial class DoubleToIntConverterPage
 	{
-		public DoubleToIntConverterPage()
-		{
-			InitializeComponent();
-		}
+		public DoubleToIntConverterPage() => InitializeComponent();
 	}
 }

--- a/samples/XCT.Sample/Pages/Converters/EnumToBoolConverterPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/EnumToBoolConverterPage.xaml.cs
@@ -1,10 +1,7 @@
-namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
-	public partial class EnumToBoolConverterPage
-	{
-		public EnumToBoolConverterPage()
-		{
-			InitializeComponent();
-		}
-	}
+    public partial class EnumToBoolConverterPage
+    {
+        public EnumToBoolConverterPage() => InitializeComponent();
+    }
 }

--- a/samples/XCT.Sample/Pages/Converters/EqualConverterPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/EqualConverterPage.xaml.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Xamarin.Forms;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
-	public partial class EqualConverterPage 
+	public partial class EqualConverterPage
 	{
-		public EqualConverterPage()
-		{
-			InitializeComponent();
-		}
+		public EqualConverterPage() => InitializeComponent();
 	}
 }

--- a/samples/XCT.Sample/Pages/Converters/IndexToArrayItemConverterPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/IndexToArrayItemConverterPage.xaml.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Xamarin.Forms;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
-	public partial class IndexToArrayItemConverterPage 
+	public partial class IndexToArrayItemConverterPage
 	{
-		public IndexToArrayItemConverterPage()
-		{
-			InitializeComponent();
-		}
+		public IndexToArrayItemConverterPage() => InitializeComponent();
 	}
 }

--- a/samples/XCT.Sample/Pages/Converters/IntToBoolConverterPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/IntToBoolConverterPage.xaml.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Xamarin.Forms;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
-	public partial class IntToBoolConverterPage 
+	public partial class IntToBoolConverterPage
 	{
-		public IntToBoolConverterPage()
-		{
-			InitializeComponent();
-		}
+		public IntToBoolConverterPage() => InitializeComponent();
 	}
 }

--- a/samples/XCT.Sample/Pages/Converters/InvertedBoolConverterPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/InvertedBoolConverterPage.xaml.cs
@@ -1,10 +1,7 @@
 ﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
-	public partial class InvertedBoolConverterPage 
+	public partial class InvertedBoolConverterPage
 	{
-		public InvertedBoolConverterPage()
-		{
-			InitializeComponent();
-		}
+		public InvertedBoolConverterPage() => InitializeComponent();
 	}
 }

--- a/samples/XCT.Sample/Pages/Converters/IsNotNullOrEmptyConverterPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/IsNotNullOrEmptyConverterPage.xaml.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Xamarin.Forms;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
-	public partial class IsNotNullOrEmptyConverterPage 
+	public partial class IsNotNullOrEmptyConverterPage
 	{
-		public IsNotNullOrEmptyConverterPage()
-		{
-			InitializeComponent();
-		}
+		public IsNotNullOrEmptyConverterPage() => InitializeComponent();
 	}
 }

--- a/samples/XCT.Sample/Pages/Converters/ListToStringConverterPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/ListToStringConverterPage.xaml.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Xamarin.Forms;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
-	public partial class ListToStringConverterPage 
+	public partial class ListToStringConverterPage
 	{
-		public ListToStringConverterPage()
-		{
-			InitializeComponent();
-		}
+		public ListToStringConverterPage() => InitializeComponent();
 	}
 }

--- a/samples/XCT.Sample/Pages/Converters/NotEqualConverterPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/NotEqualConverterPage.xaml.cs
@@ -1,15 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Xamarin.Forms;
-
-namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
-	public partial class NotEqualConverterPage 
+	public partial class NotEqualConverterPage
 	{
-		public NotEqualConverterPage()
-		{
-			InitializeComponent();
-		}
+		public NotEqualConverterPage() => InitializeComponent();
 	}
 }

--- a/samples/XCT.Sample/Pages/Converters/TextCaseConverterPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Converters/TextCaseConverterPage.xaml.cs
@@ -1,10 +1,7 @@
 ﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Converters
 {
-	public partial class TextCaseConverterPage 
+	public partial class TextCaseConverterPage
 	{
-		public TextCaseConverterPage()
-		{
-			InitializeComponent();
-		}
+		public TextCaseConverterPage() => InitializeComponent();
 	}
 }

--- a/samples/XCT.Sample/Pages/Effects/ShadowEffectPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Effects/ShadowEffectPage.xaml.cs
@@ -1,11 +1,7 @@
-﻿
-namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
 {
 	public partial class ShadowEffectPage
 	{
-		public ShadowEffectPage()
-		{
-			InitializeComponent();
-		}
+		public ShadowEffectPage() => InitializeComponent();
 	}
 }

--- a/samples/XCT.Sample/Pages/Markup/SearchPage.logic.cs
+++ b/samples/XCT.Sample/Pages/Markup/SearchPage.logic.cs
@@ -9,21 +9,21 @@ namespace Xamarin.CommunityToolkit.Sample
 	public partial class SearchPage : BasePage
 	{
 		readonly SearchViewModel vm;
-		View header;
+		View? header;
 
 		public SearchPage()
 		{
 			On<iOS>().SetUseSafeArea(true);
 			BackgroundColor = Color.Black;
 
-			BindingContext = new SearchViewModel();
+			BindingContext = vm = new SearchViewModel();
 			Build();
 		}
 
 		void Search_FocusChanged(object sender, FocusEventArgs e)
 		{
 			ViewExtensions.CancelAnimations(header);
-			header.TranslateTo(e.IsFocused ? -56 : 0, 0, 250, Easing.CubicOut);
+			header?.TranslateTo(e.IsFocused ? -56 : 0, 0, 250, Easing.CubicOut);
 		}
 	}
 }

--- a/samples/XCT.Sample/Pages/TestCases/MediaElementSourcePage.xaml.cs
+++ b/samples/XCT.Sample/Pages/TestCases/MediaElementSourcePage.xaml.cs
@@ -1,22 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xamarin.CommunityToolkit.Core;
+﻿using Xamarin.CommunityToolkit.Core;
 using Xamarin.Forms;
-using Xamarin.Forms.Xaml;
 
 namespace Xamarin.CommunityToolkit.Sample.Pages.TestCases
 {
 	public partial class MediaElementSourcePage
 	{
-		public MediaElementSourcePage()
-		{
-			InitializeComponent();
-		}
+		public MediaElementSourcePage() => InitializeComponent();
 	}
-
 
 	class MediaElementViewModel : BindableObject
 	{

--- a/samples/XCT.Sample/Pages/TestCases/TouchEffectCollectionViewPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/TestCases/TouchEffectCollectionViewPage.xaml.cs
@@ -1,19 +1,16 @@
-﻿
-using System.Windows.Input;
-using Xamarin.Forms;
+﻿using System.Windows.Input;
+using Xamarin.CommunityToolkit.ObjectModel;
 
 namespace Xamarin.CommunityToolkit.Sample.Pages.TestCases
 {
 	public partial class TouchEffectCollectionViewPage
 	{
-		ICommand longPressCommand;
-
 		public TouchEffectCollectionViewPage()
-			=> InitializeComponent();
-
-		public ICommand LongPressCommand => longPressCommand ??= new Command(() =>
 		{
-			this.DisplayAlert("Long Press", null, "OK");
-		});
+			InitializeComponent();
+			LongPressCommand = new AsyncCommand(() => DisplayAlert("Long Press", null, "OK"));
+		}
+
+		public ICommand LongPressCommand { get; }
 	}
 }

--- a/samples/XCT.Sample/Pages/Views/SnackBarPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Views/SnackBarPage.xaml.cs
@@ -40,6 +40,7 @@ namespace Xamarin.CommunityToolkit.Sample.Pages.Views
 
 			await this.DisplaySnackBarAsync(options);
 		}
+
 		async void DisplayToastClicked(object sender, EventArgs args)
 		{
 			await this.DisplayToastAsync(GenerateLongText(5));

--- a/samples/XCT.Sample/ViewModels/AboutViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/AboutViewModel.cs
@@ -12,9 +12,9 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 	{
 		readonly GitHubClient gitHubClient = new GitHubClient(new ProductHeaderValue("XamarinCommunityToolkitSample"));
 
-		RepositoryContributor[] contributors = new RepositoryContributor[0];
+		RepositoryContributor[] contributors = Array.Empty<RepositoryContributor>();
 
-		RepositoryContributor selectedContributor;
+		RepositoryContributor? selectedContributor;
 
 		string emptyViewText = "Loading data...";
 
@@ -37,7 +37,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 			set => SetProperty(ref contributors, value);
 		}
 
-		public RepositoryContributor SelectedContributor
+		public RepositoryContributor? SelectedContributor
 		{
 			get => selectedContributor;
 			set => SetProperty(ref selectedContributor, value);

--- a/samples/XCT.Sample/ViewModels/Base/BaseGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Base/BaseGalleryViewModel.cs
@@ -20,9 +20,9 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 
 		public ICommand FilterCommand { get; }
 
-		public string FilterValue { private get; set; }
+		public string FilterValue { private get; set; } = string.Empty;
 
-		public IEnumerable<SectionModel> FilteredItems { get; private set; }
+		public IEnumerable<SectionModel> FilteredItems { get; private set; } = Array.Empty<SectionModel>();
 
 		protected abstract IEnumerable<SectionModel> CreateItems();
 

--- a/samples/XCT.Sample/ViewModels/Behaviors/MaxLengthReachedBehaviorViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Behaviors/MaxLengthReachedBehaviorViewModel.cs
@@ -6,7 +6,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 {
 	public class MaxLengthReachedBehaviorViewModel : BaseViewModel
 	{
-		string commandExecutions;
+		string commandExecutions = string.Empty;
 
 		public string CommandExecutions
 		{

--- a/samples/XCT.Sample/ViewModels/Behaviors/ProgressBarAnimationBehaviorViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Behaviors/ProgressBarAnimationBehaviorViewModel.cs
@@ -1,37 +1,31 @@
-﻿using System;
-using System.Threading.Tasks;
-using System.Windows.Input;
-using Xamarin.CommunityToolkit.ObjectModel;
+﻿using System.Windows.Input;
+using Xamarin.Forms;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 {
 	public class ProgressBarAnimationBehaviorViewModel : BaseViewModel
 	{
 		double progress;
-		ICommand setTo0Command;
-		ICommand setTo50Command;
-		ICommand setTo100Command;
+
+		public ProgressBarAnimationBehaviorViewModel()
+		{
+			SetTo0Command = new Command(() => SetProgress(0));
+			SetTo50Command = new Command(() => SetProgress(0.5));
+			SetTo100Command = new Command(() => SetProgress(1));
+		}
+
+		public ICommand SetTo0Command { get; }
+
+		public ICommand SetTo50Command { get; }
+
+		public ICommand SetTo100Command { get; }
 
 		public double Progress
 		{
 			get => progress;
-			set
-			{
-				progress = value;
-				OnPropertyChanged();
-			}
+			set => SetProperty(ref progress, value);
 		}
 
-		public ICommand SetTo0Command => setTo0Command ??= new AsyncCommand(() => SetProgress(0));
-
-		public ICommand SetTo50Command => setTo50Command ??= new AsyncCommand(() => SetProgress(0.5));
-
-		public ICommand SetTo100Command => setTo100Command ??= new AsyncCommand(() => SetProgress(1));
-
-		async Task SetProgress(double
-			progress)
-		{
-			Progress = progress;
-		}
+		void SetProgress(double progress) => Progress = progress;
 	}
 }

--- a/samples/XCT.Sample/ViewModels/Behaviors/UserStoppedTypingBehaviorViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Behaviors/UserStoppedTypingBehaviorViewModel.cs
@@ -6,9 +6,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 {
 	public class UserStoppedTypingBehaviorViewModel : BaseViewModel
 	{
-		#region Properties
-
-		string performedSearches;
+		string performedSearches = string.Empty;
 
 		public string PerformedSearches
 		{
@@ -17,8 +15,6 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Behaviors
 		}
 
 		public ICommand SearchCommand { get; }
-
-		#endregion Properties
 
 		public UserStoppedTypingBehaviorViewModel()
 			=> SearchCommand = CommandFactory.Create<string>(PerformSearch);

--- a/samples/XCT.Sample/ViewModels/Converters/ByteArrayToImageSourceViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Converters/ByteArrayToImageSourceViewModel.cs
@@ -11,9 +11,9 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 	{
 		readonly GitHubClient gitHubClient = new GitHubClient(new ProductHeaderValue("XamarinCommunityToolkitSample"));
 
-		byte[] avatar;
+		byte[]? avatar;
 
-		public byte[] Avatar
+		public byte[]? Avatar
 		{
 			get => avatar;
 			set => SetProperty(ref avatar, value);

--- a/samples/XCT.Sample/ViewModels/Converters/EnumToBoolConverterViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Converters/EnumToBoolConverterViewModel.cs
@@ -1,25 +1,25 @@
-namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 {
-	public class EnumToBoolConverterViewModel : BaseViewModel
-	{
-		private IssueState selectedState = IssueState.None;
+    public class EnumToBoolConverterViewModel : BaseViewModel
+    {
+        private IssueState selectedState = IssueState.None;
 
-		public IssueState SelectedState
-		{
-			get => selectedState;
-			set => SetProperty(ref selectedState, value);
-		}
-	}
+        public IssueState SelectedState
+        {
+            get => selectedState;
+            set => SetProperty(ref selectedState, value);
+        }
+    }
 
-	public enum IssueState
-	{
-		None = 0,
-		New = 1,
-		Open = 2,
-		Waiting = 3,
-		Developing = 4,
-		WantFix = 5,
-		Rejected = 6,
-		Resolved = 7
-	}
+    public enum IssueState
+    {
+        None = 0,
+        New = 1,
+        Open = 2,
+        Waiting = 3,
+        Developing = 4,
+        WantFix = 5,
+        Rejected = 6,
+        Resolved = 7
+    }
 }

--- a/samples/XCT.Sample/ViewModels/Converters/IndexToArrayItemConverterViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Converters/IndexToArrayItemConverterViewModel.cs
@@ -1,9 +1,9 @@
-﻿using System;
-namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 {
 	public class IndexToArrayItemConverterViewModel : BaseViewModel
 	{
 		int index;
+
 		public int Index
 		{
 			get => index;

--- a/samples/XCT.Sample/ViewModels/Converters/IsNullOrEmptyConverterViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Converters/IsNullOrEmptyConverterViewModel.cs
@@ -7,7 +7,11 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 {
 	public class IsNullOrEmptyConverterViewModel : BaseViewModel
 	{
-		public ObservableCollection<string> DummyItemSource { get; set; } = new ObservableCollection<string>
+		string? selectedItem;
+
+		public IsNullOrEmptyConverterViewModel() => ClearSelectionCommand = new Command(() => SelectedItem = null);
+
+		public ObservableCollection<string> DummyItemSource { get; } = new ObservableCollection<string>
 		{
 			"Dummy Item 0",
 			"Dummy Item 1",
@@ -17,16 +21,12 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 			"Dummy Item 5",
 		};
 
-		string selectedItem;
+		public ICommand ClearSelectionCommand { get; }
 
-		public string SelectedItem
+		public string? SelectedItem
 		{
 			get => selectedItem;
 			set => SetProperty(ref selectedItem, value);
 		}
-
-		ICommand clearSelectionCommand;
-
-		public ICommand ClearSelectionCommand => clearSelectionCommand ??= new Command(() => SelectedItem = null);
 	}
 }

--- a/samples/XCT.Sample/ViewModels/Converters/ItemTappedEventArgsViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Converters/ItemTappedEventArgsViewModel.cs
@@ -7,13 +7,12 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 {
 	public class ItemTappedEventArgsViewModel
 	{
-		public IEnumerable<Person> Items { get; } =
-			new List<Person>()
-			{
-				new Person() { Id = 1, Name = "Person 1" },
-				new Person() { Id = 2, Name = "Person 2" },
-				new Person() { Id = 3, Name = "Person 3" }
-			};
+		public IEnumerable<Person> Items { get; } = new List<Person>()
+		{
+			new Person() { Id = 1, Name = "Person 1" },
+			new Person() { Id = 2, Name = "Person 2" },
+			new Person() { Id = 3, Name = "Person 3" }
+		};
 
 		public ICommand ItemTappedCommand { get; } =
 			CommandFactory.Create<Person>(person => Application.Current.MainPage.DisplayAlert("Item Tapped: ", person.Name, "Cancel"));
@@ -23,6 +22,6 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 	{
 		public int Id { get; set; }
 
-		public string Name { get; set; }
+		public string Name { get; set; } = string.Empty;
 	}
 }

--- a/samples/XCT.Sample/ViewModels/Converters/VariableMultiValueConverterViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Converters/VariableMultiValueConverterViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
+﻿namespace Xamarin.CommunityToolkit.Sample.ViewModels.Converters
 {
 	public class VariableMultiValueConverterViewModel : BaseViewModel
 	{

--- a/samples/XCT.Sample/ViewModels/Effects/EffectsGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Effects/EffectsGalleryViewModel.cs
@@ -32,20 +32,17 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Effects
 			new SectionModel(
 				typeof(TouchEffectPage),
 				nameof(TouchEffect),
-				"The TouchEffect is an effect that allows changing the view's appearance depending on the touch state (normal, pressed, hovered). Also, it allows to handle long presses."
-				),
+				"The TouchEffect is an effect that allows changing the view's appearance depending on the touch state (normal, pressed, hovered). Also, it allows to handle long presses."),
 
 			new SectionModel(
 				typeof(LifeCycleEffectPage),
 				nameof(LifecycleEffect),
-				"The LifeCycle is an effect that allows you to know when a control or layout is loaded or/and unloaded in the screen and perform actions based on that."
-				),
-        
+				"The LifeCycle is an effect that allows you to know when a control or layout is loaded or/and unloaded in the screen and perform actions based on that."),
+
 			new SectionModel(
 				typeof(ShadowEffectPage),
 				nameof(ShadowEffect),
-				"The ShadowEffect allows all views to display shadow."),
-
+				"The ShadowEffect allows all views to display shadow.")
 		};
 	}
 }

--- a/samples/XCT.Sample/ViewModels/Markup/SearchViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Markup/SearchViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Xamarin.Essentials;
@@ -67,7 +68,9 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Markup
 
 		public ICommand OpenHelpCommand { get; }
 
-		void Back() { }
+		void Back()
+        {
+        }
 
 		void Like(Tweet tweet) => tweet.IsLikedByMe = !tweet.IsLikedByMe;
 
@@ -77,18 +80,18 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Markup
 
 		public class Tweet : BaseViewModel
 		{
-			public string AuthorImage { get; set; }
+			public string AuthorImage { get; set; } = string.Empty;
 
-			public string Header { get; set; }
+			public string Header { get; set; } = string.Empty;
 
-			public List<TextFragment> Body { get; set; }
+			public List<TextFragment> Body { get; set; } = Enumerable.Empty<TextFragment>().ToList();
 
 			public bool IsLikedByMe { get; set; }
 		}
 
 		public class TextFragment
 		{
-			public string Text { get; set; }
+			public string Text { get; set; } = string.Empty;
 
 			public bool IsMatch { get; set; }
 		}

--- a/samples/XCT.Sample/ViewModels/SettingViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/SettingViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Windows.Input;
@@ -12,25 +13,9 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 {
 	public class SettingViewModel : BaseViewModel
 	{
-		IList<Language> supportedLanguages;
-
-		public IList<Language> SupportedLanguages
-		{
-			get => supportedLanguages;
-			private set => SetProperty(ref supportedLanguages, value);
-		}
+		IList<Language> supportedLanguages = Array.Empty<Language>();
 
 		Language selectedLanguage;
-
-		public Language SelectedLanguage
-		{
-			get => selectedLanguage;
-			set => SetProperty(ref selectedLanguage, value);
-		}
-
-		public LocalizedString AppVersion { get; } = new LocalizedString(() => string.Format(AppResources.Version, AppInfo.VersionString));
-
-		public ICommand ChangeLanguageCommand { get; }
 
 		public SettingViewModel()
 		{
@@ -41,6 +26,22 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels
 				LocalizationResourceManager.Current.CurrentCulture = CultureInfo.GetCultureInfo(SelectedLanguage.CI);
 				LoadLanguages();
 			});
+		}
+
+		public LocalizedString AppVersion { get; } = new LocalizedString(() => string.Format(AppResources.Version, AppInfo.VersionString));
+
+		public ICommand ChangeLanguageCommand { get; }
+
+		public Language SelectedLanguage
+		{
+			get => selectedLanguage;
+			set => SetProperty(ref selectedLanguage, value);
+		}
+
+		public IList<Language> SupportedLanguages
+		{
+			get => supportedLanguages;
+			private set => SetProperty(ref supportedLanguages, value);
 		}
 
 		void LoadLanguages()

--- a/samples/XCT.Sample/ViewModels/Views/ExpanderViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/ExpanderViewModel.cs
@@ -46,7 +46,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 
 		public sealed class Item : BaseViewModel
 		{
-			string name;
+			string name = string.Empty;
 			bool isExpanded;
 			bool isEnabled = true;
 

--- a/samples/XCT.Sample/ViewModels/Views/PopupControlViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/PopupControlViewModel.cs
@@ -13,7 +13,8 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 	{
 		INavigation Navigation => App.Current.MainPage.Navigation;
 
-		public IEnumerable<SectionModel> Examples { get; } = new List<SectionModel> {
+		public IEnumerable<SectionModel> Examples { get; } = new[]
+		{
 			new SectionModel(typeof(SimplePopup), "Simple Popup", Color.Red, "Displays a basic popup centered on the screen"),
 			new SectionModel(typeof(PopupPositionPage), "Custom Positioning Popup", Color.Red, "Displays a basic popup anywhere on the screen using VerticalOptions and HorizontalOptions"),
 			new SectionModel(typeof(ButtonPopup), "Popup With 1 Button", Color.Red, "Displays a basic popup with a confirm button"),
@@ -37,7 +38,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 			if (view is Popup<string> popup)
 			{
 				var result = await Navigation.ShowPopupAsync(popup);
-				await App.Current.MainPage.DisplayAlert("Popup Result", result, "OKAY");
+				await Application.Current.MainPage.DisplayAlert("Popup Result", result, "OKAY");
 			}
 			else if (view is BasePopup basePopup)
 			{

--- a/samples/XCT.Sample/ViewModels/Views/StateLayoutViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/StateLayoutViewModel.cs
@@ -7,7 +7,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 {
 	public class StateLayoutViewModel : BaseViewModel
 	{
-		string customState;
+		string customState = string.Empty;
 		LayoutState currentState;
 		LayoutState mainState;
 

--- a/samples/XCT.Sample/ViewModels/Views/TabItemsSourceViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/TabItemsSourceViewModel.cs
@@ -7,11 +7,16 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 {
 	public class Monkey
 	{
-		public string Index { get; set; }
-		public string Name { get; set; }
-		public string Location { get; set; }
-		public string Details { get; set; }
-		public string Image { get; set; }
+		public string Index { get; set; } = string.Empty;
+
+		public string Name { get; set; } = string.Empty;
+
+		public string Location { get; set; } = string.Empty;
+
+		public string Details { get; set; } = string.Empty;
+
+		public string Image { get; set; } = string.Empty;
+
 		public Color Color { get; set; }
 	}
 
@@ -25,112 +30,106 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views
 			UpdateDataCommand = CommandFactory.Create(UpdateData);
 		}
 
-		public ObservableCollection<Monkey> Monkeys { get; set; }
+		public ObservableCollection<Monkey> Monkeys { get; } = LoadMonkeys();
 
 		public ICommand ClearDataCommand { get; }
 
 		public ICommand UpdateDataCommand { get; }
 
-		void LoadMonkeys()
+		static ObservableCollection<Monkey> LoadMonkeys() => new ObservableCollection<Monkey>
 		{
-			Monkeys = new ObservableCollection<Monkey>
+			new Monkey
 			{
-				new Monkey
-				{
-					Index = "0",
-					Name = "Baboon",
-					Location = "Africa & Asia",
-					Details = "Baboons are African and Arabian Old World monkeys belonging to the genus Papio, part of the subfamily Cercopithecinae.",
-					Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Papio_anubis_%28Serengeti%2C_2009%29.jpg/200px-Papio_anubis_%28Serengeti%2C_2009%29.jpg",
-					Color = Color.LightSalmon
-				},
+				Index = "0",
+				Name = "Baboon",
+				Location = "Africa & Asia",
+				Details = "Baboons are African and Arabian Old World monkeys belonging to the genus Papio, part of the subfamily Cercopithecinae.",
+				Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Papio_anubis_%28Serengeti%2C_2009%29.jpg/200px-Papio_anubis_%28Serengeti%2C_2009%29.jpg",
+				Color = Color.LightSalmon
+			},
 
-				new Monkey
-				{
-					Index = "1",
-					Name = "Capuchin Monkey",
-					Location = "Central & South America",
-					Details = "The capuchin monkeys are New World monkeys of the subfamily Cebinae. Prior to 2011, the subfamily contained only a single genus, Cebus.",
-					Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Capuchin_Costa_Rica.jpg/200px-Capuchin_Costa_Rica.jpg",
-					Color = Color.LightBlue
-				},
+			new Monkey
+			{
+				Index = "1",
+				Name = "Capuchin Monkey",
+				Location = "Central & South America",
+				Details = "The capuchin monkeys are New World monkeys of the subfamily Cebinae. Prior to 2011, the subfamily contained only a single genus, Cebus.",
+				Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Capuchin_Costa_Rica.jpg/200px-Capuchin_Costa_Rica.jpg",
+				Color = Color.LightBlue
+			},
 
-				new Monkey
-				{
-					Index = "2",
-					Name = "Blue Monkey",
-					Location = "Central and East Africa",
-					Details = "The blue monkey or diademed monkey is a species of Old World monkey native to Central and East Africa, ranging from the upper Congo River basin east to the East African Rift and south to northern Angola and Zambia",
-					Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/83/BlueMonkey.jpg/220px-BlueMonkey.jpg",
-					Color = Color.LightSlateGray
-				},
+			new Monkey
+			{
+				Index = "2",
+				Name = "Blue Monkey",
+				Location = "Central and East Africa",
+				Details = "The blue monkey or diademed monkey is a species of Old World monkey native to Central and East Africa, ranging from the upper Congo River basin east to the East African Rift and south to northern Angola and Zambia",
+				Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/83/BlueMonkey.jpg/220px-BlueMonkey.jpg",
+				Color = Color.LightSlateGray
+			},
 
-				new Monkey
-				{
-					Index = "3",
-					Name = "Squirrel Monkey",
-					Location = "Central & South America",
-					Details = "The squirrel monkeys are the New World monkeys of the genus Saimiri. They are the only genus in the subfamily Saimirinae. The name of the genus Saimiri is of Tupi origin, and was also used as an English name by early researchers.",
-					Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Saimiri_sciureus-1_Luc_Viatour.jpg/220px-Saimiri_sciureus-1_Luc_Viatour.jpg",
-					Color = Color.Chocolate
-				},
+			new Monkey
+			{
+				Index = "3",
+				Name = "Squirrel Monkey",
+				Location = "Central & South America",
+				Details = "The squirrel monkeys are the New World monkeys of the genus Saimiri. They are the only genus in the subfamily Saimirinae. The name of the genus Saimiri is of Tupi origin, and was also used as an English name by early researchers.",
+				Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Saimiri_sciureus-1_Luc_Viatour.jpg/220px-Saimiri_sciureus-1_Luc_Viatour.jpg",
+				Color = Color.Chocolate
+			},
 
-				new Monkey
-				{
-					Index = "4",
-					Name = "Golden Lion Tamarin",
-					Location = "Brazil",
-					Details = "The golden lion tamarin also known as the golden marmoset, is a small New World monkey of the family Callitrichidae.",
-					Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Golden_lion_tamarin_portrait3.jpg/220px-Golden_lion_tamarin_portrait3.jpg",
-					Color = Color.Violet
-				},
+			new Monkey
+			{
+				Index = "4",
+				Name = "Golden Lion Tamarin",
+				Location = "Brazil",
+				Details = "The golden lion tamarin also known as the golden marmoset, is a small New World monkey of the family Callitrichidae.",
+				Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Golden_lion_tamarin_portrait3.jpg/220px-Golden_lion_tamarin_portrait3.jpg",
+				Color = Color.Violet
+			},
 
-				new Monkey
-				{
-					Index = "5",
-					Name = "Howler Monkey",
-					Location = "South America",
-					Details = "Howler monkeys are among the largest of the New World monkeys. Fifteen species are currently recognised. Previously classified in the family Cebidae, they are now placed in the family Atelidae.",
-					Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Alouatta_guariba.jpg/200px-Alouatta_guariba.jpg",
-					Color = Color.Aqua
-				},
+			new Monkey
+			{
+				Index = "5",
+				Name = "Howler Monkey",
+				Location = "South America",
+				Details = "Howler monkeys are among the largest of the New World monkeys. Fifteen species are currently recognised. Previously classified in the family Cebidae, they are now placed in the family Atelidae.",
+				Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Alouatta_guariba.jpg/200px-Alouatta_guariba.jpg",
+				Color = Color.Aqua
+			},
 
-				new Monkey
-				{
-					Index = "6",
-					Name = "Japanese Macaque",
-					Location = "Japan",
-					Details = "The Japanese macaque, is a terrestrial Old World monkey species native to Japan. They are also sometimes known as the snow monkey because they live in areas where snow covers the ground for months each",
-					Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Macaca_fuscata_fuscata1.jpg/220px-Macaca_fuscata_fuscata1.jpg",
-					Color = Color.OrangeRed
-				},
+			new Monkey
+			{
+				Index = "6",
+				Name = "Japanese Macaque",
+				Location = "Japan",
+				Details = "The Japanese macaque, is a terrestrial Old World monkey species native to Japan. They are also sometimes known as the snow monkey because they live in areas where snow covers the ground for months each",
+				Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Macaca_fuscata_fuscata1.jpg/220px-Macaca_fuscata_fuscata1.jpg",
+				Color = Color.OrangeRed
+			},
 
-				new Monkey
-				{
-					Index = "7",
-					Name = "Mandrill",
-					Location = "Southern Cameroon, Gabon, Equatorial Guinea, and Congo",
-					Details = "The mandrill is a primate of the Old World monkey family, closely related to the baboons and even more closely to the drill. It is found in southern Cameroon, Gabon, Equatorial Guinea, and Congo.",
-					Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Mandrill_at_san_francisco_zoo.jpg/220px-Mandrill_at_san_francisco_zoo.jpg",
-					Color = Color.MediumPurple
-				},
+			new Monkey
+			{
+				Index = "7",
+				Name = "Mandrill",
+				Location = "Southern Cameroon, Gabon, Equatorial Guinea, and Congo",
+				Details = "The mandrill is a primate of the Old World monkey family, closely related to the baboons and even more closely to the drill. It is found in southern Cameroon, Gabon, Equatorial Guinea, and Congo.",
+				Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Mandrill_at_san_francisco_zoo.jpg/220px-Mandrill_at_san_francisco_zoo.jpg",
+				Color = Color.MediumPurple
+			},
 
-				new Monkey
-				{
-					Index = "8",
-					Name = "Proboscis Monkey",
-					Location = "Borneo",
-					Details = "The proboscis monkey or long-nosed monkey, known as the bekantan in Malay, is a reddish-brown arboreal Old World monkey that is endemic to the south-east Asian island of Borneo.",
-					Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Proboscis_Monkey_in_Borneo.jpg/250px-Proboscis_Monkey_in_Borneo.jpg",
-					Color = Color.Pink
-				}
-			};
-		}
+			new Monkey
+			{
+				Index = "8",
+				Name = "Proboscis Monkey",
+				Location = "Borneo",
+				Details = "The proboscis monkey or long-nosed monkey, known as the bekantan in Malay, is a reddish-brown arboreal Old World monkey that is endemic to the south-east Asian island of Borneo.",
+				Image = "http://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Proboscis_Monkey_in_Borneo.jpg/250px-Proboscis_Monkey_in_Borneo.jpg",
+				Color = Color.Pink
+			}
+		};
 
-		void ClearData()
-		{
-			Monkeys.Clear();
-		}
+		void ClearData() => Monkeys.Clear();
 
 		void UpdateData()
 		{

--- a/samples/XCT.Sample/ViewModels/Views/Tabs/LazyTestViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/Tabs/LazyTestViewModel.cs
@@ -6,7 +6,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views.Tabs
 	{
 		public static LazyTestViewModel Current { get; } = new LazyTestViewModel();
 
-		string title;
+		string title = string.Empty;
 
 		public string Title
 		{

--- a/samples/XCT.Sample/ViewModels/Views/Tabs/NormalTestViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Views/Tabs/NormalTestViewModel.cs
@@ -6,7 +6,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Views.Tabs
 	{
 		public static NormalTestViewModel Current { get; } = new NormalTestViewModel();
 
-		string loadedViews;
+		string loadedViews = string.Empty;
 
 		public string LoadedViews
 		{

--- a/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
+++ b/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +14,7 @@
     <None Remove="resources\**" />
     <EmbeddedResource Include="Images\**" />
     <EmbeddedResource Include="Fonts\**" />
+    <Compile Remove="Pages\Converters\EnumToBoolConverterPage.xaml.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Behaviors/MaxLengthReachedBehavior_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Behaviors/MaxLengthReachedBehavior_Tests.cs
@@ -144,8 +144,8 @@ namespace Xamarin.CommunityToolkit.UnitTests.Behaviors
 
 		Entry CreateEntry(int? maxLength = 2,
 						  bool shouldDismissKeyboardAutomatically = false,
-						  ICommand command = null,
-						  EventHandler<MaxLengthReachedEventArgs> eventHandler = null)
+						  ICommand? command = null,
+						  EventHandler<MaxLengthReachedEventArgs>? eventHandler = null)
 		{
 			var behavior = new MaxLengthReachedBehavior
 			{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Behaviors/UserStoppedTypingBehavior_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Behaviors/UserStoppedTypingBehavior_Tests.cs
@@ -160,8 +160,8 @@ namespace Xamarin.CommunityToolkit.UnitTests.Behaviors
 		public Entry CreateEntryWithBehavior(int timeThreshold = defaultTimeThreshold,
 											 int lengthThreshold = defaultLengthThreshold,
 											 bool shouldDismissKeyboardAutomatically = false,
-											 ICommand command = null,
-											 object commandParameter = null)
+											 ICommand? command = null,
+											 object? commandParameter = null)
 		{
 			var entry = new Entry
 			{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/DoubleToIntConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/DoubleToIntConverter_Tests.cs
@@ -12,7 +12,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 		[InlineData(2.55, 3)]
 		[InlineData(2.555, 3)]
 		[InlineData(2.555, 652, 255)]
-		public void DoubleToIntConverter(double value, int expectedResult, object ratio = null)
+		public void DoubleToIntConverter(double value, int expectedResult, object? ratio = null)
 		{
 			var doubleToIntConverter = new DoubleToIntConverter();
 
@@ -23,7 +23,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 
 		[Theory]
 		[InlineData(2, 2)]
-		public void DoubleToIntConverterBack(int value, double expectedResult, object ratio = null)
+		public void DoubleToIntConverterBack(int value, double expectedResult, object? ratio = null)
 		{
 			var doubleToIntConverter = new DoubleToIntConverter();
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/EnumToBoolConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/EnumToBoolConverter_Tests.cs
@@ -80,68 +80,68 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 			Assert.Equal(expectedResult, result);
 		}
 
-		public static IEnumerable<object[]> ConvertTestData()
+		public static IEnumerable<object?[]> ConvertTestData()
 		{
 			// Simple enum
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Five, true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six, false
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six, true
+				new object?[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six, true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.Six, null, true
+				new object?[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.Six, null, true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.One, TestEnumForEnumToBoolConverter.Five, false
+				new object?[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.One, TestEnumForEnumToBoolConverter.Five, false
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.Two, null, false
+				new object?[] { TestEnumForEnumToBoolConverter.Five, TestEnumForEnumToBoolConverter.Six }, TestEnumForEnumToBoolConverter.Two, null, false
 			};
 
 			// Flagged enum
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.One, null, true
+				new object?[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.One, null, true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.Two, null, true
+				new object?[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.Two, null, true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.Three, null, true
+				new object?[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.Three, null, true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
-				new object[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.Four, null, false
+				new object?[] { (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), TestFlaggedEnumForEnumToBoolConverter.Two }, TestFlaggedEnumForEnumToBoolConverter.Four, null, false
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, TestFlaggedEnumForEnumToBoolConverter.One, (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, TestFlaggedEnumForEnumToBoolConverter.Three, (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, TestFlaggedEnumForEnumToBoolConverter.Two, (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), false
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), true
 			};
-			yield return new object[]
+			yield return new object?[]
 			{
 				null, (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Two | TestFlaggedEnumForEnumToBoolConverter.Three), (TestFlaggedEnumForEnumToBoolConverter.One | TestFlaggedEnumForEnumToBoolConverter.Three), false
 			};

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ItemSelectedEventArgsConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ItemSelectedEventArgsConverter_Tests.cs
@@ -9,14 +9,16 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 {
 	public class ItemSelectedEventArgsConverter_Tests
 	{
-		static object expectedValue = 100;
+		static readonly object expectedValue = 100;
 
 		public static IEnumerable<object[]> GetData() => new List<object[]>
 		{
             // We know it's deprecated, still good to test it
 #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
             new object[] { new SelectedItemChangedEventArgs(expectedValue), expectedValue },
-			new object[] { null, null },
+            new object?[] { null, null },
+#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
 #pragma warning restore CS0618 // Type or member is obsolete
 		};
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ItemTappedEventArgsConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ItemTappedEventArgsConverter_Tests.cs
@@ -15,8 +15,10 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 			{
             // We know it's deprecated, still good to test it
 #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
                 new object[] { new ItemTappedEventArgs(null, expectedValue), expectedValue },
                 new object[] { new ItemTappedEventArgs(null, null), null },
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 #pragma warning restore CS0618 // Type or member is obsolete
 			};
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ListIsNotNullOrEmptyConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ListIsNotNullOrEmptyConverter_Tests.cs
@@ -9,16 +9,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 {
 	public class ListIsNotNullOrEmptyConverter_Tests
 	{
-		public static IEnumerable<object[]> GetData()
+		public static IEnumerable<object?[]> GetData() => new List<object?[]>
 		{
-			return new List<object[]>
-			{
-				new object[] { new List<string>(), false},
-				new object[] { new List<string>() { "TestValue"}, true},
-				new object[] { null, false},
-				new object[] { Enumerable.Range(1, 3), true},
-			};
-		}
+			new object[] { new List<string>(), false},
+			new object[] { new List<string>() { "TestValue"}, true},
+			new object?[] { null, false},
+			new object[] { Enumerable.Range(1, 3), true},
+		};
 
 		[Theory]
 		[MemberData(nameof(GetData))]

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ListIsNullOrEmptyConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ListIsNullOrEmptyConverter_Tests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -9,16 +9,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 {
 	public class ListIsNullOrEmptyConverter_Tests
 	{
-		public static IEnumerable<object[]> GetData()
-		{
-			return new List<object[]>
+		public static IEnumerable<object?[]> GetData() => new List<object?[]>
 			{
 				new object[] { new List<string>(), true},
-				new object[] { new List<string>() { "TestValue"}, false},
-				new object[] { null, true},
-				new object[] { Enumerable.Range(1, 3), false},
+				new object[] { new List<string>() { "TestValue" }, false},
+				new object?[] { null, true },
+				new object[] { Enumerable.Range(1, 3), false },
 			};
-		}
 
 		[Theory]
 		[MemberData(nameof(GetData))]

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ListToStringConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/ListToStringConverter_Tests.cs
@@ -7,17 +7,16 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 {
 	public class ListToStringConverter_Tests
 	{
-		public static IEnumerable<object[]> GetData()
-			=> new List<object[]>
-			{
-				new object[] { new string[] { "A", "B", "C" }, "+_+", "A+_+B+_+C" },
-				new object[] { new string[] { "A", string.Empty, "C" }, ",", "A,C" },
-				new object[] { new string[] { "A", null, "C" }, ",", "A,C" },
-				new object[] { new string[] { "A" }, ":-:", "A" },
-				new object[] { new string[] { }, ",", string.Empty },
-				new object[] { null, ",", string.Empty },
-				new object[] { new string[] { "A", "B", "C" }, null, "ABC" },
-			};
+		public static IEnumerable<object?[]> GetData() => new List<object?[]>
+		{
+			new object[] { new string[] { "A", "B", "C" }, "+_+", "A+_+B+_+C" },
+			new object[] { new string[] { "A", string.Empty, "C" }, ",", "A,C" },
+			new object?[] { new string?[] { "A", null, "C" }, ",", "A,C" },
+			new object[] { new string[] { "A" }, ":-:", "A" },
+			new object[] { new string[] { }, ",", string.Empty },
+			new object?[] { null, ",", string.Empty },
+			new object?[] { new string[] { "A", "B", "C" }, null, "ABC" },
+		};
 
 		[Theory]
 		[MemberData(nameof(GetData))]

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/EnableInitOnlyProperties.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/EnableInitOnlyProperties.cs
@@ -1,0 +1,4 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    public record IsExternalInit;
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizationResourceManagerTests/LocalizationResourceManagerTests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizationResourceManagerTests/LocalizationResourceManagerTests.cs
@@ -48,7 +48,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.LocalizationResourceManager
 			// Arrange
 			var culture2 = new CultureInfo("en");
 			localizationManager.CurrentCulture = culture2;
-			CultureInfo changedCulture = null;
+			CultureInfo? changedCulture = null;
 			localizationManager.PropertyChanged += (s, e) => changedCulture = localizationManager.CurrentCulture;
 
 			// Act, Assert

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizedStringTests/LocalizedStringTests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/LocalizedStringTests/LocalizedStringTests.cs
@@ -20,7 +20,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.LocalizedStringTests
 		readonly CultureInfo initialCulture = CultureInfo.InvariantCulture;
 		readonly ResourceManager resourceManager;
 
-		LocalizedString localizedString;
+		LocalizedString? localizedString;
 
 		[Fact]
 		public void LocalizedStringTests_Localized_ValidImplementation()
@@ -30,7 +30,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.LocalizedStringTests
 			var culture2 = new CultureInfo("en");
 			localizedString = new LocalizedString(localizationManager, () => localizationManager[testString]);
 
-			string responceOnCultureChanged = null;
+			string? responceOnCultureChanged = null;
 			localizedString.PropertyChanged += (sender, args) => responceOnCultureChanged = localizedString.Localized;
 
 			// Act

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/WeakEventManagerTests/WeakEventManager_ActionT_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/WeakEventManagerTests/WeakEventManager_ActionT_Tests.cs
@@ -135,14 +135,12 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 		public void WeakEventManagerActionT_AddEventHandler_NullHandler()
 		{
 			// Arrange
-			Action<string> nullAction = null;
+			Action<string>? nullAction = null;
 
 			// Act
 
 			// Assert
-#pragma warning disable CS8604 //Possible null reference argument for parameter
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.AddEventHandler(nullAction, nameof(ActionEvent)));
-#pragma warning restore CS8604 //Possible null reference argument for parameter
 
 		}
 
@@ -154,23 +152,19 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.AddEventHandler(s => { var temp = s; }, null));
-#pragma warning restore CS8625
 		}
 
 		[Fact]
 		public void WeakEventManagerActionT_AddEventHandler_EmptyEventName()
 		{
 			// Arrange
-			Action<string> nullAction = null;
+			Action<string>? nullAction = null;
 
 			// Act
 
 			// Assert
-#pragma warning disable CS8604 //Possible null reference argument for parameter
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.AddEventHandler(nullAction, string.Empty));
-#pragma warning restore CS8604 //Possible null reference argument for parameter
 		}
 
 		[Fact]
@@ -181,23 +175,19 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.AddEventHandler(s => { var temp = s; }, " "));
-#pragma warning restore CS8625
 		}
 
 		[Fact]
 		public void WeakEventManagerActionT_RemoveEventHandler_NullHandler()
 		{
 			// Arrange
-			Action<string> nullAction = null;
+			Action<string>? nullAction = null;
 
 			// Act
 
 			// Assert
-#pragma warning disable CS8604 //Possible null reference argument for parameter
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.RemoveEventHandler(nullAction));
-#pragma warning restore CS8604
 		}
 
 		[Fact]
@@ -208,9 +198,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.RemoveEventHandler(s => { var temp = s; }, null));
-#pragma warning restore CS8625
 		}
 
 		[Fact]
@@ -221,9 +209,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.RemoveEventHandler(s => { var temp = s; }, string.Empty));
-#pragma warning restore CS8625
 		}
 
 		[Fact]
@@ -234,9 +220,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
 			Assert.Throws<ArgumentNullException>(() => actionEventManager.RemoveEventHandler(s => { var temp = s; }, " "));
-#pragma warning restore CS8625
 		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/WeakEventManagerTests/WeakEventManager_EventHandlerT_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Helpers/WeakEventManagerTests/WeakEventManager_EventHandlerT_Tests.cs
@@ -17,7 +17,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			const string stringEventArg = "Test";
 			var didEventFire = false;
 
-			void HandleTestEvent(object sender, string? e)
+			void HandleTestEvent(object? sender, string? e)
 			{
 				if (sender == null || e == null)
 					throw new ArgumentNullException(nameof(sender));
@@ -49,7 +49,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 
 			var didEventFire = false;
 
-			void HandleTestEvent(object sender, string e)
+			void HandleTestEvent(object? sender, string e)
 			{
 				Assert.Null(sender);
 
@@ -74,7 +74,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			TestStringEvent += HandleTestEvent;
 			var didEventFire = false;
 
-			void HandleTestEvent(object sender, string e)
+			void HandleTestEvent(object? sender, string e)
 			{
 				if (sender == null)
 					throw new ArgumentNullException(nameof(sender));
@@ -105,7 +105,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 
 			var didEventFire = false;
 
-			void HandleTestEvent(object sender, string e) => didEventFire = true;
+			void HandleTestEvent(object? sender, string e) => didEventFire = true;
 
 			// Act
 			TestStringWeakEventManager.RaiseEvent(this, "Test", nameof(TestEvent));
@@ -119,13 +119,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 		public void WeakEventManager_NullEventManager()
 		{
 			// Arrange
-			WeakEventManager<string> unassignedEventManager = null;
+			WeakEventManager<string>? unassignedEventManager = null;
 
 			// Act
 
 			// Assert
 #pragma warning disable CS8602 //Dereference of a possible null reference
-			Assert.Throws<NullReferenceException>(() => unassignedEventManager.RaiseEvent(null, null, nameof(TestEvent)));
+			Assert.Throws<NullReferenceException>(() => unassignedEventManager.RaiseEvent(null, string.Empty, nameof(TestEvent)));
 #pragma warning restore CS8602
 		}
 
@@ -137,7 +137,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			var didEventFire = false;
 
 			TestStringEvent += HandleTestEvent;
-			void HandleTestEvent(object sender, string e) => didEventFire = true;
+			void HandleTestEvent(object? sender, string e) => didEventFire = true;
 
 			// Act
 #pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
@@ -157,7 +157,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 
 			TestStringEvent += HandleTestEvent;
 			TestStringEvent -= HandleTestEvent;
-			void HandleTestEvent(object sender, string e) => didEventFire = true;
+			void HandleTestEvent(object? sender, string e) => didEventFire = true;
 
 			// Act
 			TestStringWeakEventManager.RaiseEvent(this, "Test", nameof(TestStringEvent));
@@ -174,9 +174,9 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 //Cannot convert null literal to non-nullable reference type
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
 			Assert.Throws<ArgumentNullException>(() => TestStringWeakEventManager.AddEventHandler((EventHandler<string>)null));
-#pragma warning restore CS8625
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 		}
 
 		[Fact]
@@ -187,9 +187,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference
 			Assert.Throws<ArgumentNullException>(() => TestStringWeakEventManager.AddEventHandler(s => { var temp = s; }, null));
-#pragma warning restore CS8625
 		}
 
 		[Fact]
@@ -222,9 +220,9 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
 			Assert.Throws<ArgumentNullException>(() => TestStringWeakEventManager.RemoveEventHandler((EventHandler<string>)null));
-#pragma warning restore CS8625
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 		}
 
 		[Fact]
@@ -235,9 +233,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			// Act
 
 			// Assert
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference
 			Assert.Throws<ArgumentNullException>(() => TestStringWeakEventManager.AddEventHandler(s => { var temp = s; }, null));
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference
 		}
 
 		[Fact]
@@ -269,12 +265,12 @@ namespace Xamarin.CommunityToolkit.UnitTests.Helpers.WeakEventManagerTests
 			TestStringEvent += HandleTestStringEvent;
 			var didEventFire = false;
 
-			void HandleTestStringEvent(object sender, string e) => didEventFire = true;
+			void HandleTestStringEvent(object? sender, string e) => didEventFire = true;
 
 			// Act
 
 			// Assert
-			Assert.Throws<InvalidHandleEventException>(() => TestStringWeakEventManager.RaiseEvent("", nameof(TestStringEvent)));
+			Assert.Throws<InvalidHandleEventException>(() => TestStringWeakEventManager.RaiseEvent(string.Empty, nameof(TestStringEvent)));
 			Assert.False(didEventFire);
 			TestStringEvent -= HandleTestStringEvent;
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Mocks/MockPlatformServices.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Mocks/MockPlatformServices.cs
@@ -31,7 +31,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Mocks
 
 		public OSAppTheme RequestedTheme => OSAppTheme.Unspecified;
 
-		public string RuntimePlatform { get; set; }
+		public string RuntimePlatform { get; set; } = string.Empty;
 
 		public void BeginInvokeOnMainThread(Action action)
 			=> action();
@@ -49,7 +49,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Mocks
 		public Assembly[] GetAssemblies()
 			=> new Assembly[0];
 
-		public IIsolatedStorageFile GetUserStoreForApplication()
+		public IIsolatedStorageFile? GetUserStoreForApplication()
 			=> null;
 
 		Assembly[] IPlatformServices.GetAssemblies()

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Mocks/MockResourceManager.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Mocks/MockResourceManager.cs
@@ -5,6 +5,6 @@ namespace Xamarin.CommunityToolkit.UnitTests.Mocks
 {
 	class MockResourceManager : ResourceManager
 	{
-		public override string GetString(string name, CultureInfo culture) => culture.EnglishName;
+		public override string GetString(string name, CultureInfo? culture) => culture?.EnglishName ?? string.Empty;
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Namespace_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Namespace_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Reflection;
 using Xamarin.CommunityToolkit.Behaviors.Internals;
 using Xamarin.CommunityToolkit.Converters;
@@ -15,62 +16,72 @@ namespace Xamarin.CommunityToolkit.UnitTests
 		[Fact]
 		public void MakeSureConvertersAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(InvertedBoolConverter)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(InvertedBoolConverter))?.GetTypes();
+			if (allTheTypes is null)
+				throw new NullReferenceException();
 
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Converter") && t.GetInterface(nameof(IValueConverter)) != null))
 			{
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Converters"),
-					$"{type.FullName} not in Xamarin.CommunityToolkit.Converters namespace");
+				Assert.True(type?.Namespace?.Equals("Xamarin.CommunityToolkit.Converters"),
+					$"{type?.FullName} not in Xamarin.CommunityToolkit.Converters namespace");
 			}
 		}
 
 		[Fact]
 		public void MakeSureEffectsAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(SafeAreaEffect)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(SafeAreaEffect))?.GetTypes();
+			if (allTheTypes is null)
+				throw new NullReferenceException();
 
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Effect") && t.IsClass && t.IsSealed && t.IsAbstract))
 			{
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Effects"),
-					$"{type.FullName} not in Xamarin.CommunityToolkit.Effects namespace");
+				Assert.True(type?.Namespace?.Equals("Xamarin.CommunityToolkit.Effects"),
+					$"{type?.FullName} not in Xamarin.CommunityToolkit.Effects namespace");
 			}
 		}
 
 		[Fact]
 		public void MakeSureMarkupExtensionsAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(TranslateExtension)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(TranslateExtension))?.GetTypes();
+			if (allTheTypes is null)
+				throw new NullReferenceException();
 
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Extension") && t.GetInterface("IMarkupExtension") != null))
 			{
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Extensions") ||
-					type.Namespace.Equals("Xamarin.CommunityToolkit.Extensions.Internals"),
-					$"{type.FullName} not in nameof(Xamarin.CommunityToolkit.Extensions namespace");
+				Assert.True(type?.Namespace?.Equals("Xamarin.CommunityToolkit.Extensions") is true ||
+					type?.Namespace?.Equals("Xamarin.CommunityToolkit.Extensions.Internals") is true,
+					$"{type?.FullName} not in nameof(Xamarin.CommunityToolkit.Extensions namespace");
 			}
 		}
 
 		[Fact]
 		public void MakeSureBehaviorsAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior<>)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(BaseBehavior<>))?.GetTypes();
+			if (allTheTypes is null)
+				throw new NullReferenceException();
 
 			foreach (var type in allTheTypes.Where(t => t.Name.EndsWith("Behavior") && t.IsSubclassOf(typeof(BaseBehavior<>))))
 			{
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.Behaviors"),
-					$"{type.FullName} not in Xamarin.CommunityToolkit.Behaviors namespace");
+				Assert.True(type?.Namespace?.Equals("Xamarin.CommunityToolkit.Behaviors"),
+					$"{type?.FullName} not in Xamarin.CommunityToolkit.Behaviors namespace");
 			}
 		}
 
 		[Fact]
 		public void MakeSureViewsAreInTheRightNamespace()
 		{
-			var allTheTypes = Assembly.GetAssembly(typeof(AvatarView)).GetTypes();
+			var allTheTypes = Assembly.GetAssembly(typeof(AvatarView))?.GetTypes();
+			if (allTheTypes is null)
+				throw new NullReferenceException();
 
 			foreach (var type in allTheTypes.Where(t => t.IsSubclassOf(typeof(View))))
 			{
-				Assert.True(type.Namespace.Equals("Xamarin.CommunityToolkit.UI.Views") ||
-					type.Namespace.Equals("Xamarin.CommunityToolkit.UI.Views.Internals"),
-					$"{type.FullName} not in Xamarin.CommunityToolkit.UI.Views namespace");
+				Assert.True(type?.Namespace?.Equals("Xamarin.CommunityToolkit.UI.Views") is true ||
+					type?.Namespace?.Equals("Xamarin.CommunityToolkit.UI.Views.Internals") is true,
+					$"{type?.FullName} not in Xamarin.CommunityToolkit.UI.Views namespace");
 			}
 		}
 	}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/AsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/AsyncCommand_Tests.cs
@@ -152,7 +152,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 		public void AsyncCommand_NoParameter_NoCanExecute_Test()
 		{
 			// Arrange
-			Func<bool> canExecute = null;
+			Func<bool>? canExecute = null;
 			var command = new AsyncCommand(NoParameterTask, canExecute);
 
 			// Act
@@ -189,7 +189,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(didCanExecuteChangeFire);
 			Assert.True(command.CanExecute(null));
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => didCanExecuteChangeFire = true;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => didCanExecuteChangeFire = true;
 		}
 
 		[Fact]
@@ -222,7 +222,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(didCanExecuteChangeFire);
 			Assert.True(command.CanExecute(null));
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => didCanExecuteChangeFire = true;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => didCanExecuteChangeFire = true;
 		});
 
 		[Fact]
@@ -258,14 +258,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 				Assert.True(command.CanExecute(null));
 			});
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => didCanExecuteChangeFire = true;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => didCanExecuteChangeFire = true;
 		}
 
 		[Fact]
 		public async Task AsyncCommand_RaiseCanExecuteChanged_BackgroundThreadCreation_MainThreadExecution_Test()
 		{
 			// Arrange
-			AsyncCommand command = null;
+			AsyncCommand? command = null;
 			var didCanExecuteChangeFire = false;
 			var canCommandExecute = false;
 
@@ -289,20 +289,23 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			}).ConfigureAwait(true);
 
 			// Act
+			if (command is null)
+				throw new NullReferenceException();
+
 			command.RaiseCanExecuteChanged();
 
 			// Assert
 			Assert.True(didCanExecuteChangeFire);
 			Assert.True(command.CanExecute(null));
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => didCanExecuteChangeFire = true;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => didCanExecuteChangeFire = true;
 		}
 
 		[Fact]
 		public async Task AsyncCommand_ChangeCanExecute_Test()
 		{
 			// Arrange
-			var canExecuteChangedTCS = new TaskCompletionSource<object>();
+			var canExecuteChangedTCS = new TaskCompletionSource<object?>();
 
 			var canCommandExecute = false;
 			var didCanExecuteChangeFire = false;
@@ -322,16 +325,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.False(didCanExecuteChangeFire);
 
 			// Act
-#pragma warning disable CS0618 // Type or member is obsolete
 			command.ChangeCanExecute();
 			await canExecuteChangedTCS.Task;
-#pragma warning restore CS0618 // Type or member is obsolete
 
 			// Assert
 			Assert.True(didCanExecuteChangeFire);
 			Assert.True(command.CanExecute(null));
 
-			void handleCanExecuteChanged(object sender, EventArgs e)
+			void handleCanExecuteChanged(object? sender, EventArgs e)
 			{
 				didCanExecuteChangeFire = true;
 				canExecuteChangedTCS.SetResult(null);
@@ -363,14 +364,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(command.CanExecute(null));
 			Assert.Equal(0, canExecuteChangedCount);
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 		}
 
 		[Fact]
 		public async Task AsyncCommand_CanExecuteChanged_DoesNotAllowMultipleExecutions_Test()
 		{
 			// Arrange
-			var canExecuteChangedGreaterThan1TCS = new TaskCompletionSource<object>();
+			var canExecuteChangedGreaterThan1TCS = new TaskCompletionSource<object?>();
 
 			var canExecuteChangedCount = 0;
 
@@ -394,7 +395,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(command.CanExecute(null));
 			Assert.Equal(2, canExecuteChangedCount);
 
-			void handleCanExecuteChanged(object sender, EventArgs e)
+			void handleCanExecuteChanged(object? sender, EventArgs e)
 			{
 				if (++canExecuteChangedCount > 1)
 					canExecuteChangedGreaterThan1TCS.SetResult(null);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/IAsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/IAsyncCommand_Tests.cs
@@ -201,7 +201,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(command.CanExecute(null));
 			Assert.Equal(0, canExecuteChangedCount);
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 		}
 
 		[Fact]
@@ -229,7 +229,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(command.CanExecute(null));
 			Assert.Equal(2, canExecuteChangedCount);
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/ICommand_AsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncCommandTests/ICommand_AsyncCommand_Tests.cs
@@ -43,7 +43,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 		public void ICommand_ExecuteAsync_InvalidValueTypeParameter_Test()
 		{
 			// Arrange
-			InvalidCommandParameterException actualInvalidCommandParameterException = null;
+			InvalidCommandParameterException? actualInvalidCommandParameterException = null;
 			var expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(string), typeof(int));
 
 			ICommand command = new AsyncCommand<string>(StringParameterTask);
@@ -61,7 +61,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 		public void ICommand_ExecuteAsync_InvalidReferenceTypeParameter_Test()
 		{
 			// Arrange
-			InvalidCommandParameterException actualInvalidCommandParameterException = null;
+			InvalidCommandParameterException? actualInvalidCommandParameterException = null;
 			var expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(int), typeof(string));
 
 			ICommand command = new AsyncCommand<int>(IntParameterTask);
@@ -78,7 +78,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 		public void ICommand_ExecuteAsync_ValueTypeParameter_Test()
 		{
 			// Arrange
-			InvalidCommandParameterException actualInvalidCommandParameterException = null;
+			InvalidCommandParameterException? actualInvalidCommandParameterException = null;
 			var expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(int));
 
 			ICommand command = new AsyncCommand<int>(IntParameterTask);
@@ -197,7 +197,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 
 			ICommand command = new AsyncCommand<int>(IntParameterTask);
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(Delay);
@@ -239,7 +239,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			Assert.True(command.CanExecute(null));
 			Assert.Equal(2, canExecuteChangedCount);
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 		}
 
 		[Fact]
@@ -251,7 +251,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			ICommand command = new AsyncCommand(() => IntParameterTask(Delay));
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(null);
@@ -277,7 +277,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncComm
 			ICommand command = new AsyncCommand(() => IntParameterTask(Delay), allowsMultipleExecutions: false);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(null);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/AsyncValueCommand_Tests.cs
@@ -175,7 +175,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public void AsyncValueCommandNoParameter_NoCanExecute_Test()
 		{
 			// Arrange
-			Func<bool> canExecute = null;
+			Func<bool>? canExecute = null;
 			var command = new AsyncValueCommand(NoParameterTask, canExecute);
 
 			// Act
@@ -188,7 +188,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public async Task AsyncValueCommand_RaiseCanExecuteChanged_Test()
 		{
 			// Arrange
-			var handleCanExecuteChangedTCS = new TaskCompletionSource<object>();
+			var handleCanExecuteChangedTCS = new TaskCompletionSource<object?>();
 
 			var canCommandExecute = false;
 			var didCanExecuteChangeFire = false;
@@ -215,7 +215,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			Assert.True(didCanExecuteChangeFire);
 			Assert.True(command.CanExecute(null));
 
-			void handleCanExecuteChanged(object sender, EventArgs e)
+			void handleCanExecuteChanged(object? sender, EventArgs e)
 			{
 				didCanExecuteChangeFire = true;
 				handleCanExecuteChangedTCS.SetResult(null);
@@ -226,7 +226,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public async Task AsyncValueCommand_ChangeCanExecute_Test()
 		{
 			// Arrange
-			var handleCanExecuteChangedTCS = new TaskCompletionSource<object>();
+			var handleCanExecuteChangedTCS = new TaskCompletionSource<object?>();
 
 			var canCommandExecute = false;
 			var didCanExecuteChangeFire = false;
@@ -255,7 +255,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			Assert.True(didCanExecuteChangeFire);
 			Assert.True(command.CanExecute(null));
 
-			void handleCanExecuteChanged(object sender, EventArgs e)
+			void handleCanExecuteChanged(object? sender, EventArgs e)
 			{
 				didCanExecuteChangeFire = true;
 				handleCanExecuteChangedTCS.SetResult(null);
@@ -271,7 +271,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			var command = new AsyncValueCommand<int>(IntParameterTask);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			Assert.True(command.AllowsMultipleExecutions);
 
@@ -299,7 +299,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			var command = new AsyncValueCommand<int>(IntParameterTask, allowsMultipleExecutions: false);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			Assert.False(command.AllowsMultipleExecutions);
 
@@ -327,7 +327,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			var command = new AsyncValueCommand(() => IntParameterTask(Delay));
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			Assert.True(command.AllowsMultipleExecutions);
 
@@ -355,7 +355,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			var command = new AsyncValueCommand(() => IntParameterTask(Delay), allowsMultipleExecutions: false);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			Assert.False(command.AllowsMultipleExecutions);
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/ICommand_AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/AsyncValueCommandTests/ICommand_AsyncValueCommand_Tests.cs
@@ -43,7 +43,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public async Task ICommand_Execute_InvalidValueTypeParameter_Test()
 		{
 			// Arrange
-			InvalidCommandParameterException actualInvalidCommandParameterException = null;
+			InvalidCommandParameterException? actualInvalidCommandParameterException = null;
 			var expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(string), typeof(int));
 
 			ICommand command = new AsyncValueCommand<string>(StringParameterTask);
@@ -69,7 +69,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public async Task ICommand_Execute_InvalidReferenceTypeParameter_Test()
 		{
 			// Arrange
-			InvalidCommandParameterException actualInvalidCommandParameterException = null;
+			InvalidCommandParameterException? actualInvalidCommandParameterException = null;
 			var expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(int), typeof(string));
 
 			ICommand command = new AsyncValueCommand<int>(IntParameterTask);
@@ -95,7 +95,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 		public async Task ICommand_Execute_ValueTypeParameter_Test()
 		{
 			// Arrange
-			InvalidCommandParameterException actualInvalidCommandParameterException = null;
+			InvalidCommandParameterException? actualInvalidCommandParameterException = null;
 			var expectedInvalidCommandParameterException = new InvalidCommandParameterException(typeof(int));
 
 			ICommand command = new AsyncValueCommand<int>(IntParameterTask);
@@ -224,7 +224,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			ICommand command = new AsyncValueCommand<int>(IntParameterTask);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(Delay);
@@ -249,7 +249,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			ICommand command = new AsyncValueCommand<int>(IntParameterTask, allowsMultipleExecutions: false);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(Delay);
@@ -275,7 +275,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			ICommand command = new AsyncValueCommand(() => IntParameterTask(Delay));
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(null);
@@ -301,7 +301,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.AsyncValu
 			ICommand command = new AsyncValueCommand(() => IntParameterTask(Delay), allowsMultipleExecutions: false);
 			command.CanExecuteChanged += handleCanExecuteChanged;
 
-			void handleCanExecuteChanged(object sender, EventArgs e) => canExecuteChangedCount++;
+			void handleCanExecuteChanged(object? sender, EventArgs e) => canExecuteChangedCount++;
 
 			// Act
 			command.Execute(null);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_AsyncCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_AsyncCommand_Tests.cs
@@ -13,7 +13,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncCommand_NullExecuteParameter()
 		{
 			// Arrange
-			Func<Task> execute = null;
+			Func<Task>? execute = null;
 
 			// Act
 
@@ -61,7 +61,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncCommand_FuncBool_NullExecuteParameter()
 		{
 			// Arrange
-			Func<Task> execute = null;
+			Func<Task>? execute = null;
 
 			// Act
 
@@ -73,7 +73,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public async Task AsyncCommand_FuncBool_NullCanExecuteParameter()
 		{
 			// Arrange
-			Func<bool> canExecute = null;
+			Func<bool>? canExecute = null;
 			var command = CommandFactory.Create(NoParameterTask, canExecute);
 
 			// Act
@@ -112,7 +112,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncCommandT_NullExecuteParameter()
 		{
 			// Arrange
-			Func<int, Task> execute = null;
+			Func<int, Task>? execute = null;
 
 			// Act
 
@@ -162,7 +162,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncCommandT_FuncBool_NullExecuteParameter()
 		{
 			// Arrange
-			Func<int, Task> execute = null;
+			Func<int, Task>? execute = null;
 
 			// Act
 
@@ -174,7 +174,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public async Task AsyncCommandT_FuncBool_NullCanExecuteParameter()
 		{
 			// Arrange
-			Func<bool> canExecute = null;
+			Func<bool>? canExecute = null;
 			var command = CommandFactory.Create<int>(IntParameterTask, canExecute);
 
 			// Act
@@ -213,7 +213,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncCommandTExecuteTCanExecute_NullExecuteParameter()
 		{
 			// Arrange
-			Func<int, Task> execute = null;
+			Func<int, Task>? execute = null;
 
 			// Act
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_AsyncValueCommand_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_AsyncValueCommand_Tests.cs
@@ -14,7 +14,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncValueCommand_NullExecuteParameter()
 		{
 			// Arrange
-			Func<Task> execute = null;
+			Func<Task>? execute = null;
 
 			// Act
 
@@ -62,7 +62,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncValueCommand_FuncBool_NullExecuteParameter()
 		{
 			// Arrange
-			Func<ValueTask> execute = null;
+			Func<ValueTask>? execute = null;
 
 			// Act
 
@@ -74,7 +74,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public async Task AsyncValueCommand_FuncBool_NullCanExecuteParameter()
 		{
 			// Arrange
-			Func<bool> canExecute = null;
+			Func<bool>? canExecute = null;
 			var command = CommandFactory.Create(NoParameterTask, canExecute);
 
 			// Act
@@ -113,7 +113,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncValueCommandT_NullExecuteParameter()
 		{
 			// Arrange
-			Func<int, ValueTask> execute = null;
+			Func<int, ValueTask>? execute = null;
 
 			// Act
 
@@ -163,7 +163,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncValueCommandT_FuncBool_NullExecuteParameter()
 		{
 			// Arrange
-			Func<int, ValueTask> execute = null;
+			Func<int, ValueTask>? execute = null;
 
 			// Act
 
@@ -175,7 +175,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public async Task AsyncValueCommandT_FuncBool_NullCanExecuteParameter()
 		{
 			// Arrange
-			Func<bool> canExecute = null;
+			Func<bool>? canExecute = null;
 			var command = CommandFactory.Create<int>(IntParameterTask, canExecute);
 
 			// Act
@@ -214,7 +214,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void AsyncValueCommandTExecuteTCanExecute_NullExecuteParameter()
 		{
 			// Arrange
-			Func<int, ValueTask> execute = null;
+			Func<int, ValueTask>? execute = null;
 
 			// Act
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_Command_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ICommandTests/CommandFactoryTests/CommandFactory_Command_Tests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows.Input;
-using Xamarin.CommunityToolkit.Exceptions;
 using Xamarin.CommunityToolkit.ObjectModel;
 using Xunit;
 
@@ -12,7 +11,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void Action_NullExecuteParameter()
 		{
 			// Arrange
-			Action execute = null;
+			Action? execute = null;
 
 			// Act
 
@@ -71,7 +70,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void ActionObject_NullExecuteParameter()
 		{
 			// Arrange
-			Action<object> execute = null;
+			Action<object>? execute = null;
 
 			// Act
 
@@ -132,7 +131,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel.ICommandTests.CommandFa
 		public void ActionInt_NullExecuteParameter()
 		{
 			// Arrange
-			Action<int> execute = null;
+			Action<int>? execute = null;
 
 			// Act
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableObject_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableObject_Tests.cs
@@ -7,21 +7,16 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 {
 	public sealed class ObservableObject_Tests
 	{
-		Person person;
-
-		public ObservableObject_Tests()
+		readonly Person person = new Person
 		{
-			person = new Person
-			{
-				FirstName = "James",
-				LastName = "Montemagno"
-			};
-		}
+			FirstName = "James",
+			LastName = "Montemagno"
+		};
 
 		[Fact]
 		public void OnPropertyChanged()
 		{
-			PropertyChangedEventArgs updated = null;
+			PropertyChangedEventArgs? updated = null;
 			person.PropertyChanged += (sender, args) =>
 			{
 				updated = args;
@@ -30,13 +25,13 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 			person.FirstName = "Motz";
 
 			Assert.NotNull(updated);
-			Assert.Equal(nameof(person.FirstName), updated.PropertyName);
+			Assert.Equal(nameof(person.FirstName), updated?.PropertyName);
 		}
 
 		[Fact]
 		public void OnDidntChange()
 		{
-			PropertyChangedEventArgs updated = null;
+			PropertyChangedEventArgs? updated = null;
 			person.PropertyChanged += (sender, args) =>
 			{
 				updated = args;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableRangeCollection_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/ObservableRangeCollection_Tests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using Xamarin.CommunityToolkit.ObjectModel;
 using Xunit;
 using Xunit.Sdk;
@@ -121,7 +122,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 					throw new XunitException("Expected and actual OldItems don't match.");
 				for (var i = 0; i < expected.Length; i++)
 				{
-					if (expected[i] != (int)e.OldItems[i])
+					if (expected[i] != (int?)e.OldItems[i])
 						throw new XunitException("Expected and actual OldItems don't match.");
 				}
 			};
@@ -176,12 +177,6 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 			Assert.Equal(6, collection.Count);
 		}
 
-		class CollectionWrapper<T>
-		{
-			public readonly ObservableRangeCollection<T> Collection = new ObservableRangeCollection<T>();
-			public ObservableRangeCollection<T> NullCollection;
-		}
-
 		[Fact]
 		public void AddCollection()
 		{
@@ -200,6 +195,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 		{
 			var toAdd = new[] { 3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 2, 3 };
 
+#pragma warning disable CS8670 // Object or collection initializer implicitly dereferences possibly null member.
 			Assert.Throws<ArgumentNullException>(() =>
 			{
 				var wrapper = new CollectionWrapper<int>()
@@ -207,6 +203,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 					NullCollection = { toAdd }
 				};
 			});
+#pragma warning restore CS8670 // Object or collection initializer implicitly dereferences possibly null member.
+		}
+
+		class CollectionWrapper<T>
+		{
+			public ObservableRangeCollection<T> Collection { get; } = new ObservableRangeCollection<T>();
+
+			public ObservableRangeCollection<T>? NullCollection { get; init; }
 		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/Person.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/ObjectModel/Person.cs
@@ -5,14 +5,14 @@ namespace Xamarin.CommunityToolkit.UnitTests.ObjectModel
 {
 	class Person : ObservableObject
 	{
-		string firstName;
-		string lastName;
+		string firstName = string.Empty;
+		string lastName = string.Empty;
 
-		public Action Changed { get; set; }
+		public Action? Changed { get; set; }
 
-		public Action Changing { get; set; }
+		public Action? Changing { get; set; }
 
-		public Func<string, string, bool> Validate { get; set; }
+		public Func<string, string, bool>? Validate { get; set; }
 
 		public string FirstName
 		{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Views/MediaSource_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Views/MediaSource_Tests.cs
@@ -32,7 +32,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Views
 		public void TestImplicitFileConversion()
 		{
 			var mediaElement = new UI.Views.MediaElement { Source = "File.mp4" };
-			Assert.True(mediaElement.Source != null);
+			Assert.NotNull(mediaElement.Source);
 			Assert.IsType<Core.FileMediaSource>(mediaElement.Source);
 			Assert.Equal("File.mp4", ((Core.FileMediaSource)mediaElement.Source).File);
 		}
@@ -40,7 +40,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Views
 		[Fact]
 		public void TestImplicitStringConversionWhenNull()
 		{
-			string s = null;
+			string? s = null;
 			var sut = (Core.MediaSource)s;
 			Assert.IsType<Core.FileMediaSource>(sut);
 			Assert.Null(((Core.FileMediaSource)sut).File);
@@ -50,7 +50,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Views
 		public void TestImplicitUriConversion()
 		{
 			var mediaElement = new UI.Views.MediaElement { Source = new Uri("http://xamarin.com/media.mp4") };
-			Assert.True(mediaElement.Source != null);
+			Assert.NotNull(mediaElement.Source);
 			Assert.IsType<Core.UriMediaSource>(mediaElement.Source);
 			Assert.Equal("http://xamarin.com/media.mp4", ((Core.UriMediaSource)mediaElement.Source).Uri.AbsoluteUri);
 		}
@@ -59,7 +59,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Views
 		public void TestImplicitStringUriConversion()
 		{
 			var mediaElement = new UI.Views.MediaElement { Source = "http://xamarin.com/media.mp4" };
-			Assert.True(mediaElement.Source != null);
+			Assert.NotNull(mediaElement.Source);
 			Assert.IsType<Core.UriMediaSource>(mediaElement.Source);
 			Assert.Equal("http://xamarin.com/media.mp4", ((Core.UriMediaSource)mediaElement.Source).Uri.AbsoluteUri);
 		}
@@ -67,7 +67,7 @@ namespace Xamarin.CommunityToolkit.UnitTests.Views
 		[Fact]
 		public void TestImplicitUriConversionWhenNull()
 		{
-			Uri u = null;
+			Uri? u = null;
 			var sut = (Core.MediaSource)u;
 			Assert.Null(sut);
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Xamarin.CommunityToolkit.UnitTests.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Xamarin.CommunityToolkit.UnitTests.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net461</TargetFrameworks>
-
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/BindableObjectExtensions.cs
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/BindableObjectExtensions.cs
@@ -13,12 +13,12 @@ namespace Xamarin.CommunityToolkit.Markup
 			BindableProperty targetProperty,
 			string path = bindingContextPath,
 			BindingMode mode = BindingMode.Default,
-			IValueConverter converter = null,
-			object converterParameter = null,
-			string stringFormat = null,
-			object source = null,
-			object targetNullValue = null,
-			object fallbackValue = null) where TBindable : BindableObject
+			IValueConverter? converter = null,
+			object? converterParameter = null,
+			string? stringFormat = null,
+			object? source = null,
+			object? targetNullValue = null,
+			object? fallbackValue = null) where TBindable : BindableObject
 		{
 			bindable.SetBinding(
 				targetProperty,
@@ -36,12 +36,12 @@ namespace Xamarin.CommunityToolkit.Markup
 			BindableProperty targetProperty,
 			string path = bindingContextPath,
 			BindingMode mode = BindingMode.Default,
-			Func<TSource, TDest> convert = null,
-			Func<TDest, TSource> convertBack = null,
-			string stringFormat = null,
-			object source = null,
-			TDest targetNullValue = default,
-			TDest fallbackValue = default) where TBindable : BindableObject
+			Func<TSource?, TDest>? convert = null,
+			Func<TDest?, TSource>? convertBack = null,
+			string? stringFormat = null,
+			object? source = null,
+			TDest? targetNullValue = default,
+			TDest? fallbackValue = default) where TBindable : BindableObject
 		{
 			var converter = new FuncConverter<TSource, TDest, object>(convert, convertBack);
 			bindable.SetBinding(
@@ -60,13 +60,13 @@ namespace Xamarin.CommunityToolkit.Markup
 			BindableProperty targetProperty,
 			string path = bindingContextPath,
 			BindingMode mode = BindingMode.Default,
-			Func<TSource, TParam, TDest> convert = null,
-			Func<TDest, TParam, TSource> convertBack = null,
-			TParam converterParameter = default,
-			string stringFormat = null,
-			object source = null,
-			TDest targetNullValue = default,
-			TDest fallbackValue = default) where TBindable : BindableObject
+			Func<TSource?, TParam?, TDest>? convert = null,
+			Func<TDest?, TParam?, TSource>? convertBack = null,
+			TParam? converterParameter = default,
+			string? stringFormat = null,
+			object? source = null,
+			TDest? targetNullValue = default,
+			TDest? fallbackValue = default) where TBindable : BindableObject
 		{
 			var converter = new FuncConverter<TSource, TDest, TParam>(convert, convertBack);
 			bindable.SetBinding(
@@ -84,12 +84,12 @@ namespace Xamarin.CommunityToolkit.Markup
 			this TBindable bindable,
 			string path = bindingContextPath,
 			BindingMode mode = BindingMode.Default,
-			IValueConverter converter = null,
-			object converterParameter = null,
-			string stringFormat = null,
-			object source = null,
-			object targetNullValue = null,
-			object fallbackValue = null) where TBindable : BindableObject
+			IValueConverter? converter = null,
+			object? converterParameter = null,
+			string? stringFormat = null,
+			object? source = null,
+			object? targetNullValue = null,
+			object? fallbackValue = null) where TBindable : BindableObject
 		{
 			bindable.Bind(
 				DefaultBindableProperties.GetFor(bindable),
@@ -102,12 +102,12 @@ namespace Xamarin.CommunityToolkit.Markup
 			this TBindable bindable,
 			string path = bindingContextPath,
 			BindingMode mode = BindingMode.Default,
-			Func<TSource, TDest> convert = null,
-			Func<TDest, TSource> convertBack = null,
-			string stringFormat = null,
-			object source = null,
-			TDest targetNullValue = default,
-			TDest fallbackValue = default) where TBindable : BindableObject
+			Func<TSource?, TDest>? convert = null,
+			Func<TDest?, TSource>? convertBack = null,
+			string? stringFormat = null,
+			object? source = null,
+			TDest? targetNullValue = default,
+			TDest? fallbackValue = default) where TBindable : BindableObject
 		{
 			var converter = new FuncConverter<TSource, TDest, object>(convert, convertBack);
 			bindable.Bind(
@@ -121,13 +121,13 @@ namespace Xamarin.CommunityToolkit.Markup
 			this TBindable bindable,
 			string path = bindingContextPath,
 			BindingMode mode = BindingMode.Default,
-			Func<TSource, TParam, TDest> convert = null,
-			Func<TDest, TParam, TSource> convertBack = null,
-			TParam converterParameter = default,
-			string stringFormat = null,
-			object source = null,
-			TDest targetNullValue = default,
-			TDest fallbackValue = default) where TBindable : BindableObject
+			Func<TSource?, TParam?, TDest>? convert = null,
+			Func<TDest?, TParam?, TSource>? convertBack = null,
+			TParam? converterParameter = default,
+			string? stringFormat = null,
+			object? source = null,
+			TDest? targetNullValue = default,
+			TDest? fallbackValue = default) where TBindable : BindableObject
 		{
 			var converter = new FuncConverter<TSource, TDest, TParam>(convert, convertBack);
 			bindable.Bind(
@@ -141,9 +141,9 @@ namespace Xamarin.CommunityToolkit.Markup
 		public static TBindable BindCommand<TBindable>(
 			this TBindable bindable,
 			string path = bindingContextPath,
-			object source = null,
-			string parameterPath = bindingContextPath,
-			object parameterSource = null) where TBindable : BindableObject
+			object? source = null,
+			string? parameterPath = bindingContextPath,
+			object? parameterSource = null) where TBindable : BindableObject
 		{
 			(var commandProperty, var parameterProperty) = DefaultBindableProperties.GetForCommand(bindable);
 

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/BindableObjectMultiBindExtensions.cs
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/BindableObjectMultiBindExtensions.cs
@@ -12,12 +12,12 @@ namespace Xamarin.CommunityToolkit.Markup
 			BindableProperty targetProperty,
 			BindingBase binding1,
 			BindingBase binding2,
-			Func<ValueTuple<TSource1, TSource2>, TDest> convert = null,
-			Func<TDest, ValueTuple<TSource1, TSource2>> convertBack = null,
+			Func<ValueTuple<TSource1?, TSource2?>, TDest>? convert = null,
+			Func<TDest?, ValueTuple<TSource1, TSource2>>? convertBack = null,
 			BindingMode mode = BindingMode.Default,
-			string stringFormat = null,
-			TDest targetNullValue = default,
-			TDest fallbackValue = default) where TBindable : BindableObject
+			string? stringFormat = null,
+			TDest? targetNullValue = default,
+			TDest? fallbackValue = default) where TBindable : BindableObject
 		=> bindable.Bind(
 			targetProperty,
 			new List<BindingBase> { binding1, binding2 },
@@ -34,13 +34,13 @@ namespace Xamarin.CommunityToolkit.Markup
 			BindableProperty targetProperty,
 			BindingBase binding1,
 			BindingBase binding2,
-			Func<ValueTuple<TSource1, TSource2>, TParam, TDest> convert = null,
-			Func<TDest, TParam, ValueTuple<TSource1, TSource2>> convertBack = null,
-			TParam converterParameter = default,
+			Func<ValueTuple<TSource1?, TSource2?>, TParam?, TDest>? convert = null,
+			Func<TDest?, TParam?, ValueTuple<TSource1, TSource2>>? convertBack = null,
+			TParam? converterParameter = default,
 			BindingMode mode = BindingMode.Default,
-			string stringFormat = null,
-			TDest targetNullValue = default,
-			TDest fallbackValue = default) where TBindable : BindableObject
+			string? stringFormat = null,
+			TDest? targetNullValue = default,
+			TDest? fallbackValue = default) where TBindable : BindableObject
 		=> bindable.Bind(
 			targetProperty,
 			new List<BindingBase> { binding1, binding2 },
@@ -58,12 +58,12 @@ namespace Xamarin.CommunityToolkit.Markup
 			BindingBase binding1,
 			BindingBase binding2,
 			BindingBase binding3,
-			Func<ValueTuple<TSource1, TSource2, TSource3>, TDest> convert = null,
-			Func<TDest, ValueTuple<TSource1, TSource2, TSource3>> convertBack = null,
+			Func<ValueTuple<TSource1?, TSource2?, TSource3?>, TDest>? convert = null,
+			Func<TDest?, ValueTuple<TSource1, TSource2, TSource3>>? convertBack = null,
 			BindingMode mode = BindingMode.Default,
-			string stringFormat = null,
-			TDest targetNullValue = default,
-			TDest fallbackValue = default) where TBindable : BindableObject
+			string? stringFormat = null,
+			TDest? targetNullValue = default,
+			TDest? fallbackValue = default) where TBindable : BindableObject
 		=> bindable.Bind(
 			targetProperty,
 			new List<BindingBase> { binding1, binding2, binding3 },
@@ -81,13 +81,13 @@ namespace Xamarin.CommunityToolkit.Markup
 			BindingBase binding1,
 			BindingBase binding2,
 			BindingBase binding3,
-			Func<ValueTuple<TSource1, TSource2, TSource3>, TParam, TDest> convert = null,
-			Func<TDest, TParam, ValueTuple<TSource1, TSource2, TSource3>> convertBack = null,
-			TParam converterParameter = default,
+			Func<ValueTuple<TSource1?, TSource2?, TSource3?>, TParam?, TDest>? convert = null,
+			Func<TDest?, TParam?, ValueTuple<TSource1, TSource2, TSource3>>? convertBack = null,
+			TParam? converterParameter = default,
 			BindingMode mode = BindingMode.Default,
-			string stringFormat = null,
-			TDest targetNullValue = default,
-			TDest fallbackValue = default) where TBindable : BindableObject
+			string? stringFormat = null,
+			TDest? targetNullValue = default,
+			TDest? fallbackValue = default) where TBindable : BindableObject
 		=> bindable.Bind(
 			targetProperty,
 			new List<BindingBase> { binding1, binding2, binding3 },
@@ -106,12 +106,12 @@ namespace Xamarin.CommunityToolkit.Markup
 			BindingBase binding2,
 			BindingBase binding3,
 			BindingBase binding4,
-			Func<ValueTuple<TSource1, TSource2, TSource3, TSource4>, TDest> convert = null,
-			Func<TDest, ValueTuple<TSource1, TSource2, TSource3, TSource4>> convertBack = null,
+			Func<ValueTuple<TSource1?, TSource2?, TSource3?, TSource4?>, TDest>? convert = null,
+			Func<TDest?, ValueTuple<TSource1, TSource2, TSource3, TSource4>>? convertBack = null,
 			BindingMode mode = BindingMode.Default,
-			string stringFormat = null,
-			TDest targetNullValue = default,
-			TDest fallbackValue = default) where TBindable : BindableObject
+			string? stringFormat = null,
+			TDest? targetNullValue = default,
+			TDest? fallbackValue = default) where TBindable : BindableObject
 		=> bindable.Bind(
 			targetProperty,
 			new List<BindingBase> { binding1, binding2, binding3, binding4 },
@@ -130,13 +130,13 @@ namespace Xamarin.CommunityToolkit.Markup
 			BindingBase binding2,
 			BindingBase binding3,
 			BindingBase binding4,
-			Func<ValueTuple<TSource1, TSource2, TSource3, TSource4>, TParam, TDest> convert = null,
-			Func<TDest, TParam, ValueTuple<TSource1, TSource2, TSource3, TSource4>> convertBack = null,
-			TParam converterParameter = default,
+			Func<ValueTuple<TSource1?, TSource2?, TSource3?, TSource4?>, TParam?, TDest>? convert = null,
+			Func<TDest?, TParam?, ValueTuple<TSource1, TSource2, TSource3, TSource4>>? convertBack = null,
+			TParam? converterParameter = default,
 			BindingMode mode = BindingMode.Default,
-			string stringFormat = null,
-			TDest targetNullValue = default,
-			TDest fallbackValue = default) where TBindable : BindableObject
+			string? stringFormat = null,
+			TDest? targetNullValue = default,
+			TDest? fallbackValue = default) where TBindable : BindableObject
 		=> bindable.Bind(
 			targetProperty,
 			new List<BindingBase> { binding1, binding2, binding3, binding4 },
@@ -153,11 +153,11 @@ namespace Xamarin.CommunityToolkit.Markup
 			BindableProperty targetProperty,
 			IList<BindingBase> bindings,
 			IMultiValueConverter converter,
-			object converterParameter = default,
+			object? converterParameter = default,
 			BindingMode mode = BindingMode.Default,
-			string stringFormat = null,
-			object targetNullValue = null,
-			object fallbackValue = null) where TBindable : BindableObject
+			string? stringFormat = null,
+			object? targetNullValue = null,
+			object? fallbackValue = null) where TBindable : BindableObject
 		{
 			bindable.SetBinding(targetProperty, new MultiBinding
             {

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/ElementExtensions.cs
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/ElementExtensions.cs
@@ -41,7 +41,7 @@ namespace Xamarin.CommunityToolkit.Markup
 
 		public static TElement Effects<TElement>(this TElement element, params Effect[] effects) where TElement : Element
 		{
-			for (int i = 0; i < effects.Length; i++)
+			for (var i = 0; i < effects.Length; i++)
 				element.Effects.Add(effects[i]);
 			return element;
 		}
@@ -59,7 +59,7 @@ namespace Xamarin.CommunityToolkit.Markup
 
 		public static TFontElement Font<TFontElement>(
 			this TFontElement fontElement,
-			string family = null,
+			string? family = null,
 			double? size = null,
 			bool? bold = null,
 			bool? italic = null) where TFontElement : Element, IFontElement

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/ElementGesturesExtensions.cs
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/ElementGesturesExtensions.cs
@@ -13,9 +13,9 @@ namespace Xamarin.CommunityToolkit.Markup
 		public static TGestureElement BindClickGesture<TGestureElement>(
 			this TGestureElement gestureElement,
 			string commandPath = bindingContextPath,
-			object commandSource = null,
-			string parameterPath = null,
-			object parameterSource = null) where TGestureElement : Element, IGestureRecognizers
+			object? commandSource = null,
+			string? parameterPath = null,
+			object? parameterSource = null) where TGestureElement : Element, IGestureRecognizers
 			=> ClickGesture(gestureElement, g => g.BindCommand(commandPath, commandSource, parameterPath, parameterSource));
 
 		/// <summary>Add a <see cref="SwipeGestureRecognizer"/>,
@@ -24,9 +24,9 @@ namespace Xamarin.CommunityToolkit.Markup
 		public static TGestureElement BindSwipeGesture<TGestureElement>(
 			this TGestureElement gestureElement,
 			string commandPath = bindingContextPath,
-			object commandSource = null,
-			string parameterPath = null,
-			object parameterSource = null) where TGestureElement : Element, IGestureRecognizers
+			object? commandSource = null,
+			string? parameterPath = null,
+			object? parameterSource = null) where TGestureElement : Element, IGestureRecognizers
 			=> SwipeGesture(gestureElement, g => g.BindCommand(commandPath, commandSource, parameterPath, parameterSource));
 
 		/// <summary>Add a <see cref="TapGestureRecognizer"/>,
@@ -35,9 +35,9 @@ namespace Xamarin.CommunityToolkit.Markup
 		public static TGestureElement BindTapGesture<TGestureElement>(
 			this TGestureElement gestureElement,
 			string commandPath = bindingContextPath,
-			object commandSource = null,
-			string parameterPath = null,
-			object parameterSource = null) where TGestureElement : Element, IGestureRecognizers
+			object? commandSource = null,
+			string? parameterPath = null,
+			object? parameterSource = null) where TGestureElement : Element, IGestureRecognizers
 			=> TapGesture(gestureElement, g => g.BindCommand(commandPath, commandSource, parameterPath, parameterSource));
 
 		/// <summary>Add a <see cref="ClickGestureRecognizer"/>,

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/FuncConverter.cs
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/FuncConverter.cs
@@ -6,25 +6,25 @@ namespace Xamarin.CommunityToolkit.Markup
 {
 	public class FuncConverter<TSource, TDest, TParam> : IValueConverter
 	{
-		readonly Func<TSource, TDest> convert;
-		readonly Func<TDest, TSource> convertBack;
+		readonly Func<TSource?, TDest>? convert;
+		readonly Func<TDest?, TSource>? convertBack;
 
-		readonly Func<TSource, TParam, TDest> convertWithParam;
-		readonly Func<TDest, TParam, TSource> convertBackWithParam;
+		readonly Func<TSource?, TParam?, TDest>? convertWithParam;
+		readonly Func<TDest?, TParam?, TSource>? convertBackWithParam;
 
-		readonly Func<TSource, TParam, CultureInfo, TDest> convertWithParamAndCulture;
-		readonly Func<TDest, TParam, CultureInfo, TSource> convertBackWithParamAndCulture;
+		readonly Func<TSource?, TParam?, CultureInfo, TDest>? convertWithParamAndCulture;
+		readonly Func<TDest?, TParam?, CultureInfo, TSource>? convertBackWithParamAndCulture;
 
-		public FuncConverter(Func<TSource, TParam, CultureInfo, TDest> convertWithParamAndCulture = null, Func<TDest, TParam, CultureInfo, TSource> convertBackWithParamAndCulture = null)
+		public FuncConverter(Func<TSource?, TParam?, CultureInfo, TDest>? convertWithParamAndCulture = null, Func<TDest?, TParam?, CultureInfo, TSource>? convertBackWithParamAndCulture = null)
 		{ this.convertWithParamAndCulture = convertWithParamAndCulture; this.convertBackWithParamAndCulture = convertBackWithParamAndCulture; }
 
-		public FuncConverter(Func<TSource, TParam, TDest> convertWithParam = null, Func<TDest, TParam, TSource> convertBackWithParam = null)
+		public FuncConverter(Func<TSource?, TParam?, TDest>? convertWithParam = null, Func<TDest?, TParam?, TSource>? convertBackWithParam = null)
 		{ this.convertWithParam = convertWithParam; this.convertBackWithParam = convertBackWithParam; }
 
-		public FuncConverter(Func<TSource, TDest> convert = null, Func<TDest, TSource> convertBack = null)
+		public FuncConverter(Func<TSource?, TDest>? convert = null, Func<TDest?, TSource>? convertBack = null)
 		{ this.convert = convert; this.convertBack = convertBack; }
 
-		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
 		{
 			if (convert != null)
 			{
@@ -50,7 +50,7 @@ namespace Xamarin.CommunityToolkit.Markup
 			return default(TDest);
 		}
 
-		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
 		{
 			if (convertBack != null)
 			{
@@ -79,19 +79,19 @@ namespace Xamarin.CommunityToolkit.Markup
 
 	public class FuncConverter<TSource, TDest> : FuncConverter<TSource, TDest, object>
 	{
-		public FuncConverter(Func<TSource, TDest> convert = null, Func<TDest, TSource> convertBack = null)
+		public FuncConverter(Func<TSource?, TDest>? convert = null, Func<TDest?, TSource>? convertBack = null)
 			: base(convert, convertBack) { }
 	}
 
 	public class FuncConverter<TSource> : FuncConverter<TSource, object, object>
 	{
-		public FuncConverter(Func<TSource, object> convert = null, Func<object, TSource> convertBack = null)
+		public FuncConverter(Func<TSource?, object>? convert = null, Func<object?, TSource>? convertBack = null)
 			: base(convert, convertBack) { }
 	}
 
 	public class FuncConverter : FuncConverter<object, object, object>
 	{
-		public FuncConverter(Func<object, object> convert = null, Func<object, object> convertBack = null)
+		public FuncConverter(Func<object?, object>? convert = null, Func<object?, object>? convertBack = null)
 			: base(convert, convertBack) { }
 	}
 

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/FuncMultiConverter.cs
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/FuncMultiConverter.cs
@@ -6,25 +6,25 @@ namespace Xamarin.CommunityToolkit.Markup
 {
 	public class FuncMultiConverter<TDest, TParam> : IMultiValueConverter
 	{
-		readonly Func<object[], TDest> convert;
-		readonly Func<TDest, object[]> convertBack;
+		readonly Func<object[], TDest>? convert;
+		readonly Func<TDest?, object?[]>? convertBack;
 
-		readonly Func<object[], TParam, TDest> convertWithParam;
-		readonly Func<TDest, TParam, object[]> convertBackWithParam;
+		readonly Func<object[], TParam?, TDest>? convertWithParam;
+		readonly Func<TDest?, TParam?, object?[]>? convertBackWithParam;
 
-		readonly Func<object[], TParam, CultureInfo, TDest> convertWithParamAndCulture;
-		readonly Func<TDest, TParam, CultureInfo, object[]> convertBackWithParamAndCulture;
+		readonly Func<object[], TParam?, CultureInfo, TDest>? convertWithParamAndCulture;
+		readonly Func<TDest?, TParam?, CultureInfo, object[]>? convertBackWithParamAndCulture;
 
-		public FuncMultiConverter(Func<object[], TParam, CultureInfo, TDest> convertWithParamAndCulture = null, Func<TDest, TParam, CultureInfo, object[]> convertBackWithParamAndCulture = null)
+		public FuncMultiConverter(Func<object[], TParam?, CultureInfo, TDest>? convertWithParamAndCulture = null, Func<TDest?, TParam?, CultureInfo, object[]>? convertBackWithParamAndCulture = null)
 		{ this.convertWithParamAndCulture = convertWithParamAndCulture; this.convertBackWithParamAndCulture = convertBackWithParamAndCulture; }
 
-		public FuncMultiConverter(Func<object[], TParam, TDest> convertWithParam = null, Func<TDest, TParam, object[]> convertBackWithParam = null)
+		public FuncMultiConverter(Func<object[], TParam?, TDest>? convertWithParam = null, Func<TDest?, TParam?, object?[]>? convertBackWithParam = null)
 		{ this.convertWithParam = convertWithParam; this.convertBackWithParam = convertBackWithParam; }
 
-		public FuncMultiConverter(Func<object[], TDest> convert = null, Func<TDest, object[]> convertBack = null)
+		public FuncMultiConverter(Func<object[], TDest>? convert = null, Func<TDest?, object?[]>? convertBack = null)
 		{ this.convert = convert; this.convertBack = convertBack; }
 
-		public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+		public object? Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
 		{
 			if (convert != null)
 				return convert(values);
@@ -47,7 +47,7 @@ namespace Xamarin.CommunityToolkit.Markup
 			return BindableProperty.UnsetValue;
 		}
 
-		public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+		public object?[]? ConvertBack(object? value, Type[] targetTypes, object? parameter, CultureInfo culture)
 		{
 			if (convertBack != null)
 			{
@@ -76,85 +76,91 @@ namespace Xamarin.CommunityToolkit.Markup
 
 	public class FuncMultiConverter<TSource1, TSource2, TDest> : FuncMultiConverter<TDest, object>
 	{
-		static T To<T>(object value) => value != null ? (T)value : default;
+		static T? To<T>(object? value) => value != null ? (T)value : default;
 
-		static object[] ToObjects(ValueTuple<TSource1, TSource2> values) => new object[] { values.Item1, values.Item2 };
+		static object?[] ToObjects(ValueTuple<TSource1, TSource2> values) => new object?[] { values.Item1, values.Item2 };
 
 		public FuncMultiConverter(
-			Func<ValueTuple<TSource1, TSource2>, TDest> convert = null,
-			Func<TDest, ValueTuple<TSource1, TSource2>> convertBack = null)
+			Func<ValueTuple<TSource1?, TSource2?>, TDest>? convert = null,
+			Func<TDest?, ValueTuple<TSource1, TSource2>>? convertBack = null)
 		: base(
 			convert == null ? default(Func<object[], TDest>) : (object[] values) => convert((To<TSource1>(values[0]), To<TSource2>(values[1]))),
-			convertBack == null ? default(Func<TDest, object[]>) : (TDest value) => ToObjects(convertBack(value))) { }
+			convertBack == null ? default(Func<TDest?, object?[]>) : (TDest? value) => ToObjects(convertBack(value)))
+		{ }
 	}
 
 	public class FuncMultiConverter<TSource1, TSource2, TSource3, TDest> : FuncMultiConverter<TDest, object>
 	{
-		static T To<T>(object value) => value != null ? (T)value : default;
+		static T? To<T>(object? value) => value != null ? (T)value : default;
 
-		static object[] ToObjects(ValueTuple<TSource1, TSource2, TSource3> values) => new object[] { values.Item1, values.Item2, values.Item3 };
+		static object?[] ToObjects(ValueTuple<TSource1, TSource2, TSource3> values) => new object?[] { values.Item1, values.Item2, values.Item3 };
 
 		public FuncMultiConverter(
-			Func<ValueTuple<TSource1, TSource2, TSource3>, TDest> convert = null,
-			Func<TDest, ValueTuple<TSource1, TSource2, TSource3>> convertBack = null)
+			Func<ValueTuple<TSource1?, TSource2?, TSource3?>, TDest>? convert = null,
+			Func<TDest?, ValueTuple<TSource1, TSource2, TSource3>>? convertBack = null)
 		: base(
 			convert == null ? default(Func<object[], TDest>) : (object[] values) => convert((To<TSource1>(values[0]), To<TSource2>(values[1]), To<TSource3>(values[2]))),
-			convertBack == null ? default(Func<TDest, object[]>) : (TDest value) => ToObjects(convertBack(value))) { }
+			convertBack == null ? default(Func<TDest?, object?[]>) : (TDest? value) => ToObjects(convertBack(value)))
+		{ }
 	}
 
 	public class FuncMultiConverter<TSource1, TSource2, TSource3, TSource4, TDest> : FuncMultiConverter<TDest, object>
 	{
-		static T To<T>(object value) => value != null ? (T)value : default;
+		static T? To<T>(object? value) => value != null ? (T)value : default;
 
-		static object[] ToObjects(ValueTuple<TSource1, TSource2, TSource3, TSource4> values) => new object[] { values.Item1, values.Item2, values.Item3, values.Item4 };
+		static object?[] ToObjects(ValueTuple<TSource1, TSource2, TSource3, TSource4> values) => new object?[] { values.Item1, values.Item2, values.Item3, values.Item4 };
 
 		public FuncMultiConverter(
-			Func<ValueTuple<TSource1, TSource2, TSource3, TSource4>, TDest> convert = null,
-			Func<TDest, ValueTuple<TSource1, TSource2, TSource3, TSource4>> convertBack = null)
+			Func<ValueTuple<TSource1?, TSource2?, TSource3?, TSource4?>, TDest>? convert = null,
+			Func<TDest?, ValueTuple<TSource1, TSource2, TSource3, TSource4>>? convertBack = null)
 		: base(
 			convert == null ? default(Func<object[], TDest>) : (object[] values) => convert((To<TSource1>(values[0]), To<TSource2>(values[1]), To<TSource3>(values[2]), To<TSource4>(values[3]))),
-			convertBack == null ? default(Func<TDest, object[]>) : (TDest value) => ToObjects(convertBack(value))) { }
+			convertBack == null ? default(Func<TDest?, object?[]>) : (TDest? value) => ToObjects(convertBack(value)))
+		{ }
 	}
 
 	public class FuncMultiConverterWithParam<TSource1, TSource2, TDest, TParam> : FuncMultiConverter<TDest, TParam>
 	{
-		static T To<T>(object value) => value != null ? (T)value : default;
+		static T? To<T>(object? value) => value != null ? (T)value : default;
 
-		static object[] ToObjects(ValueTuple<TSource1, TSource2> values) => new object[] { values.Item1, values.Item2 };
+		static object?[] ToObjects(ValueTuple<TSource1, TSource2> values) => new object?[] { values.Item1, values.Item2 };
 
 		public FuncMultiConverterWithParam(
-			Func<ValueTuple<TSource1, TSource2>, TParam, TDest> convert = null,
-			Func<TDest, TParam, ValueTuple<TSource1, TSource2>> convertBack = null)
+			Func<ValueTuple<TSource1?, TSource2?>, TParam?, TDest>? convert = null,
+			Func<TDest?, TParam?, ValueTuple<TSource1, TSource2>>? convertBack = null)
 		: base(
-			convert == null ? default(Func<object[], TParam, TDest>) : (object[] values, TParam param) => convert((To<TSource1>(values[0]), To<TSource2>(values[1])), param),
-			convertBack == null ? default(Func<TDest, TParam, object[]>) : (TDest value, TParam param) => ToObjects(convertBack(value, param))) { }
+			convert == null ? default(Func<object[], TParam?, TDest>) : (object[] values, TParam? param) => convert((To<TSource1>(values[0]), To<TSource2>(values[1])), param),
+			convertBack == null ? default(Func<TDest?, TParam?, object?[]>) : (TDest? value, TParam? param) => ToObjects(convertBack(value, param)))
+		{ }
 	}
 
 	public class FuncMultiConverterWithParam<TSource1, TSource2, TSource3, TDest, TParam> : FuncMultiConverter<TDest, TParam>
 	{
-		static T To<T>(object value) => value != null ? (T)value : default;
+		static T? To<T>(object value) => value != null ? (T)value : default;
 
-		static object[] ToObjects(ValueTuple<TSource1, TSource2, TSource3> values) => new object[] { values.Item1, values.Item2, values.Item3 };
+		static object?[] ToObjects(ValueTuple<TSource1, TSource2, TSource3> values) => new object?[] { values.Item1, values.Item2, values.Item3 };
 
 		public FuncMultiConverterWithParam(
-			Func<ValueTuple<TSource1, TSource2, TSource3>, TParam, TDest> convert = null,
-			Func<TDest, TParam, ValueTuple<TSource1, TSource2, TSource3>> convertBack = null)
+			Func<ValueTuple<TSource1?, TSource2?, TSource3?>, TParam?, TDest>? convert = null,
+			Func<TDest?, TParam?, ValueTuple<TSource1, TSource2, TSource3>>? convertBack = null)
 		: base(
-			convert == null ? default(Func<object[], TParam, TDest>) : (object[] values, TParam param) => convert((To<TSource1>(values[0]), To<TSource2>(values[1]), To<TSource3>(values[2])), param),
-			convertBack == null ? default(Func<TDest, TParam, object[]>) : (TDest value, TParam param) => ToObjects(convertBack(value, param))) { }
+			convert == null ? default(Func<object[], TParam?, TDest>) : (object[] values, TParam? param) => convert((To<TSource1>(values[0]), To<TSource2>(values[1]), To<TSource3>(values[2])), param),
+			convertBack == null ? default(Func<TDest?, TParam?, object?[]>) : (TDest? value, TParam? param) => ToObjects(convertBack(value, param)))
+		{ }
 	}
 
 	public class FuncMultiConverterWithParam<TSource1, TSource2, TSource3, TSource4, TDest, TParam> : FuncMultiConverter<TDest, TParam>
 	{
-		static T To<T>(object value) => value != null ? (T)value : default;
+		static T? To<T>(object? value) => value != null ? (T)value : default;
 
-		static object[] ToObjects(ValueTuple<TSource1, TSource2, TSource3, TSource4> values) => new object[] { values.Item1, values.Item2, values.Item3, values.Item4 };
+		static object?[] ToObjects(ValueTuple<TSource1, TSource2, TSource3, TSource4> values) => new object?[] { values.Item1, values.Item2, values.Item3, values.Item4 };
 
 		public FuncMultiConverterWithParam(
-			Func<ValueTuple<TSource1, TSource2, TSource3, TSource4>, TParam, TDest> convert = null,
-			Func<TDest, TParam, ValueTuple<TSource1, TSource2, TSource3, TSource4>> convertBack = null)
+			Func<ValueTuple<TSource1?, TSource2?, TSource3?, TSource4?>, TParam?, TDest>? convert = null,
+			Func<TDest?, TParam?, ValueTuple<TSource1, TSource2, TSource3, TSource4>>? convertBack = null)
 		: base(
-			convert == null ? default(Func<object[], TParam, TDest>) : (object[] values, TParam param) => convert((To<TSource1>(values[0]), To<TSource2>(values[1]), To<TSource3>(values[2]), To<TSource4>(values[3])), param),
-			convertBack == null ? default(Func<TDest, TParam, object[]>) : (TDest value, TParam param) => ToObjects(convertBack(value, param))) { }
+			convert == null ? default(Func<object[], TParam?, TDest>) : (object[] values, TParam? param) => convert((To<TSource1>(values[0]), To<TSource2>(values[1]), To<TSource3>(values[2]), To<TSource4>(values[3])), param),
+			convertBack == null ? default(Func<TDest?, TParam?, object?[]>) : (TDest? value, TParam? param) => ToObjects(convertBack(value, param)))
+		{ }
 	}
 }

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/RelativeLayout.cs
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/RelativeLayout.cs
@@ -42,14 +42,14 @@ namespace Xamarin.CommunityToolkit.Markup
 		readonly Bounds bounds;
 
 		public BoundsConstrainedView(View view, Bounds bounds)
-            : base(view) { this.bounds = bounds; }
+			: base(view) => this.bounds = bounds;
 
 		public override void AddTo(RelativeLayout layout) => layout.Children.Add(view, bounds);
 	}
 
 	public class ExpressionsConstrainedView : ConstrainedView
 	{
-		Expression x, y, width, height;
+		Expression? x, y, width, height;
 
 		public ExpressionsConstrainedView(View view)
             : base(view) { }
@@ -67,7 +67,7 @@ namespace Xamarin.CommunityToolkit.Markup
 
 	public class ConstraintsConstrainedView : ConstrainedView
 	{
-		Constraint x, y, width, height;
+		Constraint? x, y, width, height;
 
 		public ConstraintsConstrainedView(View view)
             : base(view) { }
@@ -103,7 +103,7 @@ namespace Xamarin.CommunityToolkit.Markup
 	{
 		protected readonly View view;
 
-		protected ConstrainedView(View view) { this.view = view; }
+		protected ConstrainedView(View view) => this.view = view;
 
 		public abstract void AddTo(RelativeLayout layout);
 	}

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/Style.cs
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/Style.cs
@@ -4,7 +4,7 @@ namespace Xamarin.CommunityToolkit.Markup
 {
 	public class Style<T> where T : BindableObject
 	{
-		public static implicit operator Style(Style<T> style) => style?.FormsStyle;
+		public static implicit operator Style?(Style<T>? style) => style?.FormsStyle;
 
 		public Style FormsStyle { get; }
 

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
@@ -32,6 +32,9 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance> 
     <PackageTags>xamarin,xamarin.forms,toolkit,kit,communitytoolkit,xamarincommunitytoolkit,markup,csharpformarkup,csharp,csharpmarkup</PackageTags>
     <Configurations>Debug;Release</Configurations>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard1.0')) ">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
This PR sets `<Nullable>enable</Nullable>` and `<WarningsAsErrors>nullable</WarningsAsErrors>` for the Android, GTK, iOS, Tizen, UWP & WPF Sample Projects