### PR TITLE
Changed rulesets  to reduce warning noise

### DIFF
--- a/Xamarin.CommunityToolkit.ruleset
+++ b/Xamarin.CommunityToolkit.ruleset
@@ -4,7 +4,7 @@
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA0001" Action="None" />
     <Rule Id="SA0002" Action="Warning" />
-    <Rule Id="SA1000" Action="Warning" />
+    <Rule Id="SA1000" Action="None" />
     <Rule Id="SA1001" Action="Warning" />
     <Rule Id="SA1002" Action="Warning" />
     <Rule Id="SA1003" Action="Warning" />
@@ -13,8 +13,9 @@
     <Rule Id="SA1006" Action="Warning" />
     <Rule Id="SA1007" Action="Warning" />
     <Rule Id="SA1008" Action="Warning" />
-    <Rule Id="SA1009" Action="Warning" />
+    <Rule Id="SA1009" Action="None" />
     <Rule Id="SA1010" Action="Warning" />
+    <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1012" Action="Warning" />
     <Rule Id="SA1013" Action="Warning" />
     <Rule Id="SA1014" Action="Warning" />
@@ -55,7 +56,7 @@
     <Rule Id="SA1120" Action="Warning" />
     <Rule Id="SA1121" Action="Warning" />
     <Rule Id="SA1122" Action="Warning" />
-    <Rule Id="SA1123" Action="Warning" />
+    <Rule Id="SA1123" Action="None" />
     <Rule Id="SA1124" Action="None" />
     <Rule Id="SA1125" Action="Warning" />
     <Rule Id="SA1126" Action="Warning" />
@@ -115,7 +116,6 @@
     <Rule Id="SA1409" Action="Warning" />
     <Rule Id="SA1410" Action="Warning" />
     <Rule Id="SA1411" Action="Warning" />
-    <Rule Id="SA1412" Action="Warning" />
     <Rule Id="SA1413" Action="None" />
     <Rule Id="SA1500" Action="Warning" />
     <Rule Id="SA1501" Action="Warning" />

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/AssemblyInfo/AssemblyInfo.ios.tvos.watchos.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/AssemblyInfo/AssemblyInfo.ios.tvos.watchos.macos.cs
@@ -2,7 +2,9 @@
 using Xamarin.CommunityToolkit.UI.Views;
 using Xamarin.Forms;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 [assembly: LinkerSafe]
+#pragma warning restore CS0618 // Type or member is obsolete
 
 #if XAMARIN_IOS || XAMARIN_MAC
 [assembly: ExportImageSourceHandler(typeof(GravatarImageSource), typeof(GravatarImageSourceHandler))]

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Semantic/SemanticEffect.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Semantic/SemanticEffect.shared.cs
@@ -16,7 +16,6 @@ namespace Xamarin.CommunityToolkit.Effects
 
 		public static void SetHeadingLevel(BindableObject view, HeadingLevel value) => view.SetValue(HeadingLevelProperty, value);
 
-
 		public static readonly BindableProperty DescriptionProperty = BindableProperty.CreateAttached("Description", typeof(string), typeof(SemanticEffect), default(string), propertyChanged: OnPropertyChanged);
 
 		public static string GetDescription(BindableObject bindable) => (string)bindable.GetValue(DescriptionProperty);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Semantic/SemanticEffectRouterBase.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Semantic/SemanticEffectRouterBase.android.cs
@@ -31,7 +31,6 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			}
 		}
 
