### PR TITLE
Add remove border effect implementation for uwp

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/RemoveBorder/RemoveBorderEffect.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/RemoveBorder/RemoveBorderEffect.shared.cs
@@ -16,6 +16,9 @@ namespace Xamarin.CommunityToolkit.Effects
 #elif __ANDROID__
 			if (DateTime.Now.Ticks < 0)
 				_ = new Xamarin.CommunityToolkit.Android.Effects.RemoveBorderEffect();
+#elif UWP
+			if (System.DateTime.Now.Ticks < 0)
+				_ = new Xamarin.CommunityToolkit.UWP.Effects.RemoveBorderEffect();
 #endif
 			#endregion
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/RemoveBorder/RemoveBorderEffect.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/RemoveBorder/RemoveBorderEffect.uwp.cs
@@ -1,0 +1,32 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Xamarin.CommunityToolkit.Effects;
+using Xamarin.Forms.Platform.UWP;
+using Effects = Xamarin.CommunityToolkit.UWP.Effects;
+
+[assembly: Xamarin.Forms.ExportEffect(typeof(Effects.RemoveBorderEffect), nameof(RemoveBorderEffect))]
+
+namespace Xamarin.CommunityToolkit.UWP.Effects
+{
+	public class RemoveBorderEffect : PlatformEffect
+	{
+		Thickness oldBorderThickness;
+
+		protected override void OnAttached()
+		{
+			if (Control is Control uwpControl)
+			{
+				oldBorderThickness = uwpControl.BorderThickness;
+				uwpControl.BorderThickness = new Thickness(0.0);
+			}
+		}
+
+		protected override void OnDetached()
+		{
+			if (Control is Control uwpControl)
+			{
+				uwpControl.BorderThickness = oldBorderThickness;
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Implemented RemoveBorderEffect for UWP. 

- Implements #922

### API Changes ###

n.a.

### Behavioral Changes ###

When attaching the RemoveBorderEffect on Controls like an entry on UWP the border will be gone. On detache border will be restored. 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description) => Don't see this as practical but I'm here to learn. 
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR => Rebased on current Develop
- [x] Changes adhere to coding standard

- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit) => **ToDo**
