### PR TITLE
#1059 a photoOutput != null check taken off. Rebased to develop

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
@@ -190,7 +190,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		public async Task TakePhoto()
 		{
-			if (isBusy || device == null || photoOutput != null)
+			if (isBusy || device == null)
 				return;
 
 			IsBusy = true;


### PR DESCRIPTION
### Description of Change ###

See #1060 for all details. I didn't have permission to push changes to that branch/pr and didn't want to burden the author so creating a new PR with his commit (credits are safe) to be able to move forward

### Bugs Fixed ###

- Fixes #1059
- Closes #1060
