### PR TITLE
Add EdgeInsetsExtension

### DIFF
--- a/samples/XCT.Sample.GTK/Xamarin.CommunityToolkit.Sample.GTK.csproj
+++ b/samples/XCT.Sample.GTK/Xamarin.CommunityToolkit.Sample.GTK.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Xamarin.CommunityToolkit.Sample.GTK</RootNamespace>
     <AssemblyName>Xamarin.CommunityToolkit.Sample.GTK</AssemblyName>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/samples/XCT.Sample.GTK/app.config
+++ b/samples/XCT.Sample.GTK/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/samples/XCT.Sample/Pages/Extensions/EdgeInsetsExtensionPage.xaml
+++ b/samples/XCT.Sample/Pages/Extensions/EdgeInsetsExtensionPage.xaml
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<pages:BasePage 
+    x:Name="Page"
+    x:Class="Xamarin.CommunityToolkit.Sample.Pages.Effects.EdgeInsetsExtensionPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages">
+
+    <StackLayout >
+        <Label 
+            Margin="{xct:EdgeInsets 
+                Horizontal=24,
+                Vertical=40}"
+            FontSize="Title"
+            Text="Defining a padding/marging using EdgeInsetsExtension"/>
+        <Label 
+            Margin="{xct:EdgeInsets 
+                Horizontal=24,
+                Vertical=40}"
+            Text="{{xct:EdgeInsets All=16}}"/>
+        <BoxView
+            Margin="{xct:EdgeInsets 
+                All=16}"
+            WidthRequest="50"
+            HeightRequest="50"
+            BackgroundColor="Purple"
+            Source="{xct:ImageResource Id=Xamarin.CommunityToolkit.Sample.Images.logo.png}"/>
+
+        <Label 
+            Margin="{xct:EdgeInsets 
+                Horizontal=24,
+                Vertical=40}"
+            Text="{{xct:EdgeInsets Horizontal=16}}"/>
+        <BoxView
+            Margin="{xct:EdgeInsets 
+                Horizontal=16}"
+            WidthRequest="50"
+            HeightRequest="50"
+            BackgroundColor="Orange"
+            Source="{xct:ImageResource Id=Xamarin.CommunityToolkit.Sample.Images.logo.png}"/>
+
+        <Label 
+            Margin="{xct:EdgeInsets 
+                Horizontal=24,
+                Vertical=40}"
+            Text="{{xct:EdgeInsets Vertical=16}}"/>
+        <BoxView
+            Margin="{xct:EdgeInsets 
+                Vertical=16}"
+            WidthRequest="50"
+            HeightRequest="50"
+            BackgroundColor="DarkGrey"
+            Source="{xct:ImageResource Id=Xamarin.CommunityToolkit.Sample.Images.logo.png}"/>
+
+        <Label 
+            Margin="{xct:EdgeInsets 
+                Horizontal=24,
+                Vertical=40}"
+            Text="{{xct:EdgeInsets Top=16, Bottom=40, Left=56, Right=32}}"/>
+        <BoxView
+            Margin="{xct:EdgeInsets 
+                Top=16, Bottom=40,
+                Left=56, Right=32}"
+            WidthRequest="50"
+            HeightRequest="50"
+            BackgroundColor="DarkGrey"
+            Source="{xct:ImageResource Id=Xamarin.CommunityToolkit.Sample.Images.logo.png}"/>
+    </StackLayout>
+</pages:BasePage>

--- a/samples/XCT.Sample/Pages/Extensions/EdgeInsetsExtensionPage.xaml
+++ b/samples/XCT.Sample/Pages/Extensions/EdgeInsetsExtensionPage.xaml
@@ -13,58 +13,54 @@
                 Horizontal=24,
                 Vertical=40}"
             FontSize="Title"
-            Text="Defining a padding/marging using EdgeInsetsExtension"/>
+            Text="Defining a padding/margin using EdgeInsetsExtension"/>
         <Label 
             Margin="{xct:EdgeInsets 
                 Horizontal=24,
                 Vertical=40}"
-            Text="{{xct:EdgeInsets All=16}}"/>
+            Text="{}{xct:EdgeInsets All=16}"/>
         <BoxView
             Margin="{xct:EdgeInsets 
                 All=16}"
             WidthRequest="50"
             HeightRequest="50"
