### PR TITLE
Fix CI Build Errors on Build Windows Samples job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,6 @@ jobs:
         displayName: 'Clean Solution'
         inputs:
           solution: $(PathToSln)
-          configuration: Release
           msbuildArguments:  '/t:Clean'
       - task: CmdLine@2
         displayName: 'Clear Local NuGet Cache'
@@ -102,7 +101,6 @@ jobs:
         displayName: 'Clean Solution'
         inputs:
           solution: $(PathToSln)
-          configuration: Release
           msbuildArguments:  '/t:Clean'
       - task: CmdLine@2
         displayName: 'Clear Local NuGet Cache'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
       vmImage: windows-2019
     steps:
       - task: CmdLine@2
-        displayName: 'Clear Local NuGet Cache'
+        displayName: 'Clear Local NuGet Cache' #https://github.com/actions/virtual-environments/issues/1090#issuecomment-748452120
         inputs:
           script: 'nuget locals all -clear'
       - task: MSBuild@1
@@ -98,7 +98,7 @@ jobs:
           version: $(NETCORE_TEST_VERSION_2_1)
           includePreviewVersions: false
       - task: CmdLine@2
-        displayName: 'Clear Local NuGet Cache'
+        displayName: 'Clear Local NuGet Cache' #https://github.com/actions/virtual-environments/issues/1090#issuecomment-748452120
         inputs:
           script: 'nuget locals all -clear'
       - task: MSBuild@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,10 +61,16 @@ jobs:
     pool:
       vmImage: windows-2019
     steps:
-      - task: CmdLine@2
-        displayName: 'Clean, Clear, and Restore NuGets'
+      - task: MSBuild@1
+        displayName: 'Clean Solution'
         inputs:
-          script: 'dotnet clean $(PathToSln) -c Release && dotnet nuget locals all --clear'
+          solution: $(PathToSln)
+          configuration: Release
+          msbuildArguments:  '/t:Clean'
+      - task: CmdLine@2
+        displayName: 'Clear Local NuGet Cache'
+        inputs:
+          script: 'nuget locals all -clear'
       - task: MSBuild@1
         displayName: Build Solution
         inputs:
@@ -92,6 +98,16 @@ jobs:
         inputs:
           version: $(NETCORE_TEST_VERSION_2_1)
           includePreviewVersions: false
+      - task: MSBuild@1
+        displayName: 'Clean Solution'
+        inputs:
+          solution: $(PathToSln)
+          configuration: Release
+          msbuildArguments:  '/t:Clean'
+      - task: CmdLine@2
+        displayName: 'Clear Local NuGet Cache'
+        inputs:
+          script: 'nuget locals all -clear'
       # if this is a tagged build, then update the version number
       - powershell: |
           $buildSourceBranch = "$(Build.SourceBranch)"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,17 +61,12 @@ jobs:
     pool:
       vmImage: windows-2019
     steps:
-      - task: UseDotNet@2
-        displayName: 'Install .NET SDK'
-        inputs:
-          version: $(NETCORE_VERSION)
-          includePreviewVersions: false
       - task: MSBuild@1
         displayName: Build Solution
         inputs:
           solution: $(PathToSln)
           configuration: Release
-          msbuildArguments: '/restore /t:Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
+          msbuildArguments: '/restore /t:Clean,Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
       
   - job: build_windows
     displayName: Build Windows Library
@@ -107,7 +102,7 @@ jobs:
         inputs:
           solution: $(PathToCommunityToolkitCsproj)
           configuration: Release
-          msbuildArguments: '/restore /t:Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
+          msbuildArguments: '/restore /t:Clean,Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
       - task: CopyFiles@2
         inputs:
           Contents: 'SignList.xml'
@@ -123,7 +118,7 @@ jobs:
         inputs:
           solution: $(PathToMarkupCsproj)
           configuration: Release
-          msbuildArguments: '/restore /t:Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
+          msbuildArguments: '/restore /t:Clean,Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
       - task: MSBuild@1
         displayName: Pack Markup NuGet
         inputs:
