### PR TITLE
Fix for ClearTintColor NullReferenceException on ImageButton related to PR #1836

### DIFF
--- a/samples/XCT.Sample/Pages/Effects/IconTintColorEffectPage.xaml
+++ b/samples/XCT.Sample/Pages/Effects/IconTintColorEffectPage.xaml
@@ -37,16 +37,16 @@
                         HorizontalTextAlignment="Center" />
 
                     <Image
-                        Source="https://image.flaticon.com/icons/png/512/48/48639.png"
+                        Source="https://raw.githubusercontent.com/xamarin/XamarinCommunityToolkit/main/samples/XCT.Sample.iOS/Resources/circle.png"
                         Grid.Row="1" />
 
                     <Image
-                        Source="https://image.flaticon.com/icons/png/512/48/48639.png"
+                        Source="https://raw.githubusercontent.com/xamarin/XamarinCommunityToolkit/main/samples/XCT.Sample.iOS/Resources/circle.png"
                         xct:IconTintColorEffect.TintColor="Red"
                         Grid.Row="2" />
 
                     <Image
-                        Source="https://image.flaticon.com/icons/png/512/48/48639.png"
+                        Source="https://raw.githubusercontent.com/xamarin/XamarinCommunityToolkit/main/samples/XCT.Sample.iOS/Resources/circle.png"
                         xct:IconTintColorEffect.TintColor="Green"
                         Grid.Row="3" />
 
@@ -59,18 +59,18 @@
                         Grid.Column="1"/>
 
                     <ImageButton
-                        Source="https://image.flaticon.com/icons/png/512/48/48639.png"
+                        Source="https://raw.githubusercontent.com/xamarin/XamarinCommunityToolkit/main/samples/XCT.Sample.iOS/Resources/circle.png"
                         Grid.Row="1"
                         Grid.Column="1" />
 
                     <ImageButton
-                        Source="https://image.flaticon.com/icons/png/512/48/48639.png"
+                        Source="https://raw.githubusercontent.com/xamarin/XamarinCommunityToolkit/main/samples/XCT.Sample.iOS/Resources/circle.png"
                         xct:IconTintColorEffect.TintColor="Red"
                         Grid.Row="2"
                         Grid.Column="1" />
 
                     <ImageButton
-                        Source="https://image.flaticon.com/icons/png/512/48/48639.png"
+                        Source="https://raw.githubusercontent.com/xamarin/XamarinCommunityToolkit/main/samples/XCT.Sample.iOS/Resources/circle.png"
                         xct:IconTintColorEffect.TintColor="Green"
                         Grid.Row="3"
                         Grid.Column="1" />

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
@@ -99,8 +99,8 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 				{
 					if (e.PropertyName == ImageButton.IsLoadingProperty.PropertyName)
 					{
-						var b = Element as Xamarin.Forms.ImageButton ?? throw new NullReferenceException();
-						if (!b.IsLoading)
+						var element = Element as Xamarin.Forms.ImageButton ?? throw new NullReferenceException();
+						if (!element.IsLoading)
 						{
 							SetUIButtonTintColor(button, color);
 						}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
@@ -54,11 +54,16 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 			{
 				case UIImageView imageView:
 					if (imageView.Image != null)
+					{
+						Element.PropertyChanged -= ImageViewTintColorPropertyChanged;
 						imageView.Image = imageView.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
+					}
+
 					break;
 				case UIButton button:
 					if (button.CurrentImage != null)
 					{
+						Element.PropertyChanged -= ButtonTintColorPropertyChanged;
 						var originalImage = button.CurrentImage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
 						button.SetImage(originalImage, UIControlState.Normal);
 					}
@@ -71,18 +76,7 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 		{
 			if (imageView.Image == null)
 			{
-				Element.PropertyChanged += (_, e) =>
-				{
-					if (e.PropertyName == Image.IsLoadingProperty.PropertyName)
-					{
-						var element = Element as Xamarin.Forms.Image ?? throw new NullReferenceException();
-
-						if (!element.IsLoading)
-						{
-							SetUIImageViewTintColor(imageView, color);
-						}
-					}
-				};
+				Element.PropertyChanged += ImageViewTintColorPropertyChanged;
 			}
 			else
 			{
@@ -91,21 +85,24 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 			}
 		}
 
+		void ImageViewTintColorPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == Image.IsLoadingProperty.PropertyName)
+			{
+				var b = Element as Xamarin.Forms.Image ?? throw new NullReferenceException();
+
+				if (!b.IsLoading)
+				{
+					ApplyTintColor();
+				}
+			}
+		}
+
 		void SetUIButtonTintColor(UIButton button, Color color)
 		{
 			if (button.ImageView.Image == null)
 			{
-				Element.PropertyChanged += (_, e) =>
-				{
-					if (e.PropertyName == ImageButton.IsLoadingProperty.PropertyName)
-					{
-						var element = Element as Xamarin.Forms.ImageButton ?? throw new NullReferenceException();
-						if (!element.IsLoading)
-						{
-							SetUIButtonTintColor(button, color);
-						}
-					}
-				};
+				Element.PropertyChanged += ButtonTintColorPropertyChanged;
 			}
 			else
 			{
@@ -116,6 +113,18 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 				button.TintColor = color.ToUIColor();
 				button.ImageView.TintColor = color.ToUIColor();
 				button.SetImage(templatedImage, UIControlState.Normal);
+			}
+		}
+
+		void ButtonTintColorPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == ImageButton.IsLoadingProperty.PropertyName)
+			{
+				var b = Element as Xamarin.Forms.ImageButton ?? throw new NullReferenceException();
+				if (!b.IsLoading)
+				{
+					ApplyTintColor();
+				}
 			}
 		}
 	}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
