### PR TITLE
Fix animation behavior fires command twice

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Behaviors/AnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Behaviors/AnimationBehavior_Tests.cs
@@ -1,0 +1,34 @@
+﻿using Xamarin.CommunityToolkit.Behaviors;
+using Xamarin.CommunityToolkit.UnitTests.Mocks;
+using Xamarin.Forms;
+using NUnit.Framework;
+
+namespace Xamarin.CommunityToolkit.UnitTests.Behaviors
+{
+	public class AnimationBehavior_Tests
+	{
+		[SetUp]
+		public void SetUp() => Device.PlatformServices = new MockPlatformServices();
+
+		[Test]
+		public void CommandIsInvokedOnlyOneTimePerEvent()
+		{
+			var commandInvokeCount = 0;
+			var mockView = new MockEventView
+			{
+				Behaviors =
+				{
+					new AnimationBehavior
+					{
+						EventName = nameof(MockEventView.Event),
+						Command = new Command(() => ++commandInvokeCount)
+					}
+				}
+			};
+			mockView.Event += (s, e) => { };
+			mockView.InvokeEvent();
+
+			Assert.AreEqual(commandInvokeCount, 1);
+		}
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Mocks/MockEventView.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Mocks/MockEventView.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace Xamarin.CommunityToolkit.UnitTests.Mocks
+{
+	public class MockEventView : View
+	{
+		public event EventHandler? Event;
+
+		public void InvokeEvent() => Event?.Invoke(this, EventArgs.Empty);
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Animations/AnimationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Animations/AnimationBehavior.shared.cs
@@ -47,9 +47,6 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			if (AnimationType != null)
 				await AnimationType.Animate((View?)sender);
 
-			if (Command?.CanExecute(CommandParameter) ?? false)
-				Command.Execute(CommandParameter);
-
 			isAnimating = false;
 
 			base.OnTriggerHandled(sender, eventArgs);


### PR DESCRIPTION
### Description of Change ###
Removed command invocation from AnimationBehavior class because OnTriggerHandled method calls base implementation (base.OnTriggerHandled) that invokes command as well.

https://github.com/xamarin/XamarinCommunityToolkit/blob/main/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/EventToCommandBehavior.shared.cs#L126

### Bugs Fixed ###
- Fixes #1099

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [X] Has a linked Issue, and the Issue has been `approved`
- [X] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
