### PR TITLE
Fix AvatarView UriImageSource Stream closed exception

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/AvatarView/AvatarView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/AvatarView/AvatarView.shared.cs
@@ -354,23 +354,17 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 				try
 				{
-					var imageStreamLoadingTask = GetImageStreamLoadingTask(source, imageLoadingTokenSource.Token);
-					if (imageStreamLoadingTask != null)
+					if (source is UriImageSource uriImageSource)
 					{
-						using var stream = await imageStreamLoadingTask;
-						if (stream != null)
-						{
-							var newStream = new MemoryStream();
-							stream.CopyTo(newStream);
-							newStream.Position = 0;
-							Image.IsVisible = true;
-							source = ImageSource.FromStream(() => newStream);
-						}
-						else
-						{
-							Image.IsVisible = false;
-							source = null;
-						}
+						static async Task<Stream?> getStreamAsync(UriImageSource uriSource, CancellationToken token) => uriSource.Uri != null ? await uriSource.GetStreamAsync(token) : null;
+
+						var stream = await getStreamAsync(uriImageSource, imageLoadingTokenSource.Token);
+
+						source = stream != null
+							? ImageSource.FromStream(async (token) => stream?.CanRead ?? true ? stream : (stream = await getStreamAsync(uriImageSource, token)))
+							: null;
+
+						Image.IsVisible = source != null;
 					}
 					else
 						Image.IsVisible = await imageSourceValidator.IsImageSourceValidAsync(source);
@@ -402,19 +396,5 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			return size * .4;
 		}
-
-		Task<Stream?> GetImageStreamLoadingTask(ImageSource? source, CancellationToken token) => source switch
-		{
-			IStreamImageSource streamImageSource => streamImageSource.GetStreamAsync(token),
-			UriImageSource uriImageSource => uriImageSource.Uri != null
-				? new UriImageSource
-				{
-					Uri = uriImageSource.Uri,
-					CachingEnabled = uriImageSource.CachingEnabled,
-					CacheValidity = uriImageSource.CacheValidity
-				}.GetStreamAsync(token)
-				: Task.FromResult<Stream?>(null),
-			_ => Task.FromResult<Stream?>(null)
-		};
 	}
 }


### PR DESCRIPTION
### Description of Change ###
If the stream is closed, we should try to reopen it rather than crash.

### Bugs Fixed ###
- Fixes #1046 

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
