### PR TITLE
Fix MultiValidationBehavior overwrites external BindingContext bindings

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/BaseBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/BaseBehavior.shared.cs
@@ -21,21 +21,28 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 
 		protected TView? View { get; private set; }
 
-		internal void BindContextIfNeeded(Binding binding)
+		internal bool TrySetBindingContext(Binding binding)
 		{
 			if (!IsBound(BindingContextProperty))
 			{
 				SetBinding(BindingContextProperty, defaultBindingContextBinding = binding);
+				return true;
 			}
+
+			return false;
 		}
 
-		internal void ClearContextIfNeeded()
+		internal bool TryRemoveBindingContext()
 		{
 			if (defaultBindingContextBinding != null)
 			{
 				RemoveBinding(BindingContextProperty);
 				defaultBindingContextBinding = null;
+
+				return true;
 			}
+
+			return false;
 		}
 
 		protected virtual void OnViewPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -47,7 +54,7 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 			base.OnAttachedTo(bindable);
 			View = bindable;
 			bindable.PropertyChanged += OnViewPropertyChanged;
-			BindContextIfNeeded(new Binding
+			TrySetBindingContext(new Binding
 			{
 				Path = BindingContextProperty.PropertyName,
 				Source = bindable
@@ -57,7 +64,7 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 		protected override void OnDetachingFrom(TView bindable)
 		{
 			base.OnDetachingFrom(bindable);
-			ClearContextIfNeeded();
+			TryRemoveBindingContext();
 			bindable.PropertyChanged -= OnViewPropertyChanged;
 			View = null;
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/BaseBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/BaseBehavior.shared.cs
@@ -21,6 +21,23 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 
 		protected TView? View { get; private set; }
 
+		internal void BindContextIfNeeded(Binding binding)
+		{
+			if (!IsBound(BindingContextProperty))
+			{
+				SetBinding(BindingContextProperty, defaultBindingContextBinding = binding);
+			}
+		}
+
+		internal void ClearContextIfNeeded()
+		{
+			if (defaultBindingContextBinding != null)
+			{
+				RemoveBinding(BindingContextProperty);
+				defaultBindingContextBinding = null;
+			}
+		}
+
 		protected virtual void OnViewPropertyChanged(object? sender, PropertyChangedEventArgs e)
 		{
 		}
@@ -30,28 +47,17 @@ namespace Xamarin.CommunityToolkit.Behaviors.Internals
 			base.OnAttachedTo(bindable);
 			View = bindable;
 			bindable.PropertyChanged += OnViewPropertyChanged;
-
-			if (!IsBound(BindingContextProperty))
+			BindContextIfNeeded(new Binding
 			{
-				defaultBindingContextBinding = new Binding
-				{
-					Path = BindingContextProperty.PropertyName,
-					Source = bindable
-				};
-				SetBinding(BindingContextProperty, defaultBindingContextBinding);
-			}
+				Path = BindingContextProperty.PropertyName,
+				Source = bindable
+			});
 		}
 
 		protected override void OnDetachingFrom(TView bindable)
 		{
 			base.OnDetachingFrom(bindable);
-
-			if (defaultBindingContextBinding != null)
-			{
-				RemoveBinding(BindingContextProperty);
-				defaultBindingContextBinding = null;
-			}
-
+			ClearContextIfNeeded();
 			bindable.PropertyChanged -= OnViewPropertyChanged;
 			View = null;
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/MultiValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/MultiValidationBehavior.shared.cs
@@ -92,7 +92,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			{
 				foreach (var child in e.NewItems.OfType<ValidationBehavior>())
 				{
-					child.SetBinding(BindingContextProperty, new Binding
+					child.BindContextIfNeeded(new Binding
 					{
 						Path = BindingContextProperty.PropertyName,
 						Source = this
@@ -103,7 +103,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			if (e.OldItems != null)
 			{
 				foreach (var child in e.OldItems.OfType<ValidationBehavior>())
-					child.RemoveBinding(BindingContextProperty);
+					child.ClearContextIfNeeded();
 			}
 		}
 	}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/MultiValidationBehavior.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Behaviors/Validators/MultiValidationBehavior.shared.cs
@@ -92,7 +92,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			{
 				foreach (var child in e.NewItems.OfType<ValidationBehavior>())
 				{
-					child.BindContextIfNeeded(new Binding
+					child.TrySetBindingContext(new Binding
 					{
 						Path = BindingContextProperty.PropertyName,
 						Source = this
@@ -103,7 +103,7 @@ namespace Xamarin.CommunityToolkit.Behaviors
 			if (e.OldItems != null)
 			{
 				foreach (var child in e.OldItems.OfType<ValidationBehavior>())
-					child.ClearContextIfNeeded();
+					child.TryRemoveBindingContext();
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###
Don't override child's binding context binding in MultiValidationBehavior

### Bugs Fixed ###
- Fixes #1153

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [X] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
