### PR TITLE
Fix TouchEffect inside ScrollView

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.ios.cs
@@ -192,6 +192,9 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 			if (effect?.Status != status)
 				HandleTouch(status).SafeFireAndForget();
 
+			if (status == TouchStatus.Canceled)
+				IsCanceled = true;
+
 			base.TouchesMoved(touches, evt);
 		}
 
@@ -267,13 +270,8 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 			if (gestureRecognizer is TouchUITapGestureRecognizer touchGesture && otherGestureRecognizer is UIPanGestureRecognizer &&
 				otherGestureRecognizer.State == UIGestureRecognizerState.Began)
 			{
-				touchGesture.HandleTouch(TouchStatus.Canceled, TouchInteractionStatus.Completed).ContinueWith(task =>
-				{
-					if (task.IsFaulted && task.Exception != null)
-						throw task.Exception;
-
-					touchGesture.IsCanceled = true;
-				});
+				touchGesture.HandleTouch(TouchStatus.Canceled, TouchInteractionStatus.Completed).SafeFireAndForget();
+				touchGesture.IsCanceled = true;
 			}
 
 			return true;


### PR DESCRIPTION
### Description of Change ###
We don't need to wait until HandleTouch is finished (like everywhere else in the file) 

### Bugs Fixed ###
- Fixes #1433

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [X] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
