### PR TITLE
Fix nullable regression RangeSlider crash

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BaseTemplatedView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BaseTemplatedView.shared.cs
@@ -9,9 +9,7 @@ namespace Xamarin.CommunityToolkit.UI.Views.Internals
 	/// <typeparam name="TControl">The type of the control that this template will be used for</typeparam>
 	public abstract class BaseTemplatedView<TControl> : TemplatedView where TControl : View, new()
 	{
-		TControl? control;
-
-		protected TControl Control => control ?? throw new NullReferenceException();
+		protected TControl? Control { get; private set; }
 
 		/// <summary>
 		/// Constructor of <see cref="BaseTemplatedView{TControl}" />
@@ -23,15 +21,15 @@ namespace Xamarin.CommunityToolkit.UI.Views.Internals
 		{
 			base.OnBindingContextChanged();
 
-			if (control != null)
+			if (Control != null)
 				Control.BindingContext = BindingContext;
 		}
 
 		protected override void OnChildAdded(Element child)
 		{
-			if (control == null && child is TControl content)
+			if (Control == null && child is TControl content)
 			{
-				control = content;
+				Control = content;
 				OnControlInitialized(Control);
 			}
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Expander/Expander.shared.cs
@@ -320,15 +320,15 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			if (oldHeader != null)
 			{
 				oldHeader.GestureRecognizers.Remove(headerTapGestureRecognizer);
-				Control.Children.Remove(oldHeader);
+				Control?.Children.Remove(oldHeader);
 			}
 
 			if (Header != null)
 			{
 				if (Direction.IsRegularOrder())
-					Control.Children.Insert(0, Header);
+					Control?.Children.Insert(0, Header);
 				else
-					Control.Children.Add(Header);
+					Control?.Children.Add(Header);
 
 				Header.GestureRecognizers.Add(headerTapGestureRecognizer);
 			}
@@ -359,7 +359,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			if (contentHolder != null)
 			{
 				contentHolder.AbortAnimation(expandAnimationName);
-				Control.Children.Remove(contentHolder);
+				Control?.Children.Remove(contentHolder);
 				contentHolder = null;
 			}
 			if (Content != null)
@@ -373,9 +373,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				ContentSizeRequest = 0;
 
 				if (Direction.IsRegularOrder())
-					Control.Children.Add(contentHolder);
+					Control?.Children.Add(contentHolder);
 				else
-					Control.Children.Insert(0, contentHolder);
+					Control?.Children.Insert(0, contentHolder);
 			}
 
 			if (!shouldIgnoreContentSetting)
@@ -403,9 +403,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				return;
 			}
 
-			Control.Orientation = Direction.IsVertical()
-				? StackOrientation.Vertical
-				: StackOrientation.Horizontal;
+			if (Control != null)
+			{
+				Control.Orientation = Direction.IsVertical()
+					? StackOrientation.Vertical
+					: StackOrientation.Horizontal;
+			}
 
 			lastVisibleSize = -1;
 			SetHeader(Header);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
@@ -451,6 +451,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				inactiveMenu = leftMenu;
 			}
 
+			if (Control == null)
+				return;
+
 			if (inactiveMenu == null ||
 				activeMenu == null ||
 				leftMenu?.X + leftMenu?.Width <= rightMenu?.X ||
@@ -545,7 +548,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void AddChild(View view)
 		{
-			Control.Children.Add(view);
+			Control?.Children.Add(view);
 			switch (GetPosition(view))
 			{
 				case SideMenuPosition.MainView:
@@ -562,7 +565,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void RemoveChild(View view)
 		{
-			Control.Children.Remove(view);
+			Control?.Children.Remove(view);
 			switch (GetPosition(view))
 			{
 				case SideMenuPosition.MainView:
@@ -587,8 +590,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			if (mainView == null)
 				return;
 
-			Control.RaiseChild(mainView);
-			Control.RaiseChild(overlayView);
+			Control?.RaiseChild(mainView);
+			Control?.RaiseChild(overlayView);
 		}
 
 		bool CheckMenuGestureEnabled(View? menuView)


### PR DESCRIPTION
### Description of Change ###
Do not throw an exception if the "Control" property is accessed (It can be null while control is initializing with updated bindable properties).

Also, I marked cleaned project a little (Get rid of some warnings by avoiding using obsolete API)

### Bugs Fixed ###
- Fixes #1209

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [X] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
