### PR TITLE
[iOS] ShadowEffect disappearing when coming back to the app (only with the Frame view) 

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.ios.macos.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Shadow/PlatformShadowEffect.ios.macos.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using CoreGraphics;
 using Xamarin.CommunityToolkit.Effects;
 using Xamarin.Forms;
+using System.Linq;
 
 #if __IOS__
 using NativeView = UIKit.UIView;
@@ -28,7 +29,14 @@ public class PlatformShadowEffect : PlatformEffect
 
 	const float defaultOpacity = .5f;
 
-	NativeView? View => Control ?? Container;
+	NativeView? View
+	{
+		get
+		{
+			var view = Control ?? Container;
+			return Element is Frame ? view?.Subviews.FirstOrDefault() ?? view : view;
+		}
+	}
 
 	protected override void OnAttached()
 	{


### PR DESCRIPTION
### Description of Bug ###

The shadow effect is disappearing when coming back to the app.
This issue exists only on iOS and only with the Frame view.

### Issues Fixed ###
- Fixes #1725

### Behavioral Changes ###
None

### PR Checklist ###
- [X] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [X] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
