### PR TITLE
[AvatarView] Show initials if stream is empty

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/AvatarView/AvatarView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/AvatarView/AvatarView.shared.cs
@@ -360,7 +360,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 						var stream = await getStreamAsync(uriImageSource, imageLoadingTokenSource.Token);
 
-						source = stream != null
+						source = stream != null && stream != Stream.Null && stream.CanRead && stream.Length > 0
 							? ImageSource.FromStream(async (token) => stream?.CanRead ?? true ? stream : (stream = await getStreamAsync(uriImageSource, token)))
 							: null;
 


### PR DESCRIPTION
### Description of Change ###
Show initials label if images stream is empty

### Bugs Fixed ###
- Fixes #1120

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
