### PR TITLE
SideMenuView: New types of appearance | Parallax effect | Scale factor

### DIFF
--- a/samples/XCT.Sample/Pages/Views/SideMenuViewPage.xaml
+++ b/samples/XCT.Sample/Pages/Views/SideMenuViewPage.xaml
@@ -33,19 +33,25 @@
         </StackLayout>
 
         <!-- LeftMenu -->
-        <BoxView
+        <StackLayout
+            xct:SideMenuView.ParallaxValue="50"
             xct:SideMenuView.MenuAppearanceType="SlideIn"
             xct:SideMenuView.Position="LeftMenu"
             xct:SideMenuView.MenuWidthPercentage=".5"
             xct:SideMenuView.MainViewScaleFactor=".95"
             xct:ShadowEffect.Color="Black"
-            BackgroundColor="Orange"/>
+            BackgroundColor="Orange">
+            <Label Text="LEFT MENU" />
+        </StackLayout>
 
         <!-- RightMenu -->
-        <BoxView
+        <StackLayout
+            xct:SideMenuView.ParallaxValue="75"
             xct:SideMenuView.Position="RightMenu"
-            xct:SideMenuView.MenuWidthPercentage=".3"
-            BackgroundColor="LightGreen" />
+            xct:SideMenuView.MenuWidthPercentage=".4"
+            BackgroundColor="LightGreen">
+            <Label Text="RIGHT MENU" />
+        </StackLayout>
 
     </xct:SideMenuView>
 

--- a/samples/XCT.Sample/Pages/Views/SideMenuViewPage.xaml
+++ b/samples/XCT.Sample/Pages/Views/SideMenuViewPage.xaml
@@ -16,7 +16,8 @@
 
     <xct:SideMenuView x:Name="SideMenuView">
         <!-- MainView -->
-        <StackLayout BackgroundColor="Gold">
+        <StackLayout BackgroundColor="Gold"
+                     xct:ShadowEffect.Color="Black">
             <StackLayout
                 Orientation="Horizontal">
 
@@ -33,9 +34,11 @@
 
         <!-- LeftMenu -->
         <BoxView
+            xct:SideMenuView.MenuAppearanceType="SlideIn"
             xct:SideMenuView.Position="LeftMenu"
             xct:SideMenuView.MenuWidthPercentage=".5"
             xct:SideMenuView.MainViewScaleFactor=".95"
+            xct:ShadowEffect.Color="Black"
             BackgroundColor="Orange"/>
 
         <!-- RightMenu -->

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuAppearanceType.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuAppearanceType.shared.cs
@@ -1,0 +1,9 @@
+﻿namespace Xamarin.CommunityToolkit.UI.Views
+{
+	public enum SideMenuAppearanceType
+	{
+		SlideOut,
+		SlideIn,
+		SlideInOut
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
@@ -80,8 +80,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		public static readonly BindableProperty MainViewScaleFactorProperty
 			= BindableProperty.CreateAttached(nameof(GetMainViewScaleFactor), typeof(double), typeof(SideMenuView), 1.0);
 
+		public static readonly BindableProperty MainViewOpacityFactorProperty
+			= BindableProperty.CreateAttached(nameof(GetMainViewOpacityFactor), typeof(double), typeof(SideMenuView), 1.0);
+
 		public static readonly BindableProperty MenuAppearanceTypeProperty
 			= BindableProperty.CreateAttached(nameof(GetMenuAppearanceType), typeof(SideMenuAppearanceType), typeof(SideMenuView), SideMenuAppearanceType.SlideOut);
+
 
 		public SideMenuView()
 		{
@@ -158,6 +162,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		public static void SetMainViewScaleFactor(BindableObject bindable, double value)
 			=> bindable.SetValue(MainViewScaleFactorProperty, value);
+
+		public static double GetMainViewOpacityFactor(BindableObject bindable)
+			=> (double)bindable.GetValue(MainViewOpacityFactorProperty);
+
+		public static void SetMainViewOpacityFactor(BindableObject bindable, double value)
+			=> bindable.SetValue(MainViewOpacityFactorProperty, value);
 
 		public static SideMenuAppearanceType GetMenuAppearanceType(BindableObject bindable)
 			=> (SideMenuAppearanceType)bindable.GetValue(MenuAppearanceTypeProperty);
@@ -412,8 +422,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				if (inactiveMenu != null)
 					inactiveMenu.TranslationX = -inactiveMenu.Width * nonZeroSign;
 
-				var scale = 1 - ((1 - GetMainViewScaleFactor(activeMenu)) * animationEasing.Ease(shift / activeMenuWidth));
+				var progress = animationEasing.Ease(shift / activeMenuWidth);
+				var scale = 1 - ((1 - GetMainViewScaleFactor(activeMenu)) * progress);
+				var opacity = 1 - ((1 - GetMainViewOpacityFactor(activeMenu)) * progress);
+
 				mainView.Scale = scale;
+				mainView.Opacity = opacity;
 
 				switch (GetMenuAppearanceType(activeMenu))
 				{


### PR DESCRIPTION
### Description of Change ###
Enhanced SideMenuView. Allow choosing the desired type of menu appearance. Also, now it's possible to add a "parallax" effect and manage the main view opacity during interaction with menus.

### Bugs Fixed ###
- Fixes #1191

### API Changes ###
Added: 

- Enum SideMenuAppearanceType (SlideOut, SlideIn, SlideInOut);
- Attached property MainViewOpacityFactorProperty (double, default 1.0);
- Attached property MenuAppearanceTypeProperty (SideMenuAppearanceType, default SideMenuAppearanceType.SlideOut);
- Attached property ParallaxValueProperty (double, default 0.0).


### Behavioral Changes ###
None

### PR Checklist ###
- [X] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of develop at time of PR
- [X] Changes adhere to coding standard

Documentation doesn't exist for this view now.
