### PR TITLE
[Bug] Regression: TouchEffect NativeAmination doesn't work on images

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
@@ -75,7 +75,10 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			if (Group == null)
 			{
 				if (Build.VERSION.SdkInt >= BuildVersionCodes.M)
+				{
 					View.Foreground = ripple;
+					rippleView = View;
+				}
 
 				return;
 			}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
@@ -322,7 +322,10 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			if (rippleView?.Pressed ?? false)
 			{
 				rippleView.Pressed = false;
-				rippleView.Enabled = false;
+				if (rippleView != View)
+				{
+					rippleView.Enabled = false;
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fixed NativeAnimation for images.
You can test it on sample page for TouchEffect.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #1304

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [x] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
