### PR TITLE
Add F# Project

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
-
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Xamarin.CommunityToolkit.ruleset</CodeAnalysisRuleSet>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,6 @@ variables:
   PathToCommunityToolkitUnitTestCsproj: 'src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Xamarin.CommunityToolkit.UnitTests.csproj'
   PathToMarkupUnitTestCsproj: 'src/Markup/Xamarin.CommunityToolkit.Markup.UnitTests/Xamarin.CommunityToolkit.Markup.UnitTests.csproj'
   PathToMsBuildOnMacOS: 'mono /Applications/Visual\ studio.app/Contents/Resources/lib/monodevelop/bin/MSBuild/Current/bin/MSBuild.dll'
-  PathToSln: 'samples/XCT.Sample.sln'
 
 resources:
   repositories:
@@ -68,12 +67,12 @@ jobs:
       - task: MSBuild@1
         displayName: 'Clean Solution'
         inputs:
-          solution: $(PathToSln)
+          solution: $(PathToSamplesSln)
           msbuildArguments:  '/t:Clean'
       - task: MSBuild@1
         displayName: Build Solution
         inputs:
-          solution: $(PathToSln)
+          solution: $(PathToSamplesSln)
           configuration: Release
           msbuildArguments: '/restore /t:Build /p:ContinuousIntegrationBuild=true /p:Deterministic=false'
       
@@ -104,7 +103,7 @@ jobs:
       - task: MSBuild@1
         displayName: 'Clean Solution'
         inputs:
-          solution: $(PathToSln)
+          solution: $(PathToSamplesSln)
           msbuildArguments:  '/t:Clean'
       # if this is a tagged build, then update the version number
       - powershell: |

--- a/samples/XCT.Sample.Android/Properties/AndroidManifest.xml
+++ b/samples/XCT.Sample.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.xamarincommunitytoolkitsample" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
 	<application android:label="XamarinCommunityToolkitSample.Android"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />

--- a/samples/XCT.Sample.Android/Xamarin.CommunityToolkit.Sample.Android.csproj
+++ b/samples/XCT.Sample.Android/Xamarin.CommunityToolkit.Sample.Android.csproj
@@ -16,7 +16,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>

--- a/samples/XCT.Sample.FSharp/About.txt
+++ b/samples/XCT.Sample.FSharp/About.txt
@@ -1,0 +1,5 @@
+﻿This project was added to ensure Xamarin.CommunityToolkit support for F#
+
+Specifically, in an earilier version of Xamarin.CommunityToolkit, it was reported that F# projects couldn't use the Xamarin.CommunityToolkit NuGet package: https://github.com/xamarin/XamarinCommunityToolkit/commit/e569ee3a2f4cabaffdcfad11edbc2ef495cbe51b
+
+This project ensures that all future releases of Xamarin.CommunityToolkit will continue to be compatible with F#.

--- a/samples/XCT.Sample.FSharp/App.fs
+++ b/samples/XCT.Sample.FSharp/App.fs
@@ -1,0 +1,12 @@
+﻿namespace Temp
+
+open Xamarin.Forms
+
+type App() =
+    inherit Application()
+
+    let stack = StackLayout(VerticalOptions = LayoutOptions.Center)
+    let label = Label(XAlign = TextAlignment.Center, Text = "Welcome to F# Xamarin.Forms!")
+    do
+        stack.Children.Add(label)
+        base.MainPage <- ContentPage(Content = stack)

--- a/samples/XCT.Sample.FSharp/App.xaml
+++ b/samples/XCT.Sample.FSharp/App.xaml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Application xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Temp.App">
+	<Application.Resources>
+		<!-- Application resource dictionary -->
+	</Application.Resources>
+</Application>

--- a/samples/XCT.Sample.FSharp/App.xaml.fs
+++ b/samples/XCT.Sample.FSharp/App.xaml.fs
@@ -1,0 +1,6 @@
+﻿namespace Temp
+
+open Xamarin.Forms
+
+type App() =
+    inherit Application(MainPage = MainPage())

--- a/samples/XCT.Sample.FSharp/AssemblyInfo.fs
+++ b/samples/XCT.Sample.FSharp/AssemblyInfo.fs
@@ -1,0 +1,20 @@
+﻿namespace Temp
+open System.Reflection
+open System.Runtime.CompilerServices
+
+[<assembly: AssemblyTitle("Temp")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("")>]
+[<assembly: AssemblyCopyright("${AuthorCopyright}")>]
+[<assembly: AssemblyTrademark("")>]
+
+// The assembly version has the format {Major}.{Minor}.{Build}.{Revision}
+
+[<assembly: AssemblyVersion("1.0.0.0")>]
+
+//[<assembly: AssemblyDelaySign(false)>]
+//[<assembly: AssemblyKeyFile("")>]
+
+()

