### PR TITLE
Fix TouchEffect.LongPressCommand causes System.ArgumentNullException when page is popped

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/TouchEffect.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/TouchEffect.shared.cs
@@ -1169,6 +1169,9 @@ namespace Xamarin.CommunityToolkit.Effects
 		internal void RaiseCompleted()
 		{
 			var element = Element;
+			if (element == null)
+				return;
+
 			var parameter = CommandParameter;
 			Command?.Execute(parameter);
 			weakEventManager.RaiseEvent(element, new TouchCompletedEventArgs(parameter), nameof(Completed));
@@ -1177,6 +1180,9 @@ namespace Xamarin.CommunityToolkit.Effects
 		internal void RaiseLongPressCompleted()
 		{
 			var element = Element;
+			if (element == null)
+				return;
+
 			var parameter = LongPressCommandParameter ?? CommandParameter;
 			LongPressCommand?.Execute(parameter);
 			weakEventManager.RaiseEvent(element, new LongPressCompletedEventArgs(parameter), nameof(LongPressCompleted));


### PR DESCRIPTION
### Description of Bug ###
Fix crash on Android when long press command is used for closing modal page

### Issues Fixed ###

- Fixes #1720

### Behavioral Changes ###

### PR Checklist ###
- [X] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
