### PR TITLE
Fix ObjectDisposedException in Platform Touch Effect on Android

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
@@ -10,6 +10,7 @@ using Android.Views.Accessibility;
 using Android.Widget;
 using Xamarin.CommunityToolkit.Android.Effects;
 using Xamarin.CommunityToolkit.Effects;
+using Xamarin.CommunityToolkit.Extensions;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 using AView = Android.Views.View;
@@ -45,9 +46,11 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			&& accessibilityManager.IsEnabled
 			&& accessibilityManager.IsTouchExplorationEnabled;
 
-		bool IsForegroundRippleWithTapGestureRecognizer => View.Foreground == ripple
-			&& Element is XView view
-			&& view.GestureRecognizers.Any(gesture => gesture is TapGestureRecognizer);
+		bool IsForegroundRippleWithTapGestureRecognizer
+			=> View.IsAlive() &&
+				View.Foreground == ripple &&
+				Element is XView view &&
+				view.GestureRecognizers.Any(gesture => gesture is TapGestureRecognizer);
 
 		protected override void OnAttached()
 		{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
@@ -47,7 +47,9 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 			&& accessibilityManager.IsTouchExplorationEnabled;
 
 		bool IsForegroundRippleWithTapGestureRecognizer
-			=> View.IsAlive() &&
+			=> ripple != null &&
+				ripple.IsAlive() &&
+				View.IsAlive() &&
 				View.Foreground == ripple &&
 				Element is XView view &&
 				view.GestureRecognizers.Any(gesture => gesture is TapGestureRecognizer);


### PR DESCRIPTION
### Description of Change ###
Attempt to fix ObjectDisposedException that is raised by IsForegroundRippleWithTapGestureRecognizer invocation.


### Bugs Fixed ###
- Fixes #1505

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [X] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