--- a/samples/XCT.Sample.FSharp/MainPage.xaml
+++ b/samples/XCT.Sample.FSharp/MainPage.xaml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:local="clr-namespace:Temp" x:Class="Temp.MainPage">
+	<Label Text="Welcome to Xamarin Forms!" VerticalOptions="Center" HorizontalOptions="Center" />
+</ContentPage>

--- a/samples/XCT.Sample.FSharp/MainPage.xaml.fs
+++ b/samples/XCT.Sample.FSharp/MainPage.xaml.fs
@@ -1,0 +1,8 @@
+﻿namespace Temp
+
+open Xamarin.Forms
+open Xamarin.Forms.Xaml
+
+type MainPage() =
+    inherit ContentPage()
+    let _ = base.LoadFromXaml(typeof<MainPage>)

--- a/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
+++ b/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
+++ b/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
+++ b/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
+++ b/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
@@ -1,13 +1,26 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="About.txt" />
-  </ItemGroup>
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+	</PropertyGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="MainPage.xaml">
+			<Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+		</EmbeddedResource>
+		<Compile Include="MainPage.xaml.fs">
+			<DependentUpon>MainPage.xaml</DependentUpon>
+		</Compile>
+		<EmbeddedResource Include="App.xaml" />
+		<Compile Include="App.xaml.fs">
+			<DependentUpon>App.xaml</DependentUpon>
+		</Compile>
+		<Compile Include="AssemblyInfo.fs" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FSharp.Core" Version="5.0.1" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj" />
+	</ItemGroup>
 </Project>

--- a/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
+++ b/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="About.txt" />
+  </ItemGroup>
+</Project>

--- a/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
+++ b/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
+++ b/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
@@ -1,26 +1,30 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 	</PropertyGroup>
+
 	<ItemGroup>
 		<EmbeddedResource Include="MainPage.xaml">
 			<Generator>MSBuild:UpdateDesignTimeXaml</Generator>
 		</EmbeddedResource>
 		<Compile Include="MainPage.xaml.fs">
 			<DependentUpon>MainPage.xaml</DependentUpon>
+			<SubType>Code</SubType>
 		</Compile>
 		<EmbeddedResource Include="App.xaml" />
 		<Compile Include="App.xaml.fs">
 			<DependentUpon>App.xaml</DependentUpon>
+			<SubType>Code</SubType>
 		</Compile>
 		<Compile Include="AssemblyInfo.fs" />
+		<None Include="About.txt" />
 	</ItemGroup>
+
 	<ItemGroup>
 		<PackageReference Include="FSharp.Core" Version="5.0.1" />
-	</ItemGroup>
-	<ItemGroup>
 		<ProjectReference Include="..\..\src\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj" />
 	</ItemGroup>
+
 </Project>

--- a/samples/XCT.Sample.sln
+++ b/samples/XCT.Sample.sln
@@ -33,6 +33,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.CommunityToolkit.Ma
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.CommunityToolkit.Markup.UnitTests", "..\src\Markup\Xamarin.CommunityToolkit.Markup.UnitTests\Xamarin.CommunityToolkit.Markup.UnitTests.csproj", "{AAE423C4-E9B4-434E-885C-2164C12BF79C}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Xamarin.CommunityToolkit.Sample.FSharp", "XCT.Sample.FSharp\Xamarin.CommunityToolkit.Sample.FSharp.fsproj", "{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -327,6 +329,30 @@ Global
 		{AAE423C4-E9B4-434E-885C-2164C12BF79C}.Release|x64.Build.0 = Release|Any CPU
 		{AAE423C4-E9B4-434E-885C-2164C12BF79C}.Release|x86.ActiveCfg = Release|Any CPU
 		{AAE423C4-E9B4-434E-885C-2164C12BF79C}.Release|x86.Build.0 = Release|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Debug|ARM.Build.0 = Debug|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Debug|x64.Build.0 = Debug|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Debug|x86.Build.0 = Debug|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Release|ARM.ActiveCfg = Release|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Release|ARM.Build.0 = Release|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Release|iPhone.Build.0 = Release|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Release|x64.ActiveCfg = Release|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Release|x64.Build.0 = Release|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Release|x86.ActiveCfg = Release|Any CPU
+		{D5C2D19A-E929-4587-A9DE-FA50E46AAB59}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds `Xamarin.CommunityToolkit.Sample.FSharp.fsproj`.

In an earilier version of Xamarin.CommunityToolkit, it was reported that F# projects couldn't use the Xamarin.CommunityToolkit NuGet package: https://github.com/xamarin/XamarinCommunityToolkit/commit/e569ee3a2f4cabaffdcfad11edbc2ef495cbe51b

This project ensures that all future releases of Xamarin.CommunityToolkit will continue to be compatible with F#.