### PR TITLE
Increase Xamarin.Forms Dependency to v5.0.0.2125

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
@@ -64,7 +64,7 @@
     <Compile Include="**/*.shared.*.cs" />    
     <None Include="..\..\..\LICENSE" PackagePath="" Pack="true" />
     <None Include="..\..\..\assets\XamarinCommunityToolkit_128x128.png" PackagePath="icon.png" Pack="true" />
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2083" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />
     <PackageReference Include="mdoc" Version="5.8.3" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
@@ -154,20 +154,20 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="WindowsBase" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2083" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2125" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) AND '$(OS)' == 'Windows_NT' ">
     <Compile Include="**\*.wpf.cs" />
     <Compile Include="**\*.wpf.*.cs" />
-    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2083" />
+    <PackageReference Include="Xamarin.Forms.Platform.WPF" Version="5.0.0.2125" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net471')) ">
     <Compile Include="**\*.gtk.cs" />
     <Compile Include="**\*.gtk.*.cs" />
-    <PackageReference Include="Xamarin.Forms.Platform.GTK" Version="5.0.0.2083" />
+    <PackageReference Include="Xamarin.Forms.Platform.GTK" Version="5.0.0.2125" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <Reference Include="atk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
+++ b/src/Markup/Xamarin.CommunityToolkit.Markup/Xamarin.CommunityToolkit.Markup.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2083" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2125" />
     <PackageReference Include="mdoc" Version="5.8.3" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This Pull Request increases the Xamarin.Forms dependency to v5.0.0.2125.

This new service release of Xamarin.Forms increases the allowed `Xamarin.AndroidX.*` library versions, allowing for greater flexibility for Xamarin Community Toolkit users.  E.g. In the previous version of Xamarin.Forms, the maximum version of  `Xamarin.AndroidX.Core` was `1.4.0`; in this new version of Xamarin.Forms, it is increased to `1.7.0`. (see chart below)

The previous version of Xamarin.Forms (v5.0.0.2083) added upper limits to the  `Xamarin.AndroidX.*` libraries which induced conflicts with other NuGet libraries, [as explained in greater detail here](https://github.com/xamarin/Xamarin.Forms/issues/14417#issuecomment-921149849). 

Because we have [already increased our Xamarin.Forms dependency to v5.0.0.2083](https://github.com/xamarin/XamarinCommunityToolkit/pull/1502) in the prerelease of v1.3.0 (e.g. the Xamarin.Forms dependency increase hasn't yet been promoted to stable), we can easily increase it again to v5.0.02125 before releasing v1.3.0 stable.

## Android Dependencies

| Xamarin.Forms v5.0.0.2083 (Current) | Xamarin.Forms v5.0.0.2125 (Updated) |
| --------------------------- | --------------------------- |
| <img width="467" alt="Screen Shot 2021-09-20 at 2 50 19 PM" src="https://user-images.githubusercontent.com/13558917/134080821-4a40b78d-a166-4e47-ac2c-665f39429075.png"> |  <img width="462" alt="Screen Shot 2021-09-20 at 2 50 23 PM" src="https://user-images.githubusercontent.com/13558917/134080835-ee9c6723-99ce-4cc8-be18-dd8aae48d7a9.png"> |

## Xamarin.CommunityToolkit Dependency

| |  Xamarin.CommunityToolkit v1.2.0 (Current Stable) | Xamarin.CommunityToolkit v1.3.0-pre2 (Current Prerelease) | Xamarin.CommunityToolkit vNext |
| -- | -- | -- | -- |
| Xamarin.Forms Dependency |  >= 5.0.0.1874 && <= 5.0.0.2012 | >= 5.0.0.2083 | >= 5.0.0.2125 |