### PR TITLE
DrawingView return null instead of exception

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.android.cs
@@ -48,7 +48,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			return stream;
 		}
 
-		static Bitmap GetImageInternal(IList<Point> points,
+		static Bitmap? GetImageInternal(IList<Point> points,
 			float lineWidth,
 			Color strokeColor,
 			Color backgroundColor)
@@ -59,7 +59,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			var drawingHeight = points.Max(p => p.Y) - minPointY;
 			const int minSize = 1;
 			if (drawingWidth < minSize || drawingHeight < minSize)
-				throw new Exception($"The image size should be at least {minSize} x {minSize}.");
+				return null;
 
 			var image = Bitmap.CreateBitmap((int)drawingWidth, (int)drawingHeight, Bitmap.Config.Argb8888!)!;
 			using var canvas = new Canvas(image);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.gtk.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.gtk.cs
@@ -50,7 +50,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 		}
 
-		static Bitmap GetImageInternal(IList<Point> points,
+		static Bitmap? GetImageInternal(IList<Point> points,
 			float lineWidth,
 			Color strokeColor,
 			Color backgroundColor)
@@ -62,7 +62,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			const int minSize = 1;
 			if (drawingWidth < minSize || drawingHeight < minSize)
 			{
-				throw new Exception($"The image size should be at least {minSize} x {minSize}.");
+				return null;
 			}
 
 			var bm = new Bitmap((int)drawingWidth, (int)drawingHeight);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.ios.cs
@@ -41,7 +41,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			return resizedImage.AsJPEG().AsStream();
 		}
 
-		static UIImage GetImageInternal(IList<Point> points,
+		static UIImage? GetImageInternal(IList<Point> points,
 			float lineWidth,
 			Color strokeColor,
 			Color backgroundColor)
@@ -53,7 +53,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			const int minSize = 1;
 			if (drawingWidth < minSize || drawingHeight < minSize)
 			{
-				throw new Exception($"The image size should be at least {minSize} x {minSize}.");
+				return null;
 			}
 
 			var imageSize = new CGSize(drawingWidth, drawingHeight);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.macos.cs
@@ -32,10 +32,15 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 
 			var image = GetImageInternal(points, lineWidth, strokeColor, backgroundColor);
+			if (image is null)
+			{
+				return Stream.Null;
+			}
+
 			return image.AsTiff().AsStream();
 		}
 
-		static NSImage GetImageInternal(IList<Point> points,
+		static NSImage? GetImageInternal(IList<Point> points,
 			float lineWidth,
 			Color strokeColor,
 			Color backgroundColor)
@@ -47,7 +52,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			const int minSize = 1;
 			if (drawingWidth < minSize || drawingHeight < minSize)
 			{
-				throw new Exception($"The image size should be at least {minSize} x {minSize}.");
+				return null;
 			}
 
 			var imageSize = new CGSize(drawingWidth, drawingHeight);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.tizen.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.tizen.cs
@@ -46,7 +46,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 		}
 
-		static SKImage GetImageInternal(IList<Point> points,
+		static SKImage? GetImageInternal(IList<Point> points,
 			float lineWidth,
 			Color strokeColor,
 			Color backgroundColor)
@@ -58,7 +58,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			const int minSize = 1;
 			if (drawingWidth < minSize || drawingHeight < minSize)
 			{
-				throw new Exception($"The image size should be at least {minSize} x {minSize}.");
+				return null;
 			}
 
 			var bm = new SKBitmap((int)drawingWidth, (int)drawingHeight);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.uwp.cs
@@ -50,7 +50,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 		}
 
-		static CanvasRenderTarget GetImageInternal(IList<Point> points,
+		static CanvasRenderTarget? GetImageInternal(IList<Point> points,
 			float lineWidth,
 			Color lineColor,
 			Color backgroundColor)
@@ -62,7 +62,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			const int minSize = 1;
 			if (drawingWidth < minSize || drawingHeight < minSize)
 			{
-				throw new Exception($"The image size should be at least {minSize} x {minSize}.");
+				return null;
 			}
 
 			var device = CanvasDevice.GetSharedDevice();

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.wpf.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.wpf.cs
@@ -35,6 +35,10 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 
 			var image = GetImageInternal(points, lineWidth, strokeColor, backgroundColor);
+			if (image is null)
+			{
+				return Stream.Null;
+			}
 
 			var resizedImage = MaxResizeImage(image, (float) imageSize.Width, (float) imageSize.Height);
 			using (resizedImage)
@@ -46,7 +50,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 		}
 
-		static Bitmap GetImageInternal(ICollection<Point> points,
+		static Bitmap? GetImageInternal(ICollection<Point> points,
 			float lineWidth,
 			Color strokeColor,
 			Color backgroundColor)
@@ -58,7 +62,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			const int minSize = 1;
 			if (drawingWidth < minSize || drawingHeight < minSize)
 			{
-				throw new Exception($"The image size should be at least {minSize} x {minSize}.");
+				return null;
 			}
 
 			var bm = new Bitmap((int) drawingWidth, (int) drawingHeight);


### PR DESCRIPTION
return null in case the image size is too small (the user just put 1 point. we are not able to create a bitmap with this size)

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [ ] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