-            BackgroundColor="Purple"
-            Source="{xct:ImageResource Id=Xamarin.CommunityToolkit.Sample.Images.logo.png}"/>
+            BackgroundColor="Purple"/>
 
         <Label 
             Margin="{xct:EdgeInsets 
                 Horizontal=24,
                 Vertical=40}"
-            Text="{{xct:EdgeInsets Horizontal=16}}"/>
+            Text="{}{xct:EdgeInsets Horizontal=16}"/>
         <BoxView
             Margin="{xct:EdgeInsets 
                 Horizontal=16}"
             WidthRequest="50"
             HeightRequest="50"
-            BackgroundColor="Orange"
-            Source="{xct:ImageResource Id=Xamarin.CommunityToolkit.Sample.Images.logo.png}"/>
+            BackgroundColor="Orange"/>
 
         <Label 
             Margin="{xct:EdgeInsets 
                 Horizontal=24,
                 Vertical=40}"
-            Text="{{xct:EdgeInsets Vertical=16}}"/>
+            Text="{}{xct:EdgeInsets Vertical=16}"/>
         <BoxView
             Margin="{xct:EdgeInsets 
                 Vertical=16}"
             WidthRequest="50"
             HeightRequest="50"
-            BackgroundColor="DarkGrey"
-            Source="{xct:ImageResource Id=Xamarin.CommunityToolkit.Sample.Images.logo.png}"/>
+            BackgroundColor="DarkGray"/>
 
         <Label 
             Margin="{xct:EdgeInsets 
                 Horizontal=24,
                 Vertical=40}"
-            Text="{{xct:EdgeInsets Top=16, Bottom=40, Left=56, Right=32}}"/>
+            Text="{}{xct:EdgeInsets Top=16, Bottom=40, Left=56, Right=32}"/>
         <BoxView
             Margin="{xct:EdgeInsets 
                 Top=16, Bottom=40,
                 Left=56, Right=32}"
             WidthRequest="50"
             HeightRequest="50"
-            BackgroundColor="DarkGrey"
-            Source="{xct:ImageResource Id=Xamarin.CommunityToolkit.Sample.Images.logo.png}"/>
+            BackgroundColor="DarkCyan"/>
     </StackLayout>
 </pages:BasePage>

--- a/samples/XCT.Sample/Pages/Extensions/EdgetInsetsExtensionPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/Extensions/EdgetInsetsExtensionPage.xaml.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.Effects
+{
+	public partial class EdgeInsetsExtensionPage
+	{
+		public EdgeInsetsExtensionPage() => InitializeComponent();
+	}
+}

--- a/samples/XCT.Sample/ViewModels/Extensions/ExtensionsGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/Extensions/ExtensionsGalleryViewModel.cs
@@ -13,6 +13,10 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.Effects
 				typeof(ImageResourceExtensionPage),
 				nameof(ImageResourceExtension),
 				"A XAML extension that helps to display images from embedded resources"),
+			new SectionModel(
+				typeof(EdgeInsetsExtensionPage),
+				nameof(EdgeInsetsExtension),
+				"A XAML extension that helps to declare a padding/margin with ease"),
 		};
 	}
 }

--- a/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
+++ b/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
@@ -11,6 +11,9 @@
     <None Remove="resources\**" />
     <EmbeddedResource Include="Images\**" />
     <EmbeddedResource Include="Fonts\**" />
