### PR TITLE
[SideMenuView] Fix Right Menu scale factor

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/SideMenuView/SideMenuView.shared.cs
@@ -393,7 +393,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			using (mainView.Batch())
 			{
-				var scale = 1 - ((1 - GetMainViewScaleFactor(activeMenu)) * animationEasing.Ease(shift / activeMenuWidth));
+				var scale = 1 - ((1 - GetMainViewScaleFactor(activeMenu)) * animationEasing.Ease(Abs(shift) / activeMenuWidth));
 				mainView.Scale = scale;
 				mainView.TranslationX = shift - (Sign(shift) * mainViewWidth * 0.5 * (1 - scale));
 			}


### PR DESCRIPTION
### Description of Change ###
MainViewScaleFactor should work in the same way for both Left & Right menus (if menu opened then main view's Scale should be equal scale factor value). Currently, it is wrong for the right menu.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #1249 

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [X] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
