### PR TITLE
Added Speed Property to mediaelement

### DIFF
--- a/samples/XCT.Sample/Pages/Views/MediaElementPage.xaml
+++ b/samples/XCT.Sample/Pages/Views/MediaElementPage.xaml
@@ -1,28 +1,55 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
-                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
-                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
-                x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.MediaElementPage">
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<pages:BasePage
+    x:Class="Xamarin.CommunityToolkit.Sample.Pages.Views.MediaElementPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+    xmlns:xct="http://xamarin.com/schemas/2020/toolkit">
     <pages:BasePage.Resources>
-        <xct:TimeSpanToDoubleConverter x:Key="TimeSpanConverter"/>
+        <xct:TimeSpanToDoubleConverter x:Key="TimeSpanConverter" />
     </pages:BasePage.Resources>
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <xct:MediaElement
             x:Name="mediaElement"
-            Source="https://sec.ch9.ms/ch9/5d93/a1eab4bf-3288-4faf-81c4-294402a85d93/XamarinShow_mid.mp4"
-            ShowsPlaybackControls="True"
-            MediaOpened="OnMediaOpened"
-            MediaFailed="OnMediaFailed"
-            MediaEnded="OnMediaEnded"
             HorizontalOptions="Fill"
-            SeekCompleted="OnSeekCompleted" />
-        <Slider Grid.Row="1" BindingContext="{x:Reference mediaElement}" Value="{Binding Position, Converter={StaticResource TimeSpanConverter}}" Maximum="{Binding Duration, Converter={StaticResource TimeSpanConverter}}"/>
-        <Button Grid.Row="2" Text="Reset Source (Set Null)" Clicked="OnResetClicked" />
+            MediaEnded="OnMediaEnded"
+            MediaFailed="OnMediaFailed"
+            MediaOpened="OnMediaOpened"
+            SeekCompleted="OnSeekCompleted"
+            ShowsPlaybackControls="True"
+            Source="https://sec.ch9.ms/ch9/5d93/a1eab4bf-3288-4faf-81c4-294402a85d93/XamarinShow_mid.mp4" />
+        <Slider
+            Grid.Row="1"
+            BindingContext="{x:Reference mediaElement}"
+            Maximum="{Binding Duration, Converter={StaticResource TimeSpanConverter}}"
+            Value="{Binding Position, Converter={StaticResource TimeSpanConverter}}" />
+        <Button
+            Grid.Row="2"
+            Clicked="OnResetClicked"
+            Text="Reset Source (Set Null)" />
+        <Label Grid.Row="3" Margin="20,10">
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="Speed:" />
+                    <Span Text="{Binding Source={x:Reference mediaElement}, Path=Speed}" />
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+        <Slider
+            x:Name="MainSlider"
+            Grid.Row="4"
+            Margin="20"
+            DragCompleted="Slider_DragCompleted"
+            Maximum="2"
+            Minimum=".5"
+            ThumbColor="Blue"
+            Value="{Binding Source={x:Reference mediaElement}, Path=Speed}" />
     </Grid>
 </pages:BasePage>

--- a/samples/XCT.Sample/Pages/Views/MediaElementPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Views/MediaElementPage.xaml.cs
@@ -15,5 +15,11 @@ namespace Xamarin.CommunityToolkit.Sample.Pages.Views
 		void OnSeekCompleted(object? sender, EventArgs e) => Console.WriteLine("Seek completed.");
 
 		void OnResetClicked(object? sender, EventArgs e) => mediaElement.Source = null;
+
+
+		private void Slider_DragCompleted(object sender, EventArgs e)
+		{
+			mediaElement.Speed = MainSlider.Value;
+		}
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
@@ -278,6 +278,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				case nameof(MediaElement.Volume):
 					UpdateVolume();
 					break;
+				case nameof(MediaElement.Speed):
+					UpdateSpeed();
+					break;
 			}
 
 			ElementPropertyChanged?.Invoke(this, e);
@@ -372,6 +375,17 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			mediaPlayer?.SetVolume((float)MediaElement.Volume, (float)MediaElement.Volume);
 		}
+		protected void UpdateSpeed()
+		{
+			if (MediaElement == null)
+				return;
+
+			var playbackParams = new PlaybackParams();
+			playbackParams.SetSpeed((float)MediaElement.Speed);
+			if (mediaPlayer != null)
+				mediaPlayer.PlaybackParams = playbackParams;
+			var sp = mediaPlayer?.PlaybackParams.Speed;
+		}
 
 		protected string ResolveMsAppDataUri(Uri uri)
 		{
@@ -411,6 +425,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			mediaPlayer = mp;
 			UpdateVolume();
+			UpdateSpeed();
 			mp.Looping = MediaElement.IsLooping;
 			mp.SeekTo(0);
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
@@ -377,13 +377,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		}
 		protected void UpdateSpeed()
 		{
-			if (MediaElement == null)
+			if (MediaElement == null || mediaPlayer == null)
 				return;
 
 			var playbackParams = new PlaybackParams();
 			playbackParams.SetSpeed((float)MediaElement.Speed);
-			if (mediaPlayer != null)
-				mediaPlayer.PlaybackParams = playbackParams;
+			mediaPlayer.PlaybackParams = playbackParams;
 		}
 
 		protected string ResolveMsAppDataUri(Uri uri)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
@@ -384,7 +384,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			playbackParams.SetSpeed((float)MediaElement.Speed);
 			if (mediaPlayer != null)
 				mediaPlayer.PlaybackParams = playbackParams;
