### PR TITLE
Implemented shadow on UWP

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.uwp.cs
@@ -59,7 +59,7 @@ namespace Xamarin.CommunityToolkit.UWP.Effects
 
 		protected override void OnAttached()
 		{
-			if (!(Element is View elementView))
+			if (Element is not View elementView)
 				return;
 
 			switch (state)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.uwp.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Numerics;
+using Windows.UI.Composition;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Hosting;
+using Windows.UI.Xaml.Shapes;
+using Xamarin.CommunityToolkit.Effects;
+using Xamarin.CommunityToolkit.UWP.Effects;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.UWP;
+using Grid = Xamarin.Forms.Grid;
+using Image = Windows.UI.Xaml.Controls.Image;
+
+[assembly: ExportEffect(typeof(PlatformShadowEffect), nameof(ShadowEffect))]
+
+namespace Xamarin.CommunityToolkit.UWP.Effects
+{
+	public class PlatformShadowEffect : PlatformEffect
+	{
+		enum ShadowEffectState
+		{
+			Initialized,
+			PanelCreated,
+			Attached
+		}
+
+		const float defaultRadius = 10f;
+
+		const float defaultOpacity = 1f;
+
+		ShadowEffectState state;
+
+		SpriteVisual? spriteVisual;
+
+		Layout<View>? shadowPanel;
+
+		DropShadow? shadow;
+
+		FrameworkElement View => Control ?? Container;
+
+		protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)
+		{
+			base.OnElementPropertyChanged(args);
+
+			switch (args.PropertyName)
+			{
+				case nameof(ShadowEffect.ColorPropertyName):
+				case nameof(ShadowEffect.OpacityPropertyName):
+				case nameof(ShadowEffect.RadiusPropertyName):
+				case nameof(ShadowEffect.OffsetXPropertyName):
+				case nameof(ShadowEffect.OffsetYPropertyName):
+					UpdateShadow();
+					break;
+			}
+		}
+
+		protected override void OnAttached()
+		{
+			if (!(Element is View elementView))
+				return;
+
+			switch (state)
+			{
+				case ShadowEffectState.Attached:
+					return;
+
+				case ShadowEffectState.Initialized:
+					shadowPanel = new StackLayout()
+					{
+						Children = { new Grid() }
+					};
+					state = ShadowEffectState.PanelCreated;
+
+					MoveElementTo(elementView, shadowPanel);
+					return;
+
+				case ShadowEffectState.PanelCreated:
+					AppendShadow();
+					state = ShadowEffectState.Attached;
+					return;
+
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+		}
+
+		protected override void OnDetached()
+		{
+			if (state != ShadowEffectState.Attached)
+				return;
+
+			View.SizeChanged -= ViewSizeChanged;
+			shadow?.Dispose();
+			shadow = null;
+			spriteVisual?.Dispose();
+			spriteVisual = null;
+
+			state = ShadowEffectState.PanelCreated;
+		}
+
+		void AppendShadow()
+		{
+			var view = ElementCompositionPreview.GetElementVisual(View);
+
+			var compositor = view.Compositor;
+			shadow ??= compositor.CreateDropShadow();
+			UpdateShadow();
+			spriteVisual = compositor.CreateSpriteVisual();
+			spriteVisual.Shadow = shadow;
+			spriteVisual.Size = View.ActualSize;
+			spriteVisual.Size = new Vector2(1170, 40);
+
+			View.SizeChanged += ViewSizeChanged;
+
+			var renderer = shadowPanel?.Children.First().GetOrCreateRenderer();
+			spriteVisual.ParentForTransform = ElementCompositionPreview.GetElementVisual(View);
+			ElementCompositionPreview.SetElementChildVisual(renderer?.ContainerElement, spriteVisual);
+		}
+
+		void MoveElementTo(View element, Layout<View> to)
+		{
+			Device.BeginInvokeOnMainThread(() =>
+			{
+				if (Element.Parent is Layout<View> layout)
+				{
+					var index = layout.Children.IndexOf(element);
+					layout.Children.Insert(index, to);
+
+					if (layout is Grid)
+					{
+						var row = Grid.GetRow(element);
+						var rowSpan = Grid.GetRowSpan(element);
+						var column = Grid.GetColumn(element);
+						var columnSpan = Grid.GetColumnSpan(element);
+
+						Grid.SetRow(to, row);
+						Grid.SetRowSpan(to, rowSpan);
+						Grid.SetColumn(to, column);
+						Grid.SetColumnSpan(to, columnSpan);
+					}
+				}
+				else if (Element.Parent is ScrollView scrollView)
+				{
+					scrollView.Content = to;
+				}
+				else if (Element.Parent is ContentView contentView)
+				{
+					contentView.Content = to;
+				}
+
+				to.Children.Add(element);
+			});
+		}
+
+		void UpdateShadow()
+		{
+			if (shadow == null)
+				return;
+
+			var radius = (float)ShadowEffect.GetRadius(Element);
+			var opacity = (float)ShadowEffect.GetOpacity(Element);
+			var color = ShadowEffect.GetColor(Element).ToWindowsColor();
+			var offsetX = (float)ShadowEffect.GetOffsetX(Element);
+			var offsetY = (float)ShadowEffect.GetOffsetY(Element);
+
+			shadow.Color = color;
+			shadow.BlurRadius = radius < 0 ? defaultRadius : radius;
+			shadow.Opacity = opacity < 0 ? defaultOpacity : opacity;
+			shadow.Offset = new Vector3(offsetX, offsetY, 0);
+
+			UpdateShadowMask();
+		}
+
+		void UpdateShadowMask()
+		{
+			if (shadow == null)
+				return;
+
+			shadow.Mask = View switch
+			{
+				TextBlock textBlock => textBlock.GetAlphaMask(),
+				Shape shape => shape.GetAlphaMask(),
+				Image image => image.GetAlphaMask(),
+				_ => shadow.Mask
+			};
+		}
+
+		void ViewSizeChanged(object sender, SizeChangedEventArgs e)
+		{
+			if (spriteVisual == null)
+				return;
+
+			spriteVisual.Size = View.ActualSize;
+
+			UpdateShadowMask();
+		}
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.uwp.cs
@@ -39,7 +39,7 @@ namespace Xamarin.CommunityToolkit.UWP.Effects
 
 		DropShadow? shadow;
 
-		FrameworkElement View => Control ?? Container;
+		FrameworkElement? View => Control ?? Container;
 
 		protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)
 		{
@@ -47,11 +47,13 @@ namespace Xamarin.CommunityToolkit.UWP.Effects
 
 			switch (args.PropertyName)
 			{
-				case nameof(ShadowEffect.ColorPropertyName):
-				case nameof(ShadowEffect.OpacityPropertyName):
-				case nameof(ShadowEffect.RadiusPropertyName):
-				case nameof(ShadowEffect.OffsetXPropertyName):
-				case nameof(ShadowEffect.OffsetYPropertyName):
+				case ShadowEffect.ColorPropertyName:
+				case ShadowEffect.OpacityPropertyName:
+				case ShadowEffect.RadiusPropertyName:
+				case ShadowEffect.OffsetXPropertyName:
+				case ShadowEffect.OffsetYPropertyName:
+				case nameof(VisualElement.Width):
+				case nameof(VisualElement.Height):
 					UpdateShadow();
 					break;
 			}
@@ -64,26 +66,21 @@ namespace Xamarin.CommunityToolkit.UWP.Effects
 
 			switch (state)
 			{
-				case ShadowEffectState.Attached:
-					return;
-
 				case ShadowEffectState.Initialized:
 					shadowPanel = new StackLayout()
 					{
 						Children = { new Grid() }
 					};
+
 					state = ShadowEffectState.PanelCreated;
-
 					MoveElementTo(elementView, shadowPanel);
-					return;
-
+					break;
 				case ShadowEffectState.PanelCreated:
 					AppendShadow();
 					state = ShadowEffectState.Attached;
-					return;
-
+					break;
 				default:
-					throw new ArgumentOutOfRangeException();
+					break;
 			}
 		}
 
@@ -92,7 +89,11 @@ namespace Xamarin.CommunityToolkit.UWP.Effects
 			if (state != ShadowEffectState.Attached)
 				return;
 
-			View.SizeChanged -= ViewSizeChanged;
+			if (View != null)
+			{
+				View.SizeChanged -= ViewSizeChanged;
+			}
+
 			shadow?.Dispose();
 			shadow = null;
 			spriteVisual?.Dispose();
@@ -103,7 +104,13 @@ namespace Xamarin.CommunityToolkit.UWP.Effects
 
 		void AppendShadow()
 		{
+			if (View == null)
+				return;
+
 			var view = ElementCompositionPreview.GetElementVisual(View);
+
+			if (view == null)
+				return;
 
 			var compositor = view.Compositor;
 			shadow ??= compositor.CreateDropShadow();
@@ -189,7 +196,7 @@ namespace Xamarin.CommunityToolkit.UWP.Effects
 
 		void ViewSizeChanged(object sender, SizeChangedEventArgs e)
 		{
-			if (spriteVisual == null)
+			if (spriteVisual == null || View == null)
 				return;
 
 			spriteVisual.Size = View.ActualSize;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.uwp.cs
@@ -111,7 +111,6 @@ namespace Xamarin.CommunityToolkit.UWP.Effects
 			spriteVisual = compositor.CreateSpriteVisual();
 			spriteVisual.Shadow = shadow;
 			spriteVisual.Size = View.ActualSize;
-			spriteVisual.Size = new Vector2(1170, 40);
 
 			View.SizeChanged += ViewSizeChanged;
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/ShadowEffect.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/ShadowEffect.shared.cs
@@ -62,6 +62,9 @@ namespace Xamarin.CommunityToolkit.Effects
 #elif __MACOS__
 			if (System.DateTime.Now.Ticks < 0)
 				_ = new Xamarin.CommunityToolkit.macOS.Effects.PlatformShadowEffect();
+#elif UWP
+			if (System.DateTime.Now.Ticks < 0)
+				_ = new Xamarin.CommunityToolkit.UWP.Effects.PlatformShadowEffect();
 #endif
 		}
 


### PR DESCRIPTION
### Description of Change ###

Well, I've implemented this effect via DropShadow (next DS). But DS has strange behavior. DS appears above the element and I decided to pack an element to StackLayout. 

This StackLayout has a structure: 
StackLayout
	> Grid (For shadow)
	> Element 

After these changes I appended shadow to Grid, and it's working :)

Maybe my solution isn't very good, but I think we have just one way to implement shadow on UWP. 

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #847

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->


- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)

### Screenshot ###

![2021-03-21_03-26-38](https://user-images.githubusercontent.com/7888002/111890205-52dc5c00-89f8-11eb-8537-89370be6472c.png)