### PR TITLE
Init previousState field with LayoutState.None

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/StateLayout/StateLayoutController.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/StateLayout/StateLayoutController.shared.cs
@@ -11,7 +11,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 	{
 		readonly WeakReference<Layout<View>> layoutWeakReference;
 		bool layoutIsGrid;
-		LayoutState? previousState = LayoutState.None;
+		LayoutState previousState = LayoutState.None;
 		IList<View> originalContent = Enumerable.Empty<View>().ToList();
 		CancellationTokenSource? animationTokenSource;
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/StateLayout/StateLayoutController.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/StateLayout/StateLayoutController.shared.cs
@@ -11,7 +11,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 	{
 		readonly WeakReference<Layout<View>> layoutWeakReference;
 		bool layoutIsGrid;
-		LayoutState? previousState;
+		LayoutState? previousState = LayoutState.None;
 		IList<View> originalContent = Enumerable.Empty<View>().ToList();
 		CancellationTokenSource? animationTokenSource;
 


### PR DESCRIPTION
### Description of Change ###
Initialize `previousState` field with value `LayoutState.None
`
### Bugs Fixed ###
 - Fixes #1112

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
