### PR TITLE
Expander: Add touch capture view + common animation length / easing properties

### DIFF
--- a/samples/XCT.Sample/Pages/Views/ExpanderPage.xaml
+++ b/samples/XCT.Sample/Pages/Views/ExpanderPage.xaml
@@ -27,9 +27,16 @@
                                 <Switch IsToggled="{Binding IsEnabled}" />
                             </StackLayout>
                         </xct:Expander.Header>
-                        <xct:Expander IsEnabled="{Binding IsEnabled}">
+                        <xct:Expander IsEnabled="{Binding IsEnabled}" TouchCaptureView="{x:Reference touchCaptureView}">
                             <xct:Expander.Header>
-                                <Label Text="Nested expander" FontSize="30" FontAttributes="Bold"/>
+                                <StackLayout Orientation="Horizontal">
+                                    <Label Text="Nested expander" FontSize="25" FontAttributes="Bold" VerticalOptions="Center"/>
+                                    <StackLayout x:Name="touchCaptureView" Orientation="Horizontal" VerticalOptions="Center" HorizontalOptions="EndAndExpand" xct:TouchEffect.NativeAnimation="True">
+                                        <Label Text=">" Rotation="90" FontSize="25" FontAttributes="Bold" TextColor="Black" />
+                                        <Label Text=">" Rotation="90" FontSize="25" FontAttributes="Bold" TextColor="Black" />
+                                        <Label Text=">" Rotation="90" FontSize="25" FontAttributes="Bold" TextColor="Black" />
+                                    </StackLayout>
+                                </StackLayout>
                             </xct:Expander.Header>
                             <xct:Expander.ContentTemplate>
                                 <DataTemplate>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Expander/Expander.shared.cs
@@ -51,11 +51,17 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		public static readonly BindableProperty DirectionProperty
 			= BindableProperty.Create(nameof(Direction), typeof(ExpandDirection), typeof(Expander), default(ExpandDirection), propertyChanged: OnDirectionPropertyChanged);
 
+		public static readonly BindableProperty AnimationLengthProperty
+			= BindableProperty.Create(nameof(AnimationLength), typeof(uint), typeof(Expander), defaultAnimationLength);
+
 		public static readonly BindableProperty ExpandAnimationLengthProperty
-			= BindableProperty.Create(nameof(ExpandAnimationLength), typeof(uint), typeof(Expander), defaultAnimationLength);
+			= BindableProperty.Create(nameof(ExpandAnimationLength), typeof(uint), typeof(Expander), uint.MaxValue);
 
 		public static readonly BindableProperty CollapseAnimationLengthProperty
-			= BindableProperty.Create(nameof(CollapseAnimationLength), typeof(uint), typeof(Expander), defaultAnimationLength);
+			= BindableProperty.Create(nameof(CollapseAnimationLength), typeof(uint), typeof(Expander), uint.MaxValue);
+
+		public static readonly BindableProperty AnimationEasingProperty
+			= BindableProperty.Create(nameof(AnimationEasing), typeof(Easing), typeof(Expander));
 
 		public static readonly BindableProperty ExpandAnimationEasingProperty
 			= BindableProperty.Create(nameof(ExpandAnimationEasing), typeof(Easing), typeof(Expander));
@@ -146,6 +152,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			set => SetValue(DirectionProperty, value);
 		}
 
+		public uint AnimationLength
+		{
+			get => (uint)GetValue(AnimationLengthProperty);
+			set => SetValue(AnimationLengthProperty, value);
+		}
+
 		public uint ExpandAnimationLength
 		{
 			get => (uint)GetValue(ExpandAnimationLengthProperty);
@@ -156,6 +168,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		{
 			get => (uint)GetValue(CollapseAnimationLengthProperty);
 			set => SetValue(CollapseAnimationLengthProperty, value);
+		}
+
+		public Easing AnimationEasing
+		{
+			get => (Easing)GetValue(AnimationEasingProperty);
+			set => SetValue(AnimationEasingProperty, value);
 		}
 
 		public Easing ExpandAnimationEasing
@@ -442,6 +460,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				length = ExpandAnimationLength;
 				easing = ExpandAnimationEasing;
 			}
+
+			if (length == uint.MaxValue)
+				length = AnimationLength;
+
+			easing ??= AnimationEasing;
 
 			if (lastVisibleSize > 0)
 				length = (uint)(length * (Abs(endSize - startSize) / lastVisibleSize));

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Expander/Expander.shared.cs
@@ -51,6 +51,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		public static readonly BindableProperty DirectionProperty
 			= BindableProperty.Create(nameof(Direction), typeof(ExpandDirection), typeof(Expander), default(ExpandDirection), propertyChanged: OnDirectionPropertyChanged);
 
+		public static readonly BindableProperty TouchCaptureViewProperty
+			= BindableProperty.Create(nameof(TouchCaptureView), typeof(View), typeof(Expander), propertyChanged: OnTouchCaptureViewPropertyChanged);
+
 		public static readonly BindableProperty AnimationLengthProperty
 			= BindableProperty.Create(nameof(AnimationLength), typeof(uint), typeof(Expander), defaultAnimationLength);
 
@@ -150,6 +153,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		{
 			get => (ExpandDirection)GetValue(DirectionProperty);
 			set => SetValue(DirectionProperty, value);
+		}
+
+		public View? TouchCaptureView
+		{
+			get => (View?)GetValue(TouchCaptureViewProperty);
+			set => SetValue(TouchCaptureViewProperty, value);
 		}
 
 		public uint AnimationLength
@@ -274,6 +283,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		static void OnDirectionPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 			=> ((Expander)bindable).OnDirectionPropertyChanged((ExpandDirection)oldValue);
 
+		static void OnTouchCaptureViewPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+			=> ((Expander)bindable).OnTouchCaptureViewPropertyChanged((View?)oldValue);
+
 		static object GetDefaultForceUpdateSizeCommand(BindableObject bindable)
 			=> new Command(((Expander)bindable).ForceUpdateSize);
 
@@ -289,8 +301,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		void OnIsExpandedPropertyChanged()
 			=> SetContent(false);
 
-		void OnDirectionPropertyChanged(ExpandDirection olddirection)
-			=> SetDirection(olddirection);
+		void OnDirectionPropertyChanged(ExpandDirection oldDirection)
+			=> SetDirection(oldDirection);
+
+		void OnTouchCaptureViewPropertyChanged(View? oldView)
+			=> SetTouchCaptureView(oldView);
 
 		void OnIsExpandedChanged(bool shouldIgnoreAnimation = false)
 		{
@@ -337,7 +352,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		{
 			if (oldHeader != null)
 			{
-				oldHeader.GestureRecognizers.Remove(headerTapGestureRecognizer);
 				Control?.Children.Remove(oldHeader);
 			}
 
@@ -347,9 +361,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 					Control?.Children.Insert(0, Header);
 				else
 					Control?.Children.Add(Header);
-
-				Header.GestureRecognizers.Add(headerTapGestureRecognizer);
 			}
+
+			SetTouchCaptureView(oldHeader);
 		}
 
 		void SetContent(bool isForceUpdate, bool shouldIgnoreAnimation = false, bool isForceContentReset = false)
@@ -433,6 +447,14 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			lastVisibleSize = -1;
 			SetHeader(Header);
 			SetContent(true, true, true);
+		}
+
+		void SetTouchCaptureView(View? oldView)
+		{
+			oldView?.GestureRecognizers.Remove(headerTapGestureRecognizer);
+			TouchCaptureView?.GestureRecognizers?.Remove(headerTapGestureRecognizer);
+			Header?.GestureRecognizers.Remove(headerTapGestureRecognizer);
+			(TouchCaptureView ?? Header)?.GestureRecognizers.Add(headerTapGestureRecognizer);
 		}
 
 		void InvokeAnimation(double startSize, double endSize, bool shouldIgnoreAnimation)


### PR DESCRIPTION
### Description of Change ###
Add a property that allows setting the view which will be responsible for touch handling (tap over this view will cause expander to expand or collapse).
Also, add base animation length/easing configuration properties.

Documentation updated: https://github.com/MicrosoftDocs/xamarin-communitytoolkit/pull/128

### Feature
Fixes: #1350

### API Changes ###
Added: 
 
- `uint Expander.AnimationLength { get; set; }`
- `Easing Expander.AnimationEasing { get; set; }`
- `View Expander.TouchCaptureView { get; set; }`

### Behavioral Changes ###
None

### PR Checklist ###
- [X] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of develop at time of PR
- [X] Changes adhere to coding standard
- [X] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
