### PR TITLE
Fix TouchEffect + Command.CanExecute

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.ios.cs
@@ -220,6 +220,8 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 			if (effect?.IsDisabled ?? true)
 				return;
 
+			var canExecuteAction = effect.CanExecute;
+
 			if (interactionStatus == TouchInteractionStatus.Started)
 			{
 				effect?.HandleUserInteraction(TouchInteractionStatus.Started);
@@ -230,7 +232,7 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 			if (interactionStatus.HasValue)
 				effect?.HandleUserInteraction(interactionStatus.Value);
 
-			if (effect == null || (!effect.NativeAnimation && !IsButton) || !effect.CanExecute)
+			if (effect == null || (!effect.NativeAnimation && !IsButton) || (!canExecuteAction && status == TouchStatus.Started))
 				return;
 
 			var control = effect.Element;


### PR DESCRIPTION
### Description of Change ###
CanExecute can be changed during `effect?.HandleTouch(status);` execution. So we need to get the value before that invocation. Also, we always should proceed with native touch handling if the touch is ending (Completed OR Canceled)

### Bugs Fixed ###
- Fixes #1523

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###
- [X] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
