### PR TITLE
throw meaningful error on invalid cast

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/StateLayout/StateLayout.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/StateLayout/StateLayout.shared.cs
@@ -19,7 +19,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		internal static readonly BindableProperty LayoutControllerProperty
 			= BindableProperty.CreateAttached("LayoutController", typeof(StateLayoutController), typeof(Layout<View>), default(StateLayoutController),
-				defaultValueCreator: (b) => new StateLayoutController((Layout<View>)b) { StateViews = GetStateViews(b) ?? new List<StateView>() });
+				defaultValueCreator: LayoutControllerCreator);
 
 		internal static StateLayoutController? GetLayoutController(BindableObject b)
 			=> (StateLayoutController?)b.GetValue(LayoutControllerProperty);
@@ -95,6 +95,19 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				default:
 					break;
 			}
+		}
+
+		static object LayoutControllerCreator(BindableObject bindable)
+		{
+			if (bindable is Layout<View> layoutView)
+			{
+				return new StateLayoutController(layoutView)
+				{
+					StateViews = GetStateViews(layoutView) ?? new List<StateView>()
+				};
+			}
+
+			throw new InvalidOperationException($"Cannot create the StateLayoutController. The specified view '{bindable.GetType().FullName}' does not inherit Layout<View>.");
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Updates the BindableProperty for the LayoutController. The DefaultValueCreator will now use pattern matching to validate the bindable object is a Layout<View> if it is not it will throw an InvalidOperationException with a messaging indicating that the given type was not a Layout<View> to make it a bit more clear why things are failing.

### Bugs Fixed ###

- Fixes #1239 

### API Changes ###

none

### Behavioral Changes ###

Throws more useful error

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [x] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
