### PR TITLE
Fix iOS - can't show Popup from a modal page

### DIFF
--- a/samples/XCT.Sample/Pages/TestCases/Popups/PopupModalPage.xaml
+++ b/samples/XCT.Sample/Pages/TestCases/Popups/PopupModalPage.xaml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<pages:BasePage
+    x:Class="Xamarin.CommunityToolkit.Sample.Pages.TestCases.Popups.PopupModalPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+    xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.TestCases.Popups">
+    <pages:BasePage.BindingContext>
+        <vm:PopupModalViewModel />
+    </pages:BasePage.BindingContext>
+    <pages:BasePage.Resources>
+        <ResourceDictionary>
+            <Style TargetType="Button">
+                <Setter Property="Margin" Value="20" />
+            </Style>
+        </ResourceDictionary>
+    </pages:BasePage.Resources>
+    <ContentPage.Content>
+        <StackLayout Margin="20" VerticalOptions="Center">
+            <Label HorizontalTextAlignment="Center" Text="In a Modal, ShowPopup should work on Android and iOS" />
+            <Button Command="{Binding ShowPopup}" Text="Show Popup" />
+            <Button Command="{Binding PushModal}" Text="Push new modal" />
+            <Button Command="{Binding PopModal}" Text="Dismiss modal" />
+        </StackLayout>
+    </ContentPage.Content>
+</pages:BasePage>

--- a/samples/XCT.Sample/Pages/TestCases/Popups/PopupModalPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/TestCases/Popups/PopupModalPage.xaml.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.TestCases.Popups
+{
+	public partial class PopupModalPage : BasePage
+	{
+		public PopupModalPage() => InitializeComponent();
+	}
+}

--- a/samples/XCT.Sample/Pages/TestCases/Popups/SimplePopup.xaml
+++ b/samples/XCT.Sample/Pages/TestCases/Popups/SimplePopup.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<xct:Popup
+    x:Class="Xamarin.CommunityToolkit.Sample.Pages.TestCases.Popups.SimplePopup"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+    Size="300,300">
+    <StackLayout BackgroundColor="Red">
+        <Label
+            HorizontalOptions="Center"
+            Text="This is a popup"
+            TextColor="White"
+            VerticalOptions="CenterAndExpand" />
+    </StackLayout>
+</xct:Popup>

--- a/samples/XCT.Sample/Pages/TestCases/Popups/SimplePopup.xaml.cs
+++ b/samples/XCT.Sample/Pages/TestCases/Popups/SimplePopup.xaml.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.TestCases.Popups
+{
+	public partial class SimplePopup 
+	{
+		public SimplePopup() => InitializeComponent();
+	}
+}

--- a/samples/XCT.Sample/ViewModels/TestCases/Popups/PopupModalViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/TestCases/Popups/PopupModalViewModel.cs
@@ -1,0 +1,35 @@
+﻿using System.Windows.Input;
+using Xamarin.Forms;
+using Xamarin.CommunityToolkit.Sample.Pages.TestCases.Popups;
+using Xamarin.CommunityToolkit.Extensions;
+
+namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases.Popups
+{
+	public class PopupModalViewModel : BaseViewModel
+	{
+		public PopupModalViewModel()
+		{
+			ShowPopup = new Command(PerformShowPopup);
+			PushModal = new Command(PerformPushModal);
+			PopModal = new Command(PerformPopModal);
+		}
+
+		INavigation Navigation => Application.Current.MainPage.Navigation;
+
+		public ICommand ShowPopup { get; }
+
+		public ICommand PushModal { get; }
+
+		public ICommand PopModal { get; }
+
+		void PerformShowPopup() => Navigation.ShowPopup(new SimplePopup());
+
+		async void PerformPushModal() => await Navigation.PushModalAsync(new PopupModalPage());
+
+		async void PerformPopModal()
+		{
+			if (Navigation.ModalStack.Count > 0)
+				await Navigation.PopModalAsync();
+		}
+	}
+}

--- a/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Xamarin.CommunityToolkit.Sample.Models;
 using Xamarin.CommunityToolkit.Sample.Pages.TestCases;
+using Xamarin.CommunityToolkit.Sample.Pages.TestCases.Popups;
 
 namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases
 {
@@ -27,6 +28,11 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases
 				typeof(TabViewBindingPage),
 				"TabView BindingContext",
 				"TabView with BindingContext into MainPage and other BindingContext into TabViewItem."),
+
+			new SectionModel(
+				typeof(PopupModalPage),
+				"Popup into modal",
+				"Using Popup into modal page show the popup"),
 		};
 	}
 }

--- a/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
+++ b/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
@@ -36,6 +36,12 @@
   </ItemGroup>
   
   <ItemGroup>
+    <EmbeddedResource Update="Pages\TestCases\Popups\PopupModalPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Pages\TestCases\Popups\SimplePopup.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Resx\AppResources.es.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <DependentUpon>AppResources.resx</DependentUpon>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Popup/iOS/PopupRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Popup/iOS/PopupRenderer.ios.cs
@@ -134,14 +134,16 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		void SetViewController()
 		{
 			IVisualElementRenderer currentPageRenderer;
-			if (Application.Current.MainPage?.Navigation?.ModalStack.Count > 0)
+			var modalStackCount = Application.Current.MainPage?.Navigation?.ModalStack?.Count ?? 0;
+			var mainPage = Application.Current.MainPage;
+			if (modalStackCount > 0)
 			{
-				var index = Application.Current.MainPage.Navigation.ModalStack.Count - 1;
-				currentPageRenderer = Platform.GetRenderer(Application.Current.MainPage.Navigation.ModalStack[index]);
+				var index = modalStackCount - 1;
+				currentPageRenderer = Platform.GetRenderer(mainPage!.Navigation!.ModalStack![index]);
 			}
 			else
 			{
-				currentPageRenderer = Platform.GetRenderer(Application.Current.MainPage);
+				currentPageRenderer = Platform.GetRenderer(mainPage);
 			}
 			ViewController = currentPageRenderer.ViewController;
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Popup/iOS/PopupRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Popup/iOS/PopupRenderer.ios.cs
@@ -133,7 +133,16 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void SetViewController()
 		{
-			var currentPageRenderer = Platform.GetRenderer(Application.Current.MainPage);
+			IVisualElementRenderer currentPageRenderer;
+			if (Application.Current.MainPage?.Navigation?.ModalStack.Count > 0)
+			{
+				var index = Application.Current.MainPage.Navigation.ModalStack.Count - 1;
+				currentPageRenderer = Platform.GetRenderer(Application.Current.MainPage.Navigation.ModalStack[index]);
+			}
+			else
+			{
+				currentPageRenderer = Platform.GetRenderer(Application.Current.MainPage);
+			}
 			ViewController = currentPageRenderer.ViewController;
 		}
 


### PR DESCRIPTION

### Description of Change ###

Actually on iOS, the ViewController is the MainPage ViewController, with this changes if there is any Modal into the MainPage.Navigation.ModalStack, the ViewController is the last modal displayed ViewController.

### Bugs Fixed ###

- Fixes #1189

You can try it with the sample of the issue fixed here : [XF_PopupModalIssue_Fixed.zip](https://github.com/xamarin/XamarinCommunityToolkit/files/6657933/XF_PopupModalIssue_Fixed.zip) 

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->

- [x] Has a linked Issue, and the Issue has been `approved`
- [x] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard

- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
