### PR TITLE
#1059 CameraView iOS fix

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
@@ -190,7 +190,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		public async Task TakePhoto()
 		{
-			if (isBusy || device == null || photoOutput != null)
+			if (isBusy || device == null)
 				return;
 
 			IsBusy = true;


### PR DESCRIPTION
### Description of Change ###
 
A `photoOutput != null` check taken off. This check was introduced in the commit f44fb4eb and since then no photos can be taken under iOS. 


### Bugs Fixed ###

- Fixes #1059

### API Changes ###

NA


### Behavioral Changes ###

NA

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
