### PR TITLE
[Enhancement] Add LongPressCompleted event to TouchEffect

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/EventArgs/LongPressCompletedEventArgs.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/EventArgs/LongPressCompletedEventArgs.shared.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Xamarin.CommunityToolkit.Effects
+{
+	public class LongPressCompletedEventArgs : EventArgs
+	{
+		internal LongPressCompletedEventArgs(object? parameter)
+			=> Parameter = parameter;
+
+		public object? Parameter { get; }
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/GestureManager.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/GestureManager.shared.cs
@@ -199,6 +199,7 @@ namespace Xamarin.CommunityToolkit.Effects
 				{
 					sender.HandleUserInteraction(TouchInteractionStatus.Completed);
 					sender.LongPressCommand?.Execute(sender.LongPressCommandParameter ?? sender.CommandParameter);
+					sender.RaiseLongPressCompleted();
 				});
 
 				if (Device.IsInvokeRequired)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/TouchEffect.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/TouchEffect.shared.cs
@@ -45,6 +45,12 @@ namespace Xamarin.CommunityToolkit.Effects
 			remove => weakEventManager.RemoveEventHandler(value);
 		}
 
+		public event EventHandler<LongPressCompletedEventArgs> LongPressCompleted
+		{
+			add => weakEventManager.AddEventHandler(value);
+			remove => weakEventManager.RemoveEventHandler(value);
+		}
+
 		public static readonly BindableProperty IsAvailableProperty = BindableProperty.CreateAttached(
 			nameof(IsAvailable),
 			typeof(bool),
@@ -1155,6 +1161,9 @@ namespace Xamarin.CommunityToolkit.Effects
 
 		internal void RaiseCompleted()
 			=> weakEventManager.RaiseEvent(Element, new TouchCompletedEventArgs(CommandParameter), nameof(Completed));
+
+		internal void RaiseLongPressCompleted()
+			=> weakEventManager.RaiseEvent(Element, new LongPressCompletedEventArgs(LongPressCommandParameter ?? CommandParameter), nameof(LongPressCompleted));
 
 		internal void ForceUpdateState(bool animated = true)
 		{


### PR DESCRIPTION
### Description of Change ###
This results in a situation where long presses can only be handled via a Command, and there doesn't seem to be any way of accessing it as an event (which is imperative when implementing controls etc).

### Bugs Fixed ###
- Fixes #851 

### API Changes ###
Added: 
 
- `event TouchEffect.LongPressCompleted`
- `class LongPressCompletedEventArgs`

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of develop at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
