### PR TITLE
Fix NRE for a11y semantic heading

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Semantic/SemanticEffectRouter.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Semantic/SemanticEffectRouter.uwp.cs
@@ -23,6 +23,9 @@ namespace Xamarin.CommunityToolkit.UWP.Effects
 
 		protected override void Update(FrameworkElement view, SemanticEffectRouter effect)
 		{
+			if (view == null)
+				return;
+
 			var headingLevel = (AutomationHeadingLevel)((int)SemanticEffect.GetHeadingLevel(Element));
 			AutomationProperties.SetHeadingLevel(view, headingLevel);
 


### PR DESCRIPTION
### Description of Bug ###
Null views were getting passed into the semantic heading, causing an NRE to get thrown and crashing.
Added a null check to account for this

### Behavioral Changes ###
App will no longer crash if one attempts to set a semantic heading on a null view 

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [ ] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