@@ -205,11 +200,11 @@ jobs:
       - task: CmdLine@2
         displayName: 'Build Markup'
         inputs:
-          script: '$(PathToMsBuildOnMacOS) $(PathToMarkupCsproj) /p:Configuration=Release /restore /t:Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
+          script: '$(PathToMsBuildOnMacOS) $(PathToMarkupCsproj) /p:Configuration=Release /restore /t:Clean,Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
       - task: CmdLine@2
         displayName: 'Build Community Toolkit'
         inputs:
-          script: '$(PathToMsBuildOnMacOS) $(PathToCommunityToolkitCsproj) /p:Configuration=Release /restore /t:Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
+          script: '$(PathToMsBuildOnMacOS) $(PathToCommunityToolkitCsproj) /p:Configuration=Release /restore /t:Clean,Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
       - task: CmdLine@2
         displayName: 'Run Markup Unit Tests'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,12 +61,17 @@ jobs:
     pool:
       vmImage: windows-2019
     steps:
+      - task: UseDotNet@2
+        displayName: 'Install .NET SDK'
+        inputs:
+          version: $(NETCORE_VERSION)
+          includePreviewVersions: false
       - task: MSBuild@1
         displayName: Build Solution
         inputs:
           solution: $(PathToSln)
           configuration: Release
-          msbuildArguments: '/restore /t:Clean,Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
+          msbuildArguments: '/restore /t:Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
       
   - job: build_windows
     displayName: Build Windows Library
@@ -102,7 +107,7 @@ jobs:
         inputs:
           solution: $(PathToCommunityToolkitCsproj)
           configuration: Release
-          msbuildArguments: '/restore /t:Clean,Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
+          msbuildArguments: '/restore /t:Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
       - task: CopyFiles@2
         inputs:
           Contents: 'SignList.xml'
@@ -118,7 +123,7 @@ jobs:
         inputs:
           solution: $(PathToMarkupCsproj)
           configuration: Release
-          msbuildArguments: '/restore /t:Clean,Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
+          msbuildArguments: '/restore /t:Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
       - task: MSBuild@1
         displayName: Pack Markup NuGet
         inputs:
@@ -200,11 +205,11 @@ jobs:
       - task: CmdLine@2
         displayName: 'Build Markup'
         inputs:
-          script: '$(PathToMsBuildOnMacOS) $(PathToMarkupCsproj) /p:Configuration=Release /restore /t:Clean,Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
+          script: '$(PathToMsBuildOnMacOS) $(PathToMarkupCsproj) /p:Configuration=Release /restore /t:Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
       - task: CmdLine@2
         displayName: 'Build Community Toolkit'
         inputs:
-          script: '$(PathToMsBuildOnMacOS) $(PathToCommunityToolkitCsproj) /p:Configuration=Release /restore /t:Clean,Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
+          script: '$(PathToMsBuildOnMacOS) $(PathToCommunityToolkitCsproj) /p:Configuration=Release /restore /t:Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
       - task: CmdLine@2
         displayName: 'Run Markup Unit Tests'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,11 +61,10 @@ jobs:
     pool:
       vmImage: windows-2019
     steps:
-      - task: UseDotNet@2
-        displayName: 'Install .NET SDK'
+      - task: CmdLine@2
+        displayName: 'Clean, Clear, and Restore NuGets'
         inputs:
-          version: $(NETCORE_VERSION)
-          includePreviewVersions: false
+          script: 'dotnet clean $(PathToSln) -c Release && dotnet nuget locals all --clear'
       - task: MSBuild@1
         displayName: Build Solution
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,11 @@ jobs:
     pool:
       vmImage: windows-2019
     steps:
+      - task: UseDotNet@2
+        displayName: 'Install .NET SDK'
+        inputs:
+          version: $(NETCORE_VERSION)
+          includePreviewVersions: false
       - task: MSBuild@1
         displayName: Build Solution
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,15 +61,15 @@ jobs:
     pool:
       vmImage: windows-2019
     steps:
