### PR TITLE
[Android] Make working Image + Native TouchEffect + TapGestureRecognizer 

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Linq;
 using Android.Content;
 using Android.Content.Res;
 using Android.Graphics.Drawables;
@@ -13,6 +14,7 @@ using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 using AView = Android.Views.View;
 using Color = Android.Graphics.Color;
+using XView = Xamarin.Forms.View;
 
 [assembly: ExportEffect(typeof(PlatformTouchEffect), nameof(TouchEffect))]
 
@@ -40,8 +42,12 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 		internal bool IsCanceled { get; set; }
 
 		bool IsAccessibilityMode => accessibilityManager != null
-									&& accessibilityManager.IsEnabled
-									&& accessibilityManager.IsTouchExplorationEnabled;
+			&& accessibilityManager.IsEnabled
+			&& accessibilityManager.IsTouchExplorationEnabled;
+
+		bool IsForegroundRippleWithTapGestureRecognizer => View.Foreground == ripple
+			&& Element is XView view
+			&& view.GestureRecognizers.Any(gesture => gesture is TapGestureRecognizer);
 
 		protected override void OnAttached()
 		{
@@ -301,13 +307,21 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			if (effect?.IsDisabled ?? true)
 				return;
 
-			if (effect.CanExecute && effect.NativeAnimation && rippleView != null)
+			if (effect.CanExecute && effect.NativeAnimation)
 			{
 				UpdateRipple();
-				rippleView.Enabled = true;
-				rippleView.BringToFront();
-				ripple?.SetHotspot(x, y);
-				rippleView.Pressed = true;
+				if (rippleView != null)
+				{
+					rippleView.Enabled = true;
+					rippleView.BringToFront();
+					ripple?.SetHotspot(x, y);
+					rippleView.Pressed = true;
+				}
+				else if (IsForegroundRippleWithTapGestureRecognizer)
+				{
+					ripple?.SetHotspot(x, y);
+					View.Pressed = true;
+				}
 			}
 		}
 
@@ -316,10 +330,20 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			if (effect?.IsDisabled ?? true)
 				return;
 
-			if (rippleView?.Pressed ?? false)
+			if (rippleView != null)
 			{
-				rippleView.Pressed = false;
-				rippleView.Enabled = false;
+				if (rippleView.Pressed)
+				{
+					rippleView.Pressed = false;
+					rippleView.Enabled = false;
+				}
+			}
+			else if (IsForegroundRippleWithTapGestureRecognizer)
+			{
+				if (View.Pressed)
+				{
+					View.Pressed = false;
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###
If TouchEffect is applied to View (not layout) that has TapGestureRecognizer, we should manage the ripple state on the TouchEffect renderer side (because TapGestureRecognizer intercepts events)

### Bugs Fixed ###
- Fixes #1304

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [X] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
