### PR TITLE
Fix Snackbar/Toast crashes on iOS 12.5.2

### DIFF
--- a/samples/XCT.Sample.iOS/Info.plist
+++ b/samples/XCT.Sample.iOS/Info.plist
@@ -21,7 +21,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>MinimumOSVersion</key>
-	<string>13.6</string>
+	<string>12.3</string>
 	<key>CFBundleDisplayName</key>
 	<string>XamarinCommunityToolkitSample</string>
 	<key>CFBundleIdentifier</key>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackBarAppearance.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackBarAppearance.ios.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using UIKit;
+using Xamarin.CommunityToolkit.Helpers;
 using Xamarin.Forms.Platform.iOS;
 
 namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS
 {
 	class NativeSnackBarAppearance
 	{
-		public UIColor Background { get; set; } = UIDevice.CurrentDevice.CheckSystemVersion(13, 0) ? UIColor.SystemBackgroundColor : UIColor.Gray;
+		public UIColor Background { get; set; } = XCT.IsiOS13OrNewer ? UIColor.SystemBackgroundColor : UIColor.Gray;
 
 		public UIColor Foreground { get; set; } = DefaultColor;
 
@@ -14,7 +15,7 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS
 
 		public UITextAlignment TextAlignment { get; set; } = UITextAlignment.Left;
 
-		public static UIColor DefaultColor { get; } = UIDevice.CurrentDevice.CheckSystemVersion(13, 0) ? Forms.Color.Default.ToUIColor() : UIColor.White;
+		public static UIColor DefaultColor { get; } = XCT.IsiOS13OrNewer ? Forms.Color.Default.ToUIColor() : UIColor.White;
 
 		public static UIFont DefaultFont { get; } = Forms.Font.Default.ToUIFont();
 	}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackBarAppearance.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackBarAppearance.ios.cs
@@ -6,7 +6,7 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS
 {
 	class NativeSnackBarAppearance
 	{
-		public UIColor Background { get; set; } = UIColor.SystemBackgroundColor;
+		public UIColor Background { get; set; } = UIDevice.CurrentDevice.CheckSystemVersion(13, 0) ? UIColor.SystemBackgroundColor : UIColor.Gray;
 
 		public UIColor Foreground { get; set; } = DefaultColor;
 
@@ -14,7 +14,7 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS
 
 		public UITextAlignment TextAlignment { get; set; } = UITextAlignment.Left;
 
-		public static UIColor DefaultColor { get; } = Forms.Color.Default.ToUIColor();
+		public static UIColor DefaultColor { get; } = UIDevice.CurrentDevice.CheckSystemVersion(13, 0) ? Forms.Color.Default.ToUIColor() : UIColor.White;
 
 		public static UIFont DefaultFont { get; } = Forms.Font.Default.ToUIFont();
 	}


### PR DESCRIPTION
### Description of Change ###

Fix crash on devices with version lower then ios 13

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #1252 

### API Changes ###

The default foreground is white for ios 13 and lower
The default background is gray for ios 13 and lower

### Images ###

Advanced Snackbar

![image](https://user-images.githubusercontent.com/33021114/117999189-44058c00-b34d-11eb-91c7-bb3bee0f94c6.png)

Toast
![image](https://user-images.githubusercontent.com/33021114/117999272-57b0f280-b34d-11eb-98e3-35518848df03.png)

Anchor Toast
![image](https://user-images.githubusercontent.com/33021114/118000152-3a305880-b34e-11eb-8e08-98bf2dfab9e0.png)

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [x] Has a linked Issue, and the Issue has been `approved`
- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [x] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
