### PR TITLE
Nullable fixes in DrawingView

### DIFF
--- a/samples/XCT.Sample/Pages/TestCases/DrawingViewInExpanderPage.xaml
+++ b/samples/XCT.Sample/Pages/TestCases/DrawingViewInExpanderPage.xaml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<pages:BasePage
+    x:Class="Xamarin.CommunityToolkit.Sample.Pages.TestCases.DrawingViewInExpanderPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+    xmlns:views="http://xamarin.com/schemas/2020/toolkit">
+
+    <ContentPage.Content>
+        <views:Expander>
+            <views:Expander.Header>
+                <Label Text="Click to expand" />
+            </views:Expander.Header>
+            <views:Expander.Content>
+                <views:DrawingView 
+                    HeightRequest="200"
+                    BackgroundColor="Yellow"
+                    ClearOnFinish="False"
+                    DefaultLineColor="Red" />
+            </views:Expander.Content>
+        </views:Expander>
+
+    </ContentPage.Content>
+
+</pages:BasePage>

--- a/samples/XCT.Sample/Pages/TestCases/DrawingViewInExpanderPage.xaml.cs
+++ b/samples/XCT.Sample/Pages/TestCases/DrawingViewInExpanderPage.xaml.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.CommunityToolkit.Sample.Pages.TestCases
+{
+	public partial class DrawingViewInExpanderPage
+	{
+		public DrawingViewInExpanderPage() => InitializeComponent();
+	}
+}

--- a/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
@@ -48,6 +48,11 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases
 				typeof(SnackBarActionExceptionPage),
 				"SnackBar Action Exception",
 				"Exception in SnackBar's action doesn't crash the app."),
+
+			new SectionModel(
+				typeof(DrawingViewInExpanderPage),
+				"DrawingView in expander",
+				"DrawingView in Expander Page"),
 		};
 	}
 }

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.android.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using Android.Content;
 using Android.Graphics;
@@ -78,20 +79,23 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			base.OnSizeChanged(w, h, oldw, oldh);
 
-			canvasBitmap = Bitmap.CreateBitmap(w, h, Bitmap.Config.Argb8888!)!;
-			drawCanvas = new Canvas(canvasBitmap);
-			LoadLines();
+			canvasBitmap = Bitmap.CreateBitmap(w, h, Bitmap.Config.Argb8888 ?? throw new NullReferenceException("Unable to create Bitmap config"));
+			if (canvasBitmap is not null)
+			{
+				drawCanvas = new Canvas(canvasBitmap);
+				LoadLines();
+			}
 		}
 
 		protected override void OnDraw(Canvas? canvas)
 		{
 			base.OnDraw(canvas);
 
-			if (canvas is not null)
+			if (canvas is not null && canvasBitmap is not null)
 			{
 				Draw(Element.Lines, canvas);
 
-				canvas.DrawBitmap(canvasBitmap!, 0, 0, canvasPaint);
+				canvas.DrawBitmap(canvasBitmap, 0, 0, canvasPaint);
 				canvas.DrawPath(drawPath, drawPaint);
 			}
 		}
@@ -196,7 +200,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			if (drawCanvas is null)
 				return;
 
-			drawCanvas.DrawColor(Element.BackgroundColor.ToAndroid(), PorterDuff.Mode.Clear!);
+			drawCanvas.DrawColor(Element.BackgroundColor.ToAndroid());
 			drawPath.Reset();
 			var lines = Element.Lines;
 			if (lines.Count > 0)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.gtk.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.gtk.cs
@@ -50,17 +50,17 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				SetNativeControl(vBox);
 			}
 
-			if (e.OldElement != null)
+			if (e.OldElement != null && area is not null)
 			{
-				area!.ExposeEvent -= OnDrawingAreaExposed;
+				area.ExposeEvent -= OnDrawingAreaExposed;
 				area.ButtonPressEvent -= OnMousePress;
 				area.ButtonReleaseEvent -= OnMouseRelease;
 				area.MotionNotifyEvent -= OnMouseMotion;
 			}
 
