### PR TITLE
Change iOS Snackbar/Toast default background color

### DIFF
--- a/samples/XCT.Sample/Pages/Base/BasePage.cs
+++ b/samples/XCT.Sample/Pages/Base/BasePage.cs
@@ -33,6 +33,7 @@ namespace Xamarin.CommunityToolkit.Sample.Pages
 			var page = (BasePage)Activator.CreateInstance(model.Type);
 			page.Title = model.Title;
 			page.DetailColor = model.Color;
+			page.SetAppThemeColor(BackgroundColorProperty, Color.White, Color.Black);
 			return page;
 		}
 	}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackBarAppearance.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/iOS/SnackBarAppearance.ios.cs
@@ -7,7 +7,7 @@ namespace Xamarin.CommunityToolkit.UI.Views.Helpers.iOS
 {
 	class NativeSnackBarAppearance
 	{
-		public UIColor Background { get; set; } = XCT.IsiOS13OrNewer ? UIColor.SystemBackgroundColor : UIColor.Gray;
+		public UIColor Background { get; set; } = XCT.IsiOS13OrNewer ? UIColor.SystemGrayColor : UIColor.Gray;
 
 		public UIColor Foreground { get; set; } = DefaultColor;
 


### PR DESCRIPTION
### Description of Change ###

Change the default background color for iOS Toast and Snackbar

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #

### Behavioral Changes ###

Dark theme
![image](https://user-images.githubusercontent.com/33021114/119489373-4bbd2b80-bd64-11eb-8cc5-aec7cc379e58.png)

Light theme
![image](https://user-images.githubusercontent.com/33021114/119489427-5b3c7480-bd64-11eb-9cb6-05351b7abc41.png)


### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [ ] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