+    <Compile Update="Pages\Extensions\EdgetInsetsExtensionPage.xaml.cs">
+      <DependentUpon>EdgeInsetsExtensionPage.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Extensions/EdgeInsetsExtension_Tests.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit.UnitTests/Extensions/EdgeInsetsExtension_Tests.cs
@@ -1,0 +1,192 @@
+using System;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.CommunityToolkit.Extensions;
+
+namespace Xamarin.CommunityToolkit.UnitTests.Extensions
+{
+    public class EdgeInsetsExtension_Tests
+
+    {
+        [TestCase(1, 2, 3)]
+        public void Top_ShouldReturnSpecifiedSpacing(double value, double alternative1, double alternative2)
+        {
+            var sut = new EdgeInsetsExtension
+            {
+                Top = value,
+                Vertical = alternative1,
+                All = alternative2
+            };
+
+            var result = (Thickness)sut.ProvideValue(null);
+            
+            Assert.AreEqual(value, result.Top);
+        }
+        
+        [TestCase(double.MinValue, 2, 3)]
+        public void Top_ShouldReturnVerticalSpacing(double value, double alternative1, double alternative2)
+        {
+            var sut = new EdgeInsetsExtension
+            {
+                Top = value,
+                Vertical = alternative1,
+                All = alternative2
+            };
+
+            var result = (Thickness)sut.ProvideValue(null);
+            
+            Assert.AreEqual(alternative1, result.Top);
+        }
+        
+        [TestCase(double.MinValue, double.MinValue, 3)]
+        public void Top_ShouldReturnDefaultSpacing(double value, double alternative1, double alternative2)
+        {
+            var sut = new EdgeInsetsExtension
+            {
+                Top = value,
+                Vertical = alternative1,
+                All = alternative2
+            };
+
+            var result = (Thickness)sut.ProvideValue(null);
+            
+            Assert.AreEqual(alternative2, result.Top);
+        }
+        
+        [TestCase(1, 2, 3)]
+        public void Bottom_ShouldReturnSpecifiedSpacing(double value, double alternative1, double alternative2)
+        {
+            var sut = new EdgeInsetsExtension
+            {
+                Bottom = value,
+                Vertical = alternative1,
+                All = alternative2
+            };
+
+            var result = (Thickness)sut.ProvideValue(null);
+            
+            Assert.AreEqual(value, sut.Bottom);
+            Assert.AreEqual(value, result.Bottom);
+        }
+        
+        [TestCase(double.MinValue, 2, 3)]
+        public void Bottom_ShouldReturnVerticalSpacing(double value, double alternative1, double alternative2)
+        {
+            var sut = new EdgeInsetsExtension
+            {
+                Bottom = value,
+                Vertical = alternative1,
+                All = alternative2
+            };
+
+            var result = (Thickness)sut.ProvideValue(null);
+            
+            Assert.AreEqual(alternative1, result.Bottom);
+        }
+        
+        [TestCase(double.MinValue, double.MinValue, 3)]
+        public void Bottom_ShouldReturnDefaultSpacing(double value, double alternative1, double alternative2)
+        {
+            var sut = new EdgeInsetsExtension
+            {
+                Bottom = value,
+                Vertical = alternative1,
+                All = alternative2
+            };
+
+            var result = (Thickness)sut.ProvideValue(null);
+            
+            Assert.AreEqual(alternative2, result.Bottom);
+        }
+        
+        [TestCase(1, 2, 3)]
+        public void Left_ShouldReturnSpecifiedSpacing(double value, double alternative1, double alternative2)
+        {
+            var sut = new EdgeInsetsExtension
+            {
+                Left = value,
+                Horizontal = alternative1,
+                All = alternative2
+            };
+
+            var result = (Thickness)sut.ProvideValue(null);
+            
+            Assert.AreEqual(value, result.Left);
+        }
+        
+        [TestCase(double.MinValue, 2, 3)]
+        public void Left_ShouldReturnVerticalSpacing(double value, double alternative1, double alternative2)
+        {
+            var sut = new EdgeInsetsExtension
+            {
+                Left = value,
+                Horizontal = alternative1,
+                All = alternative2
+            };
+
+            var result = (Thickness)sut.ProvideValue(null);
+            
+            Assert.AreEqual(alternative1, result.Left);
+        }
+        
+        [TestCase(double.MinValue, double.MinValue, 3)]
+        public void Left_ShouldReturnDefaultSpacing(double value, double alternative1, double alternative2)
+        {
+            var sut = new EdgeInsetsExtension
+            {
+                Left = value,
+                Horizontal = alternative1,
+                All =  alternative2
+            };
+
+            var result = (Thickness)sut.ProvideValue(null);
+            
+            Assert.AreEqual(alternative2, result.Left);
+        }
+        
+        [TestCase(1, 2, 3)]
+        public void Right_ShouldReturnSpecifiedSpacing(double value, double alternative1, double alternative2)
+        {
+            var sut = new EdgeInsetsExtension
+            {
+                Right = value,
+                Horizontal = alternative1,
+                All =  alternative2
+            };
+
+            var result = (Thickness)sut.ProvideValue(null);
+            
+            Assert.AreEqual(value, result.Right);
+        }
+        
+        [TestCase(double.MinValue, 2, 3)]
+        public void Right_ShouldReturnVerticalSpacing(double value, double alternative1, double alternative2)
+        {
+            var sut = new EdgeInsetsExtension
+            {
+                Right = value,
+                Horizontal = alternative1,
+                All =  alternative2
+            };
+
+            var result = (Thickness)sut.ProvideValue(null);
+            
+            Assert.AreEqual(alternative1, result.Right);
+        }
+        
+        [TestCase(double.MinValue, double.MinValue, 3)]
+        public void Right_ShouldReturnDefaultSpacing(double value, double alternative1, double alternative2)
+        {
+            var sut = new EdgeInsetsExtension
+            {
+                Right = value,
+                Horizontal = alternative1,
+                All =  alternative2
+            };
+
+            var result = (Thickness)sut.ProvideValue(null);
+            
+            Assert.AreEqual(alternative2, result.Right);
+        }
+    }
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Extensions/EdgeInsetsExtension.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Extensions/EdgeInsetsExtension.shared.cs
@@ -1,0 +1,43 @@
+using System;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.CommunityToolkit.Extensions
+{
+	/// <summary>
+	/// An extension to declare padding or marging more easily, more conveniently
+	/// </summary>
+	[ContentProperty(nameof(All))]
+	public class EdgeInsetsExtension : IMarkupExtension
+	{
+		public double Top { get; set; } = double.MinValue;
+		public double Left { get; set; } = double.MinValue;
+		public double Right { get; set; } = double.MinValue;
+		public double Bottom { get; set; } = double.MinValue;
+		public double All { get; set; } = 0d;
+		public double Vertical { get; set; } = double.MinValue;
+		public double Horizontal { get; set; } = double.MinValue;
+
+		public object ProvideValue(IServiceProvider serviceProvider)
+		{
+			return new Thickness(
+				GetValue(Left, Horizontal, All),
+				GetValue(Top, Vertical, All),
+				GetValue(Right, Horizontal, All),
+				GetValue(Bottom, Vertical, All)
+			);
+		}
+
+		private double GetValue(double value, double alternative1, double alternative2)
+		{
+			var valueSpecified = Math.Abs(value - double.MinValue) > double.Epsilon;
+			if (valueSpecified)
+			{
+				return value;
+			}
+
+			var alternative1Specified = Math.Abs(alternative1 - double.MinValue) > double.Epsilon;
+			return alternative1Specified ? alternative1 : alternative2;
+		}
+	}
+}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Xamarin.CommunityToolkit.csproj
@@ -215,4 +215,8 @@
   </ItemGroup>
 
   <Import Project="..\..\mdoc.targets" Condition=" '$(OS)' == 'Windows_NT' AND '$(GenerateApiDocs)' == 'true'" />
+
+  <ItemGroup>
+    <None Remove="Extensions\EdgeInsetsExtension.shared.cs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Change ###
Add `EdgeInsetsExtension` to simplify the way of defining a Thickness in XAML.

### Bugs Fixed ###
N/A

### API Changes ###
 
If there is an entirely new API, then you can use a more verbose style:

```xaml
        <Label 
            Margin="{xct:EdgeInsets 
                Horizontal=24,
                Vertical=40}"
            Text="{}{xct:EdgeInsets All=16}"/>
        <BoxView
            Margin="{xct:EdgeInsets 
                All=16}"
            WidthRequest="50"
            HeightRequest="50"
            BackgroundColor="Purple"/>

        <Label 
            Margin="{xct:EdgeInsets 
                Horizontal=24,
                Vertical=40}"
            Text="{}{xct:EdgeInsets Horizontal=16}"/>
        <BoxView
            Margin="{xct:EdgeInsets 
                Horizontal=16}"
            WidthRequest="50"
            HeightRequest="50"
            BackgroundColor="Orange"/>

        <Label 
            Margin="{xct:EdgeInsets 
                Horizontal=24,
                Vertical=40}"
            Text="{}{xct:EdgeInsets Vertical=16}"/>
        <BoxView
            Margin="{xct:EdgeInsets 
                Vertical=16}"
            WidthRequest="50"
            HeightRequest="50"
            BackgroundColor="DarkGray"/>

        <Label 
            Margin="{xct:EdgeInsets 
                Horizontal=24,
                Vertical=40}"
            Text="{}{xct:EdgeInsets Top=16, Bottom=40, Left=56, Right=32}"/>
        <BoxView
            Margin="{xct:EdgeInsets 
                Top=16, Bottom=40,
                Left=56, Right=32}"
            WidthRequest="50"
            HeightRequest="50"
            BackgroundColor="DarkCyan"/>
``` 

### PR Checklist ###
- [ ] Has a linked Issue, and the Issue has been `approved`
- [x] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