-			if (e.NewElement != null)
+			if (e.NewElement != null && area is not null)
 			{
-				area!.ExposeEvent += OnDrawingAreaExposed;
+				area.ExposeEvent += OnDrawingAreaExposed;
 				area.ButtonPressEvent += OnMousePress;
 				area.ButtonReleaseEvent += OnMouseRelease;
 				area.MotionNotifyEvent += OnMouseMotion;
@@ -82,8 +82,13 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void OnDrawingAreaExposed(object source, ExposeEventArgs args)
 		{
+			if (area is null)
+			{
+				return;
+			}
+
 			Context ctx;
-			using (ctx = CairoHelper.Create(area!.GdkWindow))
+			using (ctx = CairoHelper.Create(area.GdkWindow))
 			{
 				ctx.SetSource(new SurfacePattern(surface));
 				ctx.Paint();
@@ -111,7 +116,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			};
 			previousPoint = point;
 			isDrawing = true;
-			area!.QueueDraw();
+			area?.QueueDraw();
 			if (!Element.MultiLineMode)
 				Element.Lines.Clear();
 		}
@@ -125,7 +130,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			using var ctx = new Context(surface);
 			DrawPoint(ctx, point);
 
-			area!.QueueDraw();
+			area?.QueueDraw();
 			if (currentLine != null)
 			{
 				Element.Lines.Add(currentLine);
@@ -146,19 +151,23 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				using var ctx = new Context(surface);
 				DrawPoint(ctx, point);
 
-				area!.QueueDraw();
+				area?.QueueDraw();
 			}
 		}
 
 		void DrawPoint(Context ctx, PointD pointD)
 		{
-			ctx.SetSourceRGBA(currentLine!.LineColor.R, currentLine!.LineColor.G, currentLine!.LineColor.B, currentLine!.LineColor.A);
-			ctx.LineWidth = currentLine.LineWidth;
+			if (currentLine is not null)
+			{
+				ctx.SetSourceRGBA(currentLine.LineColor.R, currentLine.LineColor.G, currentLine.LineColor.B, currentLine.LineColor.A);
+				ctx.LineWidth = currentLine.LineWidth;
+			}
+
 			ctx.MoveTo(previousPoint);
 			previousPoint = pointD;
 			ctx.LineTo(pointD);
 			ctx.Stroke();
-			currentLine.Points.Add(new Point(pointD.X, pointD.Y));
+			currentLine?.Points.Add(new Point(pointD.X, pointD.Y));
 		}
 
 		void LoadPoints(ImageSurface imageSurface)
@@ -177,7 +186,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 						foreach (var stylusPoint in stylusPoints)
 							DrawPoint(ctx, stylusPoint);
 
-						area!.QueueDraw();
+						area?.QueueDraw();
 					}
 				}
 			}
@@ -190,12 +199,16 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			if (disposing)
 			{
-				area!.ExposeEvent -= OnDrawingAreaExposed;
-				area.ButtonPressEvent -= OnMousePress;
-				area.ButtonReleaseEvent -= OnMouseRelease;
-				area.MotionNotifyEvent -= OnMouseMotion;
-				area.Dispose();
-				surface!.Dispose();
+				if (area is not null)
+				{
+					area.ExposeEvent -= OnDrawingAreaExposed;
+					area.ButtonPressEvent -= OnMousePress;
+					area.ButtonReleaseEvent -= OnMouseRelease;
+					area.MotionNotifyEvent -= OnMouseMotion;
+					area.Dispose();
+				}
+				
+				surface?.Dispose();
 				if (Element != null)
 					Element.Lines.CollectionChanged -= OnLinesCollectionChanged;
 			}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.gtk.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.gtk.cs
@@ -161,13 +161,13 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			{
 				ctx.SetSourceRGBA(currentLine.LineColor.R, currentLine.LineColor.G, currentLine.LineColor.B, currentLine.LineColor.A);
 				ctx.LineWidth = currentLine.LineWidth;
+				currentLine.Points.Add(new Point(pointD.X, pointD.Y));
 			}
 
 			ctx.MoveTo(previousPoint);
 			previousPoint = pointD;
 			ctx.LineTo(pointD);
-			ctx.Stroke();
-			currentLine?.Points.Add(new Point(pointD.X, pointD.Y));
+			ctx.Stroke();			
 		}
 
 		void LoadPoints(ImageSurface imageSurface)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.ios.cs
