### PR TITLE
[ShadowEffect] Fix shadow appearance on Android button

### DIFF
--- a/samples/XCT.Sample/Pages/Effects/ShadowEffectPage.xaml
+++ b/samples/XCT.Sample/Pages/Effects/ShadowEffectPage.xaml
@@ -72,6 +72,14 @@
                 </Grid>
             </StackLayout>
 
+            <StackLayout>
+                <Label Text="Button with Shadow" />
+                <Button Text="Click me"
+                        Margin="0"
+                        xct:ShadowEffect.Radius="10"
+                        xct:ShadowEffect.Color="Red" />
+            </StackLayout>
+
     </StackLayout>
     </ScrollView>
 </pages:BasePage>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.android.cs
@@ -7,6 +7,7 @@ using Xamarin.CommunityToolkit.Effects;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 using AView = Android.Views.View;
+using AButton = Android.Widget.Button;
 
 [assembly: ExportEffect(typeof(PlatformShadowEffect), nameof(ShadowEffect))]
 
@@ -47,6 +48,7 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 				case ShadowEffect.OffsetYPropertyName:
 				case nameof(VisualElement.Width):
 				case nameof(VisualElement.Height):
+				case nameof(VisualElement.BackgroundColor):
 					View.Invalidate();
 					Update();
 					break;
@@ -67,20 +69,28 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 				opacity = defaultOpacity;
 
 			var androidColor = ShadowEffect.GetColor(Element).MultiplyAlpha(opacity).ToAndroid();
-
-			if (View is TextView textView)
+			if (View is AButton button)
+			{
+				button.StateListAnimator = null;
+				button.OutlineProvider = ViewOutlineProvider.Bounds;
+			}
+			else if (View is not AButton && View is TextView textView)
 			{
 				var offsetX = (float)ShadowEffect.GetOffsetX(Element);
 				var offsetY = (float)ShadowEffect.GetOffsetY(Element);
 				textView.SetShadowLayer(radius, offsetX, offsetY, androidColor);
 				return;
 			}
-
-			View.OutlineProvider = (Element as VisualElement)?.BackgroundColor.A > 0
-				? ViewOutlineProvider.PaddedBounds
-				: ViewOutlineProvider.Bounds;
+			else
+			{
+				View.OutlineProvider = (Element as VisualElement)?.BackgroundColor.A > 0
+					? ViewOutlineProvider.PaddedBounds
+					: ViewOutlineProvider.Bounds;
+			}
 
 			View.Elevation = View.Context.ToPixels(radius);
+			if (View.Parent is ViewGroup group)
+				group.SetClipToPadding(false);
 
 			if (Build.VERSION.SdkInt < BuildVersionCodes.P)
 				return;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.ios.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.ios.macos.cs
@@ -70,6 +70,7 @@ public class PlatformShadowEffect : PlatformEffect
 				break;
 			case nameof(VisualElement.Width):
 			case nameof(VisualElement.Height):
+			case nameof(VisualElement.BackgroundColor):
 				Update(View);
 				break;
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.uwp.cs
@@ -54,6 +54,7 @@ namespace Xamarin.CommunityToolkit.UWP.Effects
 				case ShadowEffect.OffsetYPropertyName:
 				case nameof(VisualElement.Width):
 				case nameof(VisualElement.Height):
+				case nameof(VisualElement.BackgroundColor):
 					UpdateShadow();
 					break;
 			}


### PR DESCRIPTION
### Description of Change ###
Since Android Button is a subclass of Android TextView, we should handle button separately from text view.
Also, we should clear the state list animator and force to set Bounds outline provider for the button.

### Bugs Fixed ###
- Fixes #988

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [X] Has a linked Issue, and the Issue has been `approved`
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
