### PR TITLE
Update Xamarin.Forms Dependency to v5.0.0.2083

### DIFF
--- a/samples/XCT.Sample.Android/Xamarin.CommunityToolkit.Sample.Android.csproj
+++ b/samples/XCT.Sample.Android/Xamarin.CommunityToolkit.Sample.Android.csproj
@@ -53,11 +53,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
-    <PackageReference Include="Xamarin.Forms.PancakeView">
-      <Version>2.3.0.759</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Forms.PancakeView" Version="2.3.0.759" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
+++ b/samples/XCT.Sample.FSharp/Xamarin.CommunityToolkit.Sample.FSharp.fsproj
@@ -23,7 +23,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FSharp.Core" Version="5.0.1" />
+		<PackageReference Include="FSharp.Core" Version="5.0.2" />
 		<ProjectReference Include="..\..\src\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj" />
 	</ItemGroup>
 

--- a/samples/XCT.Sample.GTK/Xamarin.CommunityToolkit.Sample.GTK.csproj
+++ b/samples/XCT.Sample.GTK/Xamarin.CommunityToolkit.Sample.GTK.csproj
@@ -80,12 +80,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms">
-      <Version>5.0.0.2012</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Forms.Platform.GTK">
-      <Version>5.0.0.2012</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.Forms.PancakeView" Version="2.3.0.759" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/XCT.Sample.Tizen/Xamarin.CommunityToolkit.Sample.Tizen.csproj
+++ b/samples/XCT.Sample.Tizen/Xamarin.CommunityToolkit.Sample.Tizen.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/XCT.Sample.UWP/Xamarin.CommunityToolkit.Sample.UWP.csproj
+++ b/samples/XCT.Sample.UWP/Xamarin.CommunityToolkit.Sample.UWP.csproj
@@ -146,7 +146,6 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.12" />
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
   </ItemGroup>

--- a/samples/XCT.Sample.WPF/Xamarin.CommunityToolkit.Sample.WPF.csproj
+++ b/samples/XCT.Sample.WPF/Xamarin.CommunityToolkit.Sample.WPF.csproj
@@ -110,18 +110,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTK">
-      <Version>3.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="OpenTK.GLControl">
-      <Version>3.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Forms">
-      <Version>5.0.0.2012</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Forms.Platform.WPF">
-      <Version>5.0.0.2012</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.Forms.PancakeView" Version="2.3.0.759" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/samples/XCT.Sample.iOS/Xamarin.CommunityToolkit.Sample.iOS.csproj
+++ b/samples/XCT.Sample.iOS/Xamarin.CommunityToolkit.Sample.iOS.csproj
@@ -139,11 +139,8 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
-    <PackageReference Include="Xamarin.Forms.PancakeView">
-      <Version>2.3.0.759</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Forms.PancakeView" Version="2.3.0.759" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
+++ b/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />  
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Xamarin.Forms.DebugRainbows" Version="1.1.4" />

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Xamarin.CommunityToolkit.UnitTests.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Xamarin.CommunityToolkit.UnitTests.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Semantic/SemanticEffectRouter.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Semantic/SemanticEffectRouter.android.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel;
 using Android.Widget;
 using AndroidX.Core.View;
-using AndroidX.Core.View.Accessibiity;
+using AndroidX.Core.View.Accessibility;
 using Xamarin.CommunityToolkit.Effects;
 using Xamarin.Forms;
 using Effects = Xamarin.CommunityToolkit.Android.Effects;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
@@ -64,8 +64,8 @@
     <Compile Include="**/*.shared.*.cs" />
     <None Include="..\..\..\LICENSE" PackagePath="" Pack="true" />
     <None Include="..\..\..\assets\XamarinCommunityToolkit_128x128.png" PackagePath="icon.png" Pack="true" />
-    <PackageReference Include="Xamarin.Forms" Version="[5.0.0.1874, 5.0.0.2012]" />
-    <PackageReference Include="mdoc" Version="5.8.0" PrivateAssets="all" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2083" />
+    <PackageReference Include="mdoc" Version="5.8.3" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <Compile Include="**/*.netstandard.cs" />
@@ -141,7 +141,7 @@
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('tizen')) ">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="SkiaSharp.Views" Version="2.80.2" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.80.3" />
     <Compile Include="**\*.tizen.cs" />
     <Compile Include="**\*.tizen.*.cs" />
   </ItemGroup>
@@ -154,20 +154,20 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.1874" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2083" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) AND '$(OS)' == 'Windows_NT' ">
     <Compile Include="**\*.wpf.cs" />
     <Compile Include="**\*.wpf.*.cs" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.1874" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2083" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net471')) ">
     <Compile Include="**\*.gtk.cs" />
     <Compile Include="**\*.gtk.*.cs" />
-    <PackageReference Include="Xamarin.Forms.Platform.GTK" Version="5.0.0.1874" />
+    <PackageReference Include="Xamarin.Forms.Platform.GTK" Version="5.0.0.2083" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Markup/Xamarin.CommunityToolkit.Markup.UnitTests/Xamarin.CommunityToolkit.Markup.UnitTests.csproj
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup.UnitTests/Xamarin.CommunityToolkit.Markup.UnitTests.csproj
@@ -6,13 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
@@ -33,8 +33,8 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.1874" />
-    <PackageReference Include="mdoc" Version="5.8.0" PrivateAssets="all" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2083" />
+    <PackageReference Include="mdoc" Version="5.8.3" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\LICENSE" PackagePath="" Pack="true" />


### PR DESCRIPTION
This Pull Request increases the Xamarin.Forms dependency to v5.0.0.2083.

This is required to accommodate a breaking change introduced in Xamarin.Forms v5.0.0.2083, as noted in the [Release Notes for `Xamarin.CommunityToolkit v1.2.0`](https://github.com/xamarin/XamarinCommunityToolkit/releases/tag/1.2.0):
> The upcoming version of Xamarin.Forms induces a breaking change in Xamarin.CommmunityToolkit by [increasing its `Xamarin.AndroidX.Core` dependency](https://github.com/xamarin/Xamarin.Forms/pull/14101/files#diff-a10b47d2a1fb6f9a0f879b70a6b268191496328089b0bd5776fcbd68759d59dbR25). 
>
> In our next release, v1.3.0, we will increase our Xamarin.Forms dependency to use this new version of Xamarin.Forms and resolve the breaking changes.