+      - task: CmdLine@2
+        displayName: 'Clear Local NuGet Cache'
+        inputs:
+          script: 'nuget locals all -clear'
       - task: MSBuild@1
         displayName: 'Clean Solution'
         inputs:
           solution: $(PathToSln)
           msbuildArguments:  '/t:Clean'
-      - task: CmdLine@2
-        displayName: 'Clear Local NuGet Cache'
-        inputs:
-          script: 'nuget locals all -clear'
       - task: MSBuild@1
         displayName: Build Solution
         inputs:
@@ -97,15 +97,15 @@ jobs:
         inputs:
           version: $(NETCORE_TEST_VERSION_2_1)
           includePreviewVersions: false
+      - task: CmdLine@2
+        displayName: 'Clear Local NuGet Cache'
+        inputs:
+          script: 'nuget locals all -clear'
       - task: MSBuild@1
         displayName: 'Clean Solution'
         inputs:
           solution: $(PathToSln)
           msbuildArguments:  '/t:Clean'
-      - task: CmdLine@2
-        displayName: 'Clear Local NuGet Cache'
-        inputs:
-          script: 'nuget locals all -clear'
       # if this is a tagged build, then update the version number
       - powershell: |
           $buildSourceBranch = "$(Build.SourceBranch)"


### PR DESCRIPTION
## The Problem

This Pull Requests Fixes the recurring error in the CI Build Pipeline

```bash
2021-04-05T22:06:43.9268201Z ##[error]src\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj(0,0): Error : Unable to find package MSBuild.Sdk.Extras. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages
2021-04-05T22:06:43.9281409Z D:\a\1\s\src\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj : error : Unable to find package MSBuild.Sdk.Extras. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages
2021-04-05T22:06:43.9285676Z ##[error]src\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj(0,0): Error : C:\Program Files\dotnet\sdk\5.0.201\Sdks\MSBuild.Sdk.Extras\Sdk not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.
2021-04-05T22:06:43.9288103Z D:\a\1\s\src\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj : error : C:\Program Files\dotnet\sdk\5.0.201\Sdks\MSBuild.Sdk.Extras\Sdk not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.
2021-04-05T22:06:46.6102237Z Restoring packages for C:\Users\VssAdministrator\AppData\Local\Temp\NuGetScratch\6575788914a24f2ea5ead6733dd4b016\9f07c4d7dfbc4d0cb1ae96fd47548e5d.proj...
2021-04-05T22:06:46.6133973Z ##[error]samples\XCT.Sample.Tizen\Xamarin.CommunityToolkit.Sample.Tizen.csproj(0,0): Error : Unable to find package Tizen.NET.Sdk. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages
2021-04-05T22:06:46.6136946Z D:\a\1\s\samples\XCT.Sample.Tizen\Xamarin.CommunityToolkit.Sample.Tizen.csproj : error : Unable to find package Tizen.NET.Sdk. No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages
2021-04-05T22:06:46.6156297Z ##[error]samples\XCT.Sample.Tizen\Xamarin.CommunityToolkit.Sample.Tizen.csproj(0,0): Error : C:\Program Files\dotnet\sdk\5.0.201\Sdks\Tizen.NET.Sdk\Sdk not found. Check that a recent enough .NET SDK is installed and/or increase the version specified in global.json.
```

## The Solution

This is a known-issue and the workaround for `No packages exist with this id in source(s): Microsoft Visual Studio Offline Packages` is  to clean the `sln` and clear the local NuGet Cache before building the `sln`: https://github.com/actions/virtual-environments/issues/1090#issuecomment-748452120

```bash
dotnet clean $(PathToSln) -c Release && dotnet nuget locals all --clear
```

To adapt this for `NuGet` and `MSBuild` (the `dotnet` CLI won't support Xamarin.iOS & Xamarin.Android until .NET 6) , we'll add the following steps to our Windows CI Pipelines:
```
- task: CmdLine@2
  displayName: 'Clear Local NuGet Cache'
  inputs:
    script: 'nuget locals all -clear'
- task: MSBuild@1
  displayName: 'Clean Solution'
  inputs:
    solution: $(PathToSln)
    msbuildArguments:  '/t:Clean'
```