### PR TITLE
Fix build, Fix snackbar action button color on android, fix ios action button font

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Service/DrawingViewService.macos.cs
@@ -26,7 +26,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				return Stream.Null;
 			}
 
-			return image.AsTiff().AsStream();
+			return image.AsTiff()?.AsStream() ?? Stream.Null;
 		}
 
 		/// <summary>
@@ -55,7 +55,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				return Stream.Null;
 			}
 
-			return image.AsTiff().AsStream();
+			return image.AsTiff()?.AsStream() ?? Stream.Null;
 		}
 
 		static NSImage? GetImageInternal(IList<Point> points,

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.android.cs
@@ -98,7 +98,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				}
 
 				var snackActionButtonView = snackBarView.FindViewById<TextView>(Resource.Id.snackbar_action) ?? throw new NullReferenceException();
-				if (arguments.BackgroundColor != Forms.Color.Default)
+				if (action.BackgroundColor != Forms.Color.Default)
 				{
 					snackActionButtonView.SetBackgroundColor(action.BackgroundColor.ToAndroid());
 				}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.ios.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/Snackbar/SnackBar.ios.macos.cs
@@ -102,7 +102,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 				if (action.Font != Font.Default)
 				{
-					actionButton.Font = action.Font.ToUIFont();
+					actionButton.TitleLabel.Font = action.Font.ToUIFont();
 				}
 
 				if (action.ForegroundColor != Color.Default)


### PR DESCRIPTION
<!-- 
### Description of Bug ###

Fix snackbar action button color on android, fix ios action button font

### Issues Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #1678 

### Behavioral Changes ###

snackbar action button on android has correct color

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [ ] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
