### PR TITLE
 [CameraView] [iOS] Flash does not work fix

### DIFF
--- a/samples/XCT.Sample/Pages/Views/CameraViewPage.xaml
+++ b/samples/XCT.Sample/Pages/Views/CameraViewPage.xaml
@@ -6,15 +6,44 @@
     xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
     xmlns:xct="http://xamarin.com/schemas/2020/toolkit">
     <ScrollView>
-        <StackLayout>
-            <xct:CameraView
-                x:Name="cameraView"
-                CaptureMode="Video"
-                FlashMode="On"
-                HorizontalOptions="FillAndExpand"
-                MediaCaptured="CameraView_MediaCaptured"
-                OnAvailable="CameraView_OnAvailable"
-                VerticalOptions="FillAndExpand" />
+        <Grid RowDefinitions="300, Auto">
+            <Grid ColumnDefinitions="*, *" Grid.Row="0">
+                <xct:CameraView
+                    Grid.Column="0"
+                    x:Name="cameraView"
+                    CaptureMode="Photo"
+                    FlashMode="Off"
+                    HorizontalOptions="FillAndExpand"
+                    MediaCaptured="CameraView_MediaCaptured"
+                    OnAvailable="CameraView_OnAvailable"
+                    VerticalOptions="FillAndExpand" />
+                <Label
+                    Grid.Column="0"
+                    Text="Camera"
+                    HorizontalTextAlignment="Center"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+
+                <Image
+                    Grid.Column="1"
+                    x:Name="previewPicture"
+                    Aspect="AspectFit"
+                    BackgroundColor="LightGray" />
+
+                <xct:MediaElement
+                    Grid.Column="1"
+                    x:Name="previewVideo"
+                    Aspect="AspectFit"
+                    BackgroundColor="LightGray"
+                    IsVisible="false"/>
+                <Label
+                    Grid.Column="1"
+                    Text="Result"
+                    HorizontalTextAlignment="Center"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+            </Grid>
+            
 
             <StackLayout Grid.Row="1" Orientation="Horizontal">
                 <Label x:Name="zoomLabel" />
@@ -29,7 +58,7 @@
                     Value="1" />
             </StackLayout>
 
-            <StackLayout>
+            <StackLayout Grid.Row="2">
                 <Grid ColumnDefinitions="*, *" RowDefinitions="*,*">
                     <StackLayout
                         Grid.Row="0"
@@ -38,7 +67,7 @@
                         Orientation="Horizontal">
                         <Switch
                             Margin="0,0,5,0"
-                            IsToggled="True"
+                            IsToggled="False"
                             Toggled="VideoSwitch_Toggled" />
                         <Label Text="Video" />
                     </StackLayout>
@@ -60,7 +89,7 @@
                         Orientation="Horizontal">
                         <Switch
                             Margin="0,0,5,0"
-                            IsToggled="True"
+                            IsToggled="False"
                             Toggled="FlashSwitch_Toggled" />
                         <Label Text="Flash" />
                     </StackLayout>
@@ -68,16 +97,11 @@
 
                 <Button
                     x:Name="doCameraThings"
-                    Command="{Binding ShutterCommand, Source={x:Reference cameraView}}"
+                    Clicked="DoCameraThings_Clicked"
                     IsEnabled="False"
-                    Text="Start Recording" />
-                <Image
-                    x:Name="previewPicture"
-                    Aspect="AspectFit"
-                    BackgroundColor="LightGray"
-                    HeightRequest="250"
-                    IsVisible="False" />
+                    Text="Snap picture" />
+                
             </StackLayout>
-        </StackLayout>
+        </Grid>
     </ScrollView>
 </pages:BasePage>

--- a/samples/XCT.Sample/Pages/Views/CameraViewPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Views/CameraViewPage.xaml.cs
@@ -74,6 +74,7 @@ namespace Xamarin.CommunityToolkit.Sample.Pages.Views
 				default:
 				case CameraCaptureMode.Default:
 				case CameraCaptureMode.Photo:
+					previewVideo.IsVisible = false;
 					previewPicture.IsVisible = true;
 					previewPicture.Rotation = e.Rotation;
 					previewPicture.Source = e.Image;
@@ -81,6 +82,8 @@ namespace Xamarin.CommunityToolkit.Sample.Pages.Views
 					break;
 				case CameraCaptureMode.Video:
 					previewPicture.IsVisible = false;
+					previewVideo.IsVisible = true;
+					previewVideo.Source = e.Video;
 					doCameraThings.Text = "Start Recording";
 					break;
 			}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/CameraViewRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/CameraViewRenderer.ios.cs
@@ -29,11 +29,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				Control.Available += OnAvailability;
 				Control.FinishCapture += FinishCapture;
 
-				Control.SwitchFlash(Element.FlashMode);
 				Control.SetBounds(Element.WidthRequest, Element.HeightRequest);
 				Control.VideoStabilization = Element.VideoStabilization;
 				Control.Zoom = (float)Element.Zoom;
 				Control.RetrieveCameraDevice(Element.CameraOptions);
+				Control.SwitchFlash(Element.FlashMode);
 			}
 
 			if (e.OldElement != null)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
@@ -203,6 +203,13 @@ namespace Xamarin.CommunityToolkit.UI.Views
 					photoOutputConnection.VideoOrientation = previewLayer.Connection?.VideoOrientation ?? throw new NullReferenceException();
 
 				var photoSettings = AVCapturePhotoSettings.Create();
+
+				// Torch is set somewhere different
+				if (flashMode != CameraFlashMode.Torch)
+				{
+					photoSettings.FlashMode = (AVCaptureFlashMode)flashMode;
+				}
+
 				photoSettings.IsHighResolutionPhotoEnabled = true;
 
 				var photoCaptureDelegate = new PhotoCaptureDelegate

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/iOS/FormsCameraView.ios.cs
@@ -203,7 +203,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 					photoOutputConnection.VideoOrientation = previewLayer.Connection?.VideoOrientation ?? throw new NullReferenceException();
 
 				var photoSettings = AVCapturePhotoSettings.Create();
-				photoSettings.FlashMode = (AVCaptureFlashMode)flashMode;
 				photoSettings.IsHighResolutionPhotoEnabled = true;
 
 				var photoCaptureDelegate = new PhotoCaptureDelegate


### PR DESCRIPTION
### Description of Change ###

Switched setting the flash mode to after the camera is being initialised to make it work when it's set from XAML or anywhere before it is available. Additionally made an exception for the torch when taking a picture as that's not an "official" supported flash mode.

### Bugs Fixed ###

- Fixes #747

### API Changes ###

NA

### Behavioral Changes ###

Nothing notable except that before it wasn't working or even crashing, now it all works!

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [x] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