-			var sp = mediaPlayer?.PlaybackParams.Speed;
 		}
 
 		protected string ResolveMsAppDataUri(Uri uri)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs
@@ -48,7 +48,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		  BindableProperty.Create(nameof(Volume), typeof(double), typeof(MediaElement), 1.0, BindingMode.TwoWay, new BindableProperty.ValidateValueDelegate(ValidateVolume));
 		
 		public static readonly BindableProperty SpeedProperty =
-		  BindableProperty.Create(nameof(Speed), typeof(double), typeof(MediaElement), 1.0, BindingMode.TwoWay);
+		  BindableProperty.Create(nameof(Speed), typeof(double), typeof(MediaElement), 1.0, BindingMode.OneWay);
 
 		public Aspect Aspect
 		{
@@ -187,11 +187,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			get => (double)GetValue(VolumeProperty);
 			set => SetValue(VolumeProperty, value);
 		}
-		double IMediaElementController.Speed
-		{
-			get => (double)GetValue(SpeedProperty);
-			set => SetValue(SpeedProperty, value);
-		}
 
 		void IMediaElementController.OnMediaEnded()
 		{
@@ -327,7 +322,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		int VideoWidth { get; set; }
 
 		double Volume { get; set; }
-		double Speed { get; set; }
 
 		void OnMediaEnded();
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs
@@ -187,6 +187,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			get => (double)GetValue(VolumeProperty);
 			set => SetValue(VolumeProperty, value);
 		}
+		double IMediaElementController.Speed
+		{
+			get => (double)GetValue(SpeedProperty);
+			set => SetValue(SpeedProperty, value);
+		}
 
 		void IMediaElementController.OnMediaEnded()
 		{
@@ -322,6 +327,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		int VideoWidth { get; set; }
 
 		double Volume { get; set; }
+		double Speed { get; set; }
 
 		void OnMediaEnded();
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs
@@ -187,11 +187,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			get => (double)GetValue(VolumeProperty);
 			set => SetValue(VolumeProperty, value);
 		}
-		double IMediaElementController.Speed
-		{
-			get => (double)GetValue(SpeedProperty);
-			set => SetValue(SpeedProperty, value);
-		}
 
 		void IMediaElementController.OnMediaEnded()
 		{
@@ -327,7 +322,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		int VideoWidth { get; set; }
 
 		double Volume { get; set; }
-		double Speed { get; set; }
 
 		void OnMediaEnded();
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs
@@ -46,6 +46,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		public static readonly BindableProperty VolumeProperty =
 		  BindableProperty.Create(nameof(Volume), typeof(double), typeof(MediaElement), 1.0, BindingMode.TwoWay, new BindableProperty.ValidateValueDelegate(ValidateVolume));
+		
+		public static readonly BindableProperty SpeedProperty =
+		  BindableProperty.Create(nameof(Speed), typeof(double), typeof(MediaElement), 1.0, BindingMode.TwoWay);
 
 		public Aspect Aspect
 		{
@@ -117,6 +120,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			get => (double)GetValue(VolumeProperty);
 			set => SetValue(VolumeProperty, value);
 		}
+		public double Speed
+		{
+			get => (double)GetValue(SpeedProperty);
+			set => SetValue(SpeedProperty, value);
+		}
 
 		internal event EventHandler<SeekRequested>? SeekRequested;
 
@@ -178,6 +186,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		{
 			get => (double)GetValue(VolumeProperty);
 			set => SetValue(VolumeProperty, value);
+		}
+		double IMediaElementController.Speed
+		{
+			get => (double)GetValue(SpeedProperty);
+			set => SetValue(SpeedProperty, value);
 		}
 
 		void IMediaElementController.OnMediaEnded()
@@ -314,6 +327,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		int VideoWidth { get; set; }
 
 		double Volume { get; set; }
+		double Speed { get; set; }
 
 		void OnMediaEnded();
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
@@ -258,6 +258,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				case nameof(ToolKitMediaElement.Volume):
 					UpdateVolume();
 					break;
+				case nameof(ToolKitMediaElement.Speed):
+					UpdateSpeed();
+					break;
 			}
 		}
 
@@ -308,6 +311,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		{
 			if (avPlayerViewController.Player != null)
 				avPlayerViewController.Player.Volume = (float)Element.Volume;
+		}
+		void UpdateSpeed()
+		{
+			if (avPlayerViewController.Player != null)
+				avPlayerViewController.Player.Rate = (float)Element.Speed;
 		}
 
 		void MediaElementStateRequested(object? sender, StateRequested e)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
@@ -147,7 +147,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 						Controller.CurrentState = MediaElementState.Paused;
 						break;
 
-					case 1.0f:
+					default:
 						Controller.CurrentState = MediaElementState.Playing;
 						break;
 				}
@@ -177,7 +177,6 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 				case AVPlayerStatus.ReadyToPlay:
 					var duration = avPlayerViewController.Player.CurrentItem.Duration;
-
 					if (duration.IsIndefinite)
 						Controller.Duration = TimeSpan.Zero;
 					else
@@ -301,6 +300,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			{
 				avPlayerViewController.Player.Play();
 				Controller.CurrentState = MediaElementState.Playing;
+				UpdateSpeed();
 			}
 
 			if (Element.KeepScreenOn)


### PR DESCRIPTION
### Description of Change ###

See all details in #1415 , just doing this takeover because I didn't want to burden the original author with _another_ rebase.

### Bugs Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Closes #1415 
- Fixes #649 

### API Changes ###

Added: 
 
- `double MediaElement.Speed` bindable property

### Behavioral Changes ###

User now has extra property to influence the playback speed

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [x] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
