### PR TITLE
Fix Expander crash when Direction changed

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Expander/Expander.shared.cs
@@ -315,7 +315,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			InvokeAnimation(startSize, endSize, shouldIgnoreAnimation);
 		}
 
-		void SetHeader(View oldHeader)
+		void SetHeader(View? oldHeader)
 		{
 			if (oldHeader != null)
 			{
@@ -397,8 +397,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void SetDirection(ExpandDirection oldDirection)
 		{
-			_ = Header ?? throw new InvalidOperationException($"{nameof(Header)} not initialized");
-
 			if (oldDirection.IsVertical() == Direction.IsVertical())
 			{
 				SetHeader(Header);


### PR DESCRIPTION
### Description of Change ###
Since updating from XCT 1.0.3 to 1.1.0 the application throws an exception when displaying the main page that contains an Expander.
The crash happens when the property Direction is set to a value other than Down.

We shouldn't crash if Direction is updated before the header is set.

### Bugs Fixed ###
- Fixes #1144

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
