### PR TITLE
Fix TouchEffect crash on resetting Application.MainPage

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/GestureManager.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/GestureManager.shared.cs
@@ -198,7 +198,6 @@ namespace Xamarin.CommunityToolkit.Effects
 				var longPressAction = new Action(() =>
 				{
 					sender.HandleUserInteraction(TouchInteractionStatus.Completed);
-					sender.LongPressCommand?.Execute(sender.LongPressCommandParameter ?? sender.CommandParameter);
 					sender.RaiseLongPressCompleted();
 				});
 
@@ -229,7 +228,6 @@ namespace Xamarin.CommunityToolkit.Effects
 			if (sender.Element is IButtonController button)
 				button.SendClicked();
 
-			sender.Command?.Execute(sender.CommandParameter);
 			sender.RaiseCompleted();
 		}
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/TouchEffect.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/TouchEffect.shared.cs
@@ -1160,10 +1160,20 @@ namespace Xamarin.CommunityToolkit.Effects
 			=> weakEventManager.RaiseEvent(Element, new HoverStatusChangedEventArgs(HoverStatus), nameof(HoverStatusChanged));
 
 		internal void RaiseCompleted()
-			=> weakEventManager.RaiseEvent(Element, new TouchCompletedEventArgs(CommandParameter), nameof(Completed));
+		{
+			var element = Element;
+			var parameter = CommandParameter;
+			Command?.Execute(parameter);
+			weakEventManager.RaiseEvent(element, new TouchCompletedEventArgs(parameter), nameof(Completed));
+		}
 
 		internal void RaiseLongPressCompleted()
-			=> weakEventManager.RaiseEvent(Element, new LongPressCompletedEventArgs(LongPressCommandParameter ?? CommandParameter), nameof(LongPressCompleted));
+		{
+			var element = Element;
+			var parameter = LongPressCommandParameter ?? CommandParameter;
+			LongPressCommand?.Execute(parameter);
+			weakEventManager.RaiseEvent(element, new LongPressCompletedEventArgs(parameter), nameof(LongPressCompleted));
+		}
 
 		internal void ForceUpdateState(bool animated = true)
 		{


### PR DESCRIPTION
### Description of Change ###
The crash happened when TouchEffect's Command causes the effect's detaching from the Element (Element was null in that case). So when the Completed event tried to get parameters, it led to a crash.

### Bugs Fixed ###
- Fixes #1066 
- Fixes #861

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
