### PR TITLE
Add UWP implementation for SelectAllTextEffect

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/SelectAllText/SelectAllTextEffect.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/SelectAllText/SelectAllTextEffect.shared.cs
@@ -15,6 +15,9 @@ namespace Xamarin.CommunityToolkit.Effects
 #elif __ANDROID__
 			if (DateTime.Now.Ticks < 0)
 				_ = new Xamarin.CommunityToolkit.Android.Effects.SelectAllTextEffect();
+#elif UWP
+			if (DateTime.Now.Ticks < 0)
+				_ = new Xamarin.CommunityToolkit.UWP.Effects.SelectAllTextEffect();
 #endif
 			#endregion
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/SelectAllText/SelectAllTextEffect.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/SelectAllText/SelectAllTextEffect.uwp.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Xamarin.CommunityToolkit.Effects;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.UWP;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Effects = Xamarin.CommunityToolkit.UWP.Effects;
+
+[assembly: ExportEffect(typeof(Effects.SelectAllTextEffect), nameof(SelectAllTextEffect))]
+
+namespace Xamarin.CommunityToolkit.UWP.Effects
+{
+	public class SelectAllTextEffect : PlatformEffect
+	{
+		TextBox? EditText => Control as TextBox;
+
+		protected override void OnAttached() => ApplyEffect(true);
+
+		protected override void OnDetached() => ApplyEffect(false);
+
+		void ApplyEffect(bool apply)
+		{
+			if (EditText == null)
+				throw new NotSupportedException($"Control of type: {Control?.GetType()?.Name} is not supported by this effect.");
+
+			EditText.GotFocus -= OnGotFocus;
+
+			if (apply)
+				EditText.GotFocus += OnGotFocus;
+		}
+
+		void OnGotFocus(object sender, RoutedEventArgs e) => EditText?.SelectAll();
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Adds implementation of SelectAllTextEffect for UWP platform. Effect is based on TextBox which is base class of FormsTextBox used for Entry and Edit. 

### Bugs Fixed ###

Sorry no Issue created (yet). 

### API Changes ###

n.a.

### Behavioral Changes ###

Effect now just works with UWP. 

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description) => Don't see this as practical but I'm here to learn.
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR => Rebased on current Develop
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit) => ToDo
