### PR TITLE
Fix for LocalizedString not displaying in Release mode

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/LocalizedString.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Helpers/LocalizedString.shared.cs
@@ -23,6 +23,7 @@ namespace Xamarin.CommunityToolkit.Helpers
 			localizationManager.PropertyChanged += (sender, e) => OnPropertyChanged(null);
 		}
 
+		[Preserve(Conditional = true)]
 		public string Localized => generator();
 
 		[Preserve(Conditional = true)]


### PR DESCRIPTION
### Description of Change ###

Added `Preserve` to `Localized` property

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #1069

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
