### PR TITLE
[Regression] Update shadow layer on property change 

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.ios.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.ios.macos.cs
@@ -23,85 +23,94 @@ namespace Xamarin.CommunityToolkit.macOS.Effects
 #endif
 {
 	public class PlatformShadowEffect : PlatformEffect
-{
-	const float defaultRadius = 10f;
-
-	const float defaultOpacity = .5f;
-
-	NativeView? View => Control ?? Container;
-
-	protected override void OnAttached()
 	{
-		if (View == null)
-			return;
+		const float defaultRadius = 10f;
 
-		UpdateColor(View);
-		UpdateOpacity(View);
-		UpdateRadius(View);
-		UpdateOffset(View);
-	}
+		const float defaultOpacity = .5f;
 
-	protected override void OnDetached()
-	{
-		if (View?.Layer == null)
-			return;
+		NativeView? View => Control ?? Container;
 
-		View.Layer.ShadowOpacity = 0;
-	}
-
-	protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)
-	{
-		base.OnElementPropertyChanged(args);
-
-		if (View == null)
-			return;
-
-		switch (args.PropertyName)
+		protected override void OnAttached()
 		{
-			case nameof(ShadowEffect.ColorPropertyName):
-				UpdateColor(View);
-				break;
-			case nameof(ShadowEffect.OpacityPropertyName):
-				UpdateOpacity(View);
-				break;
-			case nameof(ShadowEffect.RadiusPropertyName):
-				UpdateRadius(View);
-				break;
-			case nameof(ShadowEffect.OffsetXPropertyName):
-			case nameof(ShadowEffect.OffsetYPropertyName):
-				UpdateOffset(View);
-				break;
+			if (View == null)
+				return;
+
+			Update(View);
+		}
+
+		protected override void OnDetached()
+		{
+			if (View?.Layer == null)
+				return;
+
+			View.Layer.ShadowOpacity = 0;
+		}
+
+		protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)
+		{
+			base.OnElementPropertyChanged(args);
+
+			if (View == null)
+				return;
+
+			switch (args.PropertyName)
+			{
+				case ShadowEffect.ColorPropertyName:
+					UpdateColor(View);
+					break;
+				case ShadowEffect.OpacityPropertyName:
+					UpdateOpacity(View);
+					break;
+				case ShadowEffect.RadiusPropertyName:
+					UpdateRadius(View);
+					break;
+				case ShadowEffect.OffsetXPropertyName:
+				case ShadowEffect.OffsetYPropertyName:
+					UpdateOffset(View);
+					break;
+				case nameof(VisualElement.Width):
+				case nameof(VisualElement.Height):
+					Update(View);
+					break;
+			}
+		}
+
+		void UpdateColor(in NativeView view)
+		{
+			if (view.Layer != null)
+				view.Layer.ShadowColor = ShadowEffect.GetColor(Element).ToCGColor();
+		}
+
+		void UpdateOpacity(in NativeView view)
+		{
+			if (view.Layer != null)
+			{
+				var opacity = (float)ShadowEffect.GetOpacity(Element);
+				view.Layer.ShadowOpacity = opacity < 0 ? defaultOpacity : opacity;
+			}
+		}
+
+		void UpdateRadius(in NativeView view)
+		{
+			if (view.Layer != null)
+			{
+				var radius = (nfloat)ShadowEffect.GetRadius(Element);
+				view.Layer.ShadowRadius = radius < 0 ? defaultRadius : radius;
+			}
+		}
+
+		void UpdateOffset(in NativeView view)
+		{
+			if (view.Layer != null)
+				view.Layer.ShadowOffset = new CGSize((double)ShadowEffect.GetOffsetX(Element), (double)ShadowEffect.GetOffsetY(Element));
+		}
+
+		void Update(in NativeView view)
+		{
+			UpdateColor(view);
+			UpdateOpacity(view);
+			UpdateRadius(view);
+			UpdateOffset(view);
 		}
 	}
-
-	void UpdateColor(in NativeView view)
-	{
-		if (view.Layer != null)
-			view.Layer.ShadowColor = ShadowEffect.GetColor(Element).ToCGColor();
-	}
-
-	void UpdateOpacity(in NativeView view)
-	{
-		if (view.Layer != null)
-		{
-			var opacity = (float)ShadowEffect.GetOpacity(Element);
-			view.Layer.ShadowOpacity = opacity < 0 ? defaultOpacity : opacity;
-		}
-	}
-
-	void UpdateRadius(in NativeView view)
-	{
-		if (view.Layer != null)
-		{
-			var radius = (nfloat)ShadowEffect.GetRadius(Element);
-			view.Layer.ShadowRadius = radius < 0 ? defaultRadius : radius;
-		}
-	}
-
-	void UpdateOffset(in NativeView view)
-	{
-		if (view.Layer != null)
-			view.Layer.ShadowOffset = new CGSize((double)ShadowEffect.GetOffsetX(Element), (double)ShadowEffect.GetOffsetY(Element));
-	}
-}
 }


### PR DESCRIPTION
### Description of Change ###
Fixes regression bug introduced after failed merge.
Initially, the fix was added in https://github.com/xamarin/XamarinCommunityToolkit/pull/1109/
but then was lost after an unsuccessful merge.

When shadow effect property changes or when element size changes, we should update the shadow layer. Otherwise, it will be lost.