### PR TITLE
Reset shadow if corner radius is changed (iOS & UWP)

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.ios.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.ios.macos.cs
@@ -71,6 +71,7 @@ public class PlatformShadowEffect : PlatformEffect
 			case nameof(VisualElement.Width):
 			case nameof(VisualElement.Height):
 			case nameof(VisualElement.BackgroundColor):
+			case nameof(IBorderElement.CornerRadius):
 				Update(View);
 				break;
 		}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.uwp.cs
@@ -55,6 +55,7 @@ namespace Xamarin.CommunityToolkit.UWP.Effects
 				case nameof(VisualElement.Width):
 				case nameof(VisualElement.Height):
 				case nameof(VisualElement.BackgroundColor):
+				case nameof(IBorderElement.CornerRadius):
 					UpdateShadow();
 					break;
 			}


### PR DESCRIPTION
### Description of Bug ###
Need to reset shadow when corner radius changed for preventing shadow disappearing (e.g. if frame changes corner radius).
This fix was applied to Android, but iOS and UWP is missed for some reason.


### Behavioral Changes ###
None

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [ ] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