-
 		protected virtual void Update(global::Android.Views.View view, T effect)
 		{
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.uwp.cs
@@ -50,7 +50,6 @@ namespace Xamarin.CommunityToolkit.UWP.Effects
 					pointerDownStoryboard = new Storyboard();
 					var downThemeAnimation = new PointerDownThemeAnimation();
 
-
 					Storyboard.SetTargetName(downThemeAnimation, nativeControl.Name);
 
 					pointerDownStoryboard.Children.Add(downThemeAnimation);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Extensions/VisualElement/VisualElementExtensions.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Extensions/VisualElement/VisualElementExtensions.uwp.cs
@@ -9,7 +9,6 @@ namespace Xamarin.CommunityToolkit.Extensions
 	/// </summary>
 	public static partial class VisualElementExtensions
 	{
-
 		/// <summary>
 		/// <see cref="VisualElement"/> cleanup object to dispose and
 		/// destroy resources.

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
@@ -35,8 +35,6 @@ using System.Threading.Tasks;
 using System.Linq;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
-using Camera = Android.Hardware.Camera;
-using Math = System.Math;
 using Rect = Android.Graphics.Rect;
 using APoint = Android.Graphics.Point;
 
@@ -541,8 +539,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			{
 				LogError("Error restarting video recording", ex);
 			}
-
-
 		}
 
 		async Task PrepareSession()
@@ -783,7 +779,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			};
 		}
 
-		#region TextureView.ISurfaceTextureListener
 		async void TextureView.ISurfaceTextureListener.OnSurfaceTextureAvailable(SurfaceTexture? surface, int width, int height)
 		{
 			UpdateBackgroundColor();
@@ -803,9 +798,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		void TextureView.ISurfaceTextureListener.OnSurfaceTextureUpdated(SurfaceTexture? surface)
 		{
 		}
-		#endregion
 
-		#region Permissions
 		async Task RequestCameraPermissions()
 		{
 			if (permissionsRequested != null)
@@ -856,9 +849,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			}
 			permissionsRequested?.TrySetResult(true);
 		}
-		#endregion
 
-		#region Helpers
 		void LogError(string desc, Java.Lang.Exception? ex = null)
 		{
 			var newLine = System.Environment.NewLine;
@@ -1069,6 +1060,5 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			LogError("Couldn't find any suitable preview size");
 			return choices[0];
 		}
-		#endregion
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/WPF/MediaElementRenderer.wpf.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/WPF/MediaElementRenderer.wpf.cs
@@ -54,7 +54,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 				Control.Stretch = Element.Aspect.ToStretch();
 
-
 				Element.SeekRequested += SeekRequested;
 				Element.StateRequested += StateRequested;
 				Element.PositionRequested += PositionRequested;
@@ -73,6 +72,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		}
 
 		MediaElementState requestedState;
+
 		IMediaElementController Controller => Element as IMediaElementController;
 
 		void StateRequested(object? sender, StateRequested e)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Popup/UWP/PopupRenderer.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Popup/UWP/PopupRenderer.uwp.cs
@@ -120,8 +120,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			Opened += OnOpened;
 		}
 
-
-
 		void SetSize()
 		{
 			_ = Element ?? throw new InvalidOperationException($"{nameof(Element)} cannot be null");

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Shield.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Shield.shared.cs
@@ -314,7 +314,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void UpdateSubjectColor() => ShieldSubjectContainer.BackgroundColor = SubjectBackgroundColor;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 		void UpdateColor() => ShieldStatusContainer.BackgroundColor = Color;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 		void UpdateStatusBackgroundColor() => ShieldStatusContainer.BackgroundColor = StatusBackgroundColor;
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/NativeRoundedStackView.ios.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/Helpers/NativeRoundedStackView.ios.macos.cs
@@ -7,7 +7,6 @@ using Xamarin.Forms;
 using Xamarin.CommunityToolkit.UI.Views.Helpers.iOS;
 using UIKit;
 #elif __MACOS__
-using CoreGraphics;
 using Xamarin.CommunityToolkit.UI.Views.Helpers.macOS;
 using Xamarin.CommunityToolkit.UI.Views.Helpers.macOS.Extensions;
 using AppKit;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
@@ -31,7 +31,7 @@
     <Configurations>Debug;Release</Configurations>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <DebugType>portable</DebugType>
-    <NoWarn>SA1123</NoWarn>
+    <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <!-- Manage TargetFrameworks for development (Debug Mode) -->


### PR DESCRIPTION
Reduced the number of warnings. Rules changed

- Fixes #1485

SA1000 - space when do use `new`
SA1412 - change files to be UTF-8 files
NU1701 - libs built with another version of .NET Framework
SA1123 - Warning when we use regions