### PR TITLE
fixed bugs with math expression converter

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/MathExpressionConverter_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Converters/MathExpressionConverter_Tests.cs
@@ -11,7 +11,12 @@ namespace Xamarin.CommunityToolkit.UnitTests.Converters
 		readonly Type type = typeof(MathExpressionConverter_Tests);
 		readonly CultureInfo cultureInfo = CultureInfo.CurrentCulture;
 
+		[TestCase("min(max(4+x, 5), 10)", 2d, 6d)]
 		[TestCase("-10 + x * -2", 2d, -14d)]
+		[TestCase("x * (-2 * 5)", 2d, -20d)]
+		[TestCase("x-10", 19d, 9d)]
+		[TestCase("x*-10", 3d, -30d)]
+		[TestCase("min(x+6, 8)", 1d, 7d)]
 		[TestCase("x + x * x", 2d, 6d)]
 		[TestCase("(x + x) * x", 2d, 8d)]
 		[TestCase("3 + x * 2 / (1 - 5)^2", 4d, 3.5d)]

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/MathExpressionConverter/MathExpression.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/MathExpressionConverter/MathExpression.shared.cs
@@ -16,7 +16,7 @@ namespace Xamarin.CommunityToolkit.Converters
 		readonly IReadOnlyList<MathOperator> operators;
 		readonly IReadOnlyList<double> arguments;
 
-		public string Expression { get; }
+		internal string Expression { get; }
 
 		internal MathExpression(string expression, IEnumerable<double>? arguments = null)
 		{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/MathExpressionConverter/MathExpression.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Converters/MathExpressionConverter/MathExpression.shared.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -8,6 +9,9 @@ namespace Xamarin.CommunityToolkit.Converters
 	sealed class MathExpression
 	{
 		const string regexPattern = @"(?<!\d)\-?(?:\d+\.\d+|\d+)|\+|\-|\/|\*|\(|\)|\^|\%|\,|\w+";
+		const NumberStyles numberStyle = NumberStyles.Float | NumberStyles.AllowThousands;
+
+		static readonly IFormatProvider formatProvider = new CultureInfo("en-US");
 
 		readonly IList<MathOperator> operators;
 		readonly IList<double> arguments;
@@ -80,7 +84,7 @@ namespace Xamarin.CommunityToolkit.Converters
 
 			foreach (var value in rpn)
 			{
-				if (double.TryParse(value, out var numeric))
+				if (double.TryParse(value, numberStyle, formatProvider, out var numeric))
 				{
 					stack.Push(numeric);
 					continue;
@@ -137,7 +141,7 @@ namespace Xamarin.CommunityToolkit.Converters
 
 				var value = match.Value;
 
-				if (double.TryParse(value, out var numeric))
+				if (double.TryParse(value, numberStyle, formatProvider, out var numeric))
 				{
 					if (numeric < 0)
 					{


### PR DESCRIPTION
### Description of Change ###

Fixes some bugs with MathExpressionConverter 

### Bugs Fixed ###

Fixes bugs: with negative numerics, with functions which takes two arguments (i.e. pow(x, y)), misprint at round func and bug with different cultures.

### API Changes ###

None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [ ] Has a linked Issue, and the Issue has been `approved`
- [x] Has tests (updated)
- [ ] Has samples
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit) 

PS. Should I first create a bugs description problem or? If I implemented this converter?