@@ -61,7 +61,7 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 
 					break;
 				case UIButton button:
-					if (button.ImageView.Image != null)
+					if (button.ImageView?.Image != null)
 					{
 						Element.PropertyChanged -= ButtonTintColorPropertyChanged;
 						var originalImage = button.CurrentImage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
@@ -53,17 +53,17 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 			switch (Control)
 			{
 				case UIImageView imageView:
+					Element.PropertyChanged -= ImageViewTintColorPropertyChanged;
 					if (imageView.Image != null)
 					{
-						Element.PropertyChanged -= ImageViewTintColorPropertyChanged;
 						imageView.Image = imageView.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
 					}
 
 					break;
 				case UIButton button:
+					Element.PropertyChanged -= ButtonTintColorPropertyChanged;
 					if (button.ImageView?.Image != null)
 					{
-						Element.PropertyChanged -= ButtonTintColorPropertyChanged;
 						var originalImage = button.CurrentImage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);
 						button.SetImage(originalImage, UIControlState.Normal);
 					}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
@@ -75,9 +75,9 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 				{
 					if (e.PropertyName == Image.IsLoadingProperty.PropertyName)
 					{
-						var b = Element as Xamarin.Forms.Image ?? throw new NullReferenceException();
+						var element = Element as Xamarin.Forms.Image ?? throw new NullReferenceException();
 
-						if (!b.IsLoading)
+						if (!element.IsLoading)
 						{
 							SetUIImageViewTintColor(imageView, color);
 						}

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
@@ -61,7 +61,7 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 
 					break;
 				case UIButton button:
-					if (button.CurrentImage != null)
+					if (button.ImageView.Image != null)
 					{
 						Element.PropertyChanged -= ButtonTintColorPropertyChanged;
 						var originalImage = button.CurrentImage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
@@ -1,5 +1,5 @@
-﻿using System.ComponentModel;
-using System.Threading.Tasks;
+﻿using System;
+using System.ComponentModel;
 using UIKit;
 using Xamarin.CommunityToolkit.Effects;
 using Xamarin.Forms;
@@ -12,8 +12,6 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 {
 	public class IconTintColorEffectRouter : PlatformEffect
 	{
-		private int _retryCount = 0;
-
 		protected override void OnAttached()
 			=> ApplyTintColor();
 
@@ -69,43 +67,45 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 			}
 		}
 
-		async void SetUIImageViewTintColor(UIImageView imageView, Color color)
+		void SetUIImageViewTintColor(UIImageView imageView, Color color)
 		{
 			if (imageView.Image == null)
 			{
-				if (_retryCount < 4)
+				Element.PropertyChanged += (_, e) =>
 				{
-					_retryCount++;
-					await Task.Delay(100);
-					SetUIImageViewTintColor(imageView, color);
-				}
-				else
-				{
-					return;
-				}
+					if (e.PropertyName == Image.IsLoadingProperty.PropertyName)
+					{
+						var b = Element as Xamarin.Forms.Image ?? throw new NullReferenceException();
+
+						if (!b.IsLoading)
+						{
+							SetUIImageViewTintColor(imageView, color);
+						}
+					}
+				};
 			}
 			else
 			{
 				imageView.Image = imageView.Image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
 				imageView.TintColor = color.ToUIColor();
-				_retryCount = 0;
 			}
 		}
 
-		async void SetUIButtonTintColor(UIButton button, Color color)
+		void SetUIButtonTintColor(UIButton button, Color color)
 		{
-			if (button.CurrentImage == null)
+			if (button.ImageView.Image == null)
 			{
-				if (_retryCount < 4)
+				Element.PropertyChanged += (_, e) =>
 				{
-					_retryCount++;
-					await Task.Delay(100);
-					SetUIButtonTintColor(button, color);
-				}
-				else
-				{
-					return;
-				}
+					if (e.PropertyName == ImageButton.IsLoadingProperty.PropertyName)
+					{
+						var b = Element as Xamarin.Forms.ImageButton ?? throw new NullReferenceException();
+						if (!b.IsLoading)
+						{
+							SetUIButtonTintColor(button, color);
+						}
+					}
+				};
 			}
 			else
 			{

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/IconTintColor/IconTintColorEffectRouter.ios.cs
@@ -89,9 +89,9 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 		{
 			if (e.PropertyName == Image.IsLoadingProperty.PropertyName)
 			{
-				var b = Element as Xamarin.Forms.Image ?? throw new NullReferenceException();
+				var element = (Image)Element;
 
-				if (!b.IsLoading)
+				if (!element.IsLoading)
 				{
 					ApplyTintColor();
 				}
@@ -120,8 +120,8 @@ namespace Xamarin.CommunityToolkit.iOS.Effects
 		{
 			if (e.PropertyName == ImageButton.IsLoadingProperty.PropertyName)
 			{
-				var b = Element as Xamarin.Forms.ImageButton ?? throw new NullReferenceException();
-				if (!b.IsLoading)
+				var element = (ImageButton)Element;
+				if (!element.IsLoading)
 				{
 					ApplyTintColor();
 				}


### PR DESCRIPTION
I originally sent over a PR for Issue #934 and have found a small issue not addressed in PR #1836 which I also have this PR to resolve.

This PR is to fix a NullReferenceException in ClearTintColor when setting Application.MainPage to a different page when the current page uses the Tint Effect.  In ClearTintColor the button.ImageView is null and not checked.  I have added the conditional access qualifier and it resolves this issue.
I have also moved the detach PropertyChanged outside of the Image Null Checks in ClearTintColor as I noticed that when the ImageButton is being detached the ImageView of the button is null (I am unsure why) however I believe the PropertyChanged Event added in SetUITintColor functions should be removed regardless of the null state of the Image.