### PR TITLE
[iOS] Make RangeSlider more natural look like

### DIFF
--- a/samples/XCT.Sample/Pages/Views/RangeSliderPage.xaml
+++ b/samples/XCT.Sample/Pages/Views/RangeSliderPage.xaml
@@ -73,14 +73,14 @@
                 <Frame Padding="15, 10" BackgroundColor="LightBlue">
                     <StackLayout Spacing="10">
                         <Label Text="Thumb Size" FontAttributes="Bold"/>
-                        <Slider x:Name="ThumbSizeSlider" Maximum="50" Minimum="10" Value="30" />
+                        <Slider x:Name="ThumbSizeSlider" Maximum="50" Minimum="10" Value="28" />
                         <Label Text="Set Lower/Upper Thumb Size separately" />
                         <Switch x:Name="ThumbSizeSwitch" Toggled="OnThumbSizeSwitchToggled"/>
                         <StackLayout IsVisible="{Binding IsToggled, Source={x:Reference ThumbSizeSwitch}}">
                             <Label Text="Lower Thumb Size" />
-                            <Slider x:Name="LowerThumbSizeSlider" Maximum="50" Minimum="10" Value="30" />
+                            <Slider x:Name="LowerThumbSizeSlider" Maximum="50" Minimum="10" Value="28" />
                             <Label Text="Upper Thumb Size" />
-                            <Slider x:Name="UpperThumbSizeSlider" Maximum="50" Minimum="10" Value="30" />
+                            <Slider x:Name="UpperThumbSizeSlider" Maximum="50" Minimum="10" Value="28" />
                         </StackLayout>
 
                         <Label Text="Thumb Color" FontAttributes="Bold" Margin="0, 20, 0, 0"/>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.android.cs
@@ -45,6 +45,8 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 				case nameof(ShadowEffect.RadiusPropertyName):
 				case nameof(ShadowEffect.OffsetXPropertyName):
 				case nameof(ShadowEffect.OffsetYPropertyName):
+				case nameof(VisualElement.Width):
+				case nameof(VisualElement.Height):
 					View.Invalidate();
 					Update();
 					break;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.android.cs
@@ -40,11 +40,11 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 
 			switch (args.PropertyName)
 			{
-				case nameof(ShadowEffect.ColorPropertyName):
-				case nameof(ShadowEffect.OpacityPropertyName):
-				case nameof(ShadowEffect.RadiusPropertyName):
-				case nameof(ShadowEffect.OffsetXPropertyName):
-				case nameof(ShadowEffect.OffsetYPropertyName):
+				case ShadowEffect.ColorPropertyName:
+				case ShadowEffect.OpacityPropertyName:
+				case ShadowEffect.RadiusPropertyName:
+				case ShadowEffect.OffsetXPropertyName:
+				case ShadowEffect.OffsetYPropertyName:
 				case nameof(VisualElement.Width):
 				case nameof(VisualElement.Height):
 					View.Invalidate();

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.ios.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.ios.macos.cs
@@ -55,17 +55,17 @@ namespace Xamarin.CommunityToolkit.macOS.Effects
 
 			switch (args.PropertyName)
 			{
-				case nameof(ShadowEffect.ColorPropertyName):
+				case ShadowEffect.ColorPropertyName:
 					UpdateColor(View);
 					break;
-				case nameof(ShadowEffect.OpacityPropertyName):
+				case ShadowEffect.OpacityPropertyName:
 					UpdateOpacity(View);
 					break;
-				case nameof(ShadowEffect.RadiusPropertyName):
+				case ShadowEffect.RadiusPropertyName:
 					UpdateRadius(View);
 					break;
-				case nameof(ShadowEffect.OffsetXPropertyName):
-				case nameof(ShadowEffect.OffsetYPropertyName):
+				case ShadowEffect.OffsetXPropertyName:
+				case ShadowEffect.OffsetYPropertyName:
 					UpdateOffset(View);
 					break;
 				case nameof(VisualElement.Width):

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.ios.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.ios.macos.cs
@@ -35,10 +35,7 @@ namespace Xamarin.CommunityToolkit.macOS.Effects
 			if (View == null)
 				return;
 
-			UpdateColor(View);
-			UpdateOpacity(View);
-			UpdateRadius(View);
-			UpdateOffset(View);
+			Update(View);
 		}
 
 		protected override void OnDetached()
@@ -71,7 +68,19 @@ namespace Xamarin.CommunityToolkit.macOS.Effects
 				case nameof(ShadowEffect.OffsetYPropertyName):
 					UpdateOffset(View);
 					break;
+				case nameof(VisualElement.Width):
+				case nameof(VisualElement.Height):
+					Update(View);
+					break;
 			}
+		}
+
+		void Update(in NativeView view)
+		{
+			UpdateColor(view);
+			UpdateOpacity(view);
+			UpdateRadius(view);
+			UpdateOffset(view);
 		}
 
 		void UpdateColor(in NativeView view)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/RangeSlider/RangeSlider.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/RangeSlider/RangeSlider.shared.cs
@@ -321,7 +321,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			set => SetValue(TrackRadiusProperty, value);
 		}
 
-		static bool IsThumbShadowSupported => Device.RuntimePlatform == Device.iOS;
+		static bool IsThumbShadowSupported
+			=> Device.RuntimePlatform == Device.iOS
+			|| Device.RuntimePlatform == Device.macOS;
 
 		Frame Track { get; } = CreateFrameElement<Frame>();
 


### PR DESCRIPTION
### Description of Change ###
Update RangeSlider appearance (add shadow for iOS and macOS to be more natural look like)

Fixed shadow effect property changed bug

### API Changes ###
Changed default values of ThumbSize (30 -> 28) and TrackSize (3 -> 4).

### Behavioral Changes ###
Added shadow for thumbs on iOS and macOS

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