@@ -18,8 +18,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 	/// </summary>
 	public class DrawingViewRenderer : ViewRenderer<DrawingView, UIView>
 	{
+		readonly UIBezierPath currentPath;
 		bool disposed;
-		UIBezierPath currentPath;
 		UIColor? lineColor;
 		CGPoint previousPoint;
 		Line? currentLine;
@@ -61,11 +61,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			var touch = (UITouch)touches.AnyObject;
 			previousPoint = touch.PreviousLocationInView(this);
 			currentPath.MoveTo(previousPoint);
-			currentLine = new Line()
+			currentLine = new Line
 			{
-				Points = new ObservableCollection<Point>()
+				Points = new ObservableCollection<Point>
 				{
-					new Point(previousPoint.X, previousPoint.Y)
+					new (previousPoint.X, previousPoint.Y)
 				}
 			};
 
@@ -105,7 +105,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		public override void Draw(CGRect rect)
 		{
-			lineColor!.SetStroke();
+			lineColor?.SetStroke();
 			currentPath.Stroke();
 		}
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.macos.cs
@@ -17,8 +17,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 	/// </summary>
 	public class DrawingViewRenderer : ViewRenderer<DrawingView, NSView>
 	{
+		readonly NSBezierPath currentPath;
 		bool disposed;
-		NSBezierPath currentPath;
 		NSColor? lineColor;
 		CGPoint previousPoint;
 		Line? currentLine;
@@ -58,11 +58,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 			previousPoint = theEvent.LocationInWindow;
 			currentPath.MoveTo(previousPoint);
-			currentLine = new Line()
+			currentLine = new Line
 			{
-				Points = new ObservableCollection<Point>()
+				Points = new ObservableCollection<Point>
 				{
-					new Point(previousPoint.X, previousPoint.Y)
+					new (previousPoint.X, previousPoint.Y)
 				}
 			};
 
@@ -94,7 +94,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		public override void DrawRect(CGRect dirtyRect)
 		{
 			base.DrawRect(dirtyRect);
-			lineColor!.SetStroke();
+			lineColor?.SetStroke();
 			currentPath.Stroke();
 		}
 
@@ -124,8 +124,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			Element.Lines.CollectionChanged -= OnLinesCollectionChanged;
 
 			var smoothedPoints = line.EnableSmoothedPath
-			? SmoothedPathWithGranularity(line.Points, line.Granularity)
-			: new ObservableCollection<Point>(line.Points);
+				? SmoothedPathWithGranularity(line.Points, line.Granularity)
+				: new ObservableCollection<Point>(line.Points);
 
 			line.Points.Clear();
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.tizen.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.tizen.cs
@@ -36,17 +36,17 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				SetNativeControl(canvasView);
 			}
 
-			if (e.OldElement != null)
+			if (e.OldElement != null && canvasView is not null)
 			{
-				canvasView!.EvasCanvas.DeleteEventAction(EvasObjectCallbackType.MouseDown, MouseDown);
+				canvasView.EvasCanvas.DeleteEventAction(EvasObjectCallbackType.MouseDown, MouseDown);
 				canvasView.EvasCanvas.DeleteEventAction(EvasObjectCallbackType.MouseUp, MouseUp);
 				canvasView.EvasCanvas.DeleteEventAction(EvasObjectCallbackType.MouseMove, MouseMove);
 				canvasView.PaintSurface -= OnPaintSurface;
 			}
 
-			if (e.NewElement != null)
+			if (e.NewElement != null && canvasView is not null)
 			{
-				canvasView!.PaintSurface += OnPaintSurface;
+				canvasView.PaintSurface += OnPaintSurface;
 				canvasView.EvasCanvas.AddEventAction(EvasObjectCallbackType.MouseDown, MouseDown);
 				canvasView.EvasCanvas.AddEventAction(EvasObjectCallbackType.MouseUp, MouseUp);
 				canvasView.EvasCanvas.AddEventAction(EvasObjectCallbackType.MouseMove, MouseMove);
@@ -56,9 +56,9 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
-			if (e.PropertyName == DrawingView.LinesProperty.PropertyName)
+			if (e.PropertyName == DrawingView.LinesProperty.PropertyName && canvasView is not null)
 			{
-				canvasView!.EvasCanvas.DeleteEventAction(EvasObjectCallbackType.MouseUp, MouseUp);
+				canvasView.EvasCanvas.DeleteEventAction(EvasObjectCallbackType.MouseUp, MouseUp);
 				LoadPoints();
 				canvasView.EvasCanvas.AddEventAction(EvasObjectCallbackType.MouseUp, MouseUp);
 			}
@@ -68,10 +68,10 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void MouseMove()
 		{
-			if (isDrawing)
+			if (isDrawing && canvasView is not null)
 			{
-				var point = canvasView!.EvasCanvas.Pointer;
-				currentLine!.Points.Add(new Point(point.X, point.Y));
+				var point = canvasView.EvasCanvas.Pointer;
+				currentLine?.Points.Add(new Point(point.X, point.Y));
 				canvasView.Invalidate();
 			}
 		}
@@ -111,7 +111,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			if (Element == null)
 				return;
 
-			canvasView!.Invalidate();
+			canvasView?.Invalidate();
 		}
 
 		void DrawPath(SKCanvas canvas)
@@ -150,7 +150,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			if (Element != null)
 			{
 				Element.Lines.CollectionChanged -= OnLinesCollectionChanged;
-				canvasView!.EvasCanvas.DeleteEventAction(EvasObjectCallbackType.MouseDown, MouseDown);
+			}
+
+			if (canvasView is not null)
+			{
+				canvasView.EvasCanvas.DeleteEventAction(EvasObjectCallbackType.MouseDown, MouseDown);
 				canvasView.EvasCanvas.DeleteEventAction(EvasObjectCallbackType.MouseUp, MouseUp);
 				canvasView.EvasCanvas.DeleteEventAction(EvasObjectCallbackType.MouseMove, MouseMove);
 				canvasView.PaintSurface -= OnPaintSurface;

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/DrawingView/Renderer/DrawingViewRenderer.uwp.cs
@@ -42,24 +42,31 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				Element.Lines.CollectionChanged += OnCollectionChanged;
 				SetNativeControl(canvas);
 
-				canvas!.InkPresenter.StrokeInput.StrokeStarted += StrokeInput_StrokeStarted;
+				canvas.InkPresenter.StrokeInput.StrokeStarted += StrokeInput_StrokeStarted;
 				canvas.InkPresenter.StrokesCollected += OnInkPresenterStrokesCollected;
 			}
 
 			if (e.OldElement != null)
 			{
-				canvas!.InkPresenter.StrokeInput.StrokeStarted -= StrokeInput_StrokeStarted;
-				canvas.InkPresenter.StrokesCollected -= OnInkPresenterStrokesCollected;
-				Element!.Lines.CollectionChanged -= OnCollectionChanged;
+				if (canvas is not null)
+				{
+					canvas.InkPresenter.StrokeInput.StrokeStarted -= StrokeInput_StrokeStarted;
+					canvas.InkPresenter.StrokesCollected -= OnInkPresenterStrokesCollected;
+				}
+
+				if (Element is not null)
+				{
+					Element.Lines.CollectionChanged -= OnCollectionChanged;
+				}
 			}
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
-			if (e.PropertyName == DrawingView.LinesProperty.PropertyName)
+			if (e.PropertyName == DrawingView.LinesProperty.PropertyName && canvas is not null)
 			{
-				canvas!.InkPresenter.StrokesCollected -= OnInkPresenterStrokesCollected;
+				canvas.InkPresenter.StrokesCollected -= OnInkPresenterStrokesCollected;
 				canvas.InkPresenter.StrokeContainer.Clear();
 				LoadLines();
 				canvas.InkPresenter.StrokesCollected += OnInkPresenterStrokesCollected;
@@ -111,10 +118,13 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
-			canvas!.InkPresenter.StrokesCollected -= OnInkPresenterStrokesCollected;
-			canvas.InkPresenter.StrokeContainer.Clear();
-			LoadLines();
-			canvas.InkPresenter.StrokesCollected += OnInkPresenterStrokesCollected;
+			if (canvas is not null)
+			{
+				canvas.InkPresenter.StrokesCollected -= OnInkPresenterStrokesCollected;
+				canvas.InkPresenter.StrokeContainer.Clear();
+				LoadLines();
+				canvas.InkPresenter.StrokesCollected += OnInkPresenterStrokesCollected;
+			}
 		}
 
 		void LoadLines()
@@ -152,7 +162,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			if (Element != null)
 			{
 				Element.Lines.CollectionChanged -= OnCollectionChanged;
-				canvas!.InkPresenter.StrokeInput.StrokeStarted -= StrokeInput_StrokeStarted;
+			}
+
+			if (canvas is not null)
+			{
+				canvas.InkPresenter.StrokeInput.StrokeStarted -= StrokeInput_StrokeStarted;
 				canvas.InkPresenter.StrokesCollected -= OnInkPresenterStrokesCollected;
 			}
 
@@ -163,7 +177,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		{
 			if (!Element.MultiLineMode || force)
 			{
-				canvas!.InkPresenter.StrokeContainer.Clear();
+				canvas?.InkPresenter.StrokeContainer.Clear();
 				Element.Lines.Clear();
 			}
 		}


### PR DESCRIPTION
### Description of Bug ###

Remove null-forgiving operator in drawing view.

I am not able to deploy the app to android device with VS 17.2, I was not able to test it on Android.
It works fine on UWP, WPF

### Issues Fixed ###
<!-- Provide links to issues here. Ensure that a GitHub issue was created for your feature or bug fix before sending PR. -->

- Fixes #1747 

### Behavioral Changes ###

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [x] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
