### PR TITLE
Fixes regression TouchEffect + Button/ImageButton

### DIFF
--- a/samples/XCT.Sample/Pages/Effects/TouchEffectPage.xaml
+++ b/samples/XCT.Sample/Pages/Effects/TouchEffectPage.xaml
@@ -98,6 +98,20 @@
                     xct:TouchEffect.Command="{Binding Command, Source={x:Reference Page}}"/>
             </StackLayout>
 
+            <StackLayout Style="{StaticResource GridRowContentStyle}">
+
+                <Label Text="Button | ImageButton" />
+
+                <Button
+                    Text="Button"
+                    xct:TouchEffect.Command="{Binding Command, Mode=OneWay, Source={x:Reference Page}}" />
+
+                <ImageButton
+                    HeightRequest="150"
+                    Source="xamarinstore.jpg"
+                    xct:TouchEffect.Command="{Binding Command, Mode=OneWay, Source={x:Reference Page}}" />
+
+            </StackLayout>
 
             <StackLayout Style="{StaticResource GridRowContentStyle}">
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.ios.cs
@@ -279,6 +279,7 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 		}
 
 		public override bool ShouldReceiveTouch(UIGestureRecognizer recognizer, UITouch touch)
-			=> recognizer.View.IsDescendantOfView(touch.View);
+			=> recognizer.View.IsDescendantOfView(touch.View) ||
+				(recognizer.View as IVisualNativeElementRenderer)?.Control == touch.View;
 	}
 }


### PR DESCRIPTION
### Description of Change ###
Starting from 1.2.0 TouchEffect stopped working with Button and ImageButton.
It caused by changes #1435 

Please make sure TouchEffect works fine with Button and ImageButton (Samples added).
Also, make sure Nested TouchEffects work fine so far.

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [ ] Has a linked Issue, and the Issue has been `approved`
- [] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
