### PR TITLE
Implemented MediaElement ObjectDisposedException fix

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/FormsVideoView.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/FormsVideoView.android.cs
@@ -52,10 +52,14 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		public override async void SetVideoURI(global::Android.Net.Uri? uri, IDictionary<string, string>? headers)
 		{
-			if (uri != null)
-				await SetMetadata(uri, headers);
-
 			base.SetVideoURI(uri, headers);
+
+			// this instance could get disposed during awaiting, so a call to the base method (AFTER awaiting)
+			// would throw ObjectDisposedException and be impossible to catch due to async void
+			if (uri != null)
+			{
+				await SetMetadata(uri, headers);
+			}
 		}
 
 		protected async Task SetMetadata(global::Android.Net.Uri uri, IDictionary<string, string>? headers)

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/MediaElementRenderer.android.cs
@@ -21,7 +21,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		VisualElementTracker? tracker;
 		protected MediaController? controller;
 		protected MediaPlayer? mediaPlayer;
-		protected FormsVideoView view;
+		protected FormsVideoView? view;
 		bool isDisposed;
 		int? defaultLabelFor;
 
@@ -47,9 +47,14 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		public override float Alpha
 		{
-			get => view.Alpha;
+			get => view?.Alpha ?? throw new ObjectDisposedException(typeof(FormsVideoView).FullName);
 			set
 			{
+				if (view == null)
+				{
+					throw new ObjectDisposedException(typeof(FormsVideoView).FullName);
+				}
+
 				// VideoView opens a separate Window above the current one.
 				// This is because it is based on the SurfaceView.
 				// And we cannot set alpha or perform animations with it because it is not synchronized with your other UI elements.
@@ -509,6 +514,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				view.SetOnPreparedListener(null);
 				view.SetOnCompletionListener(null);
 				view.Dispose();
+				view = null;
 			}
 
 			if (controller != null)


### PR DESCRIPTION
### Description of Bug ###

FormsVideoView instance was never set to null after disposing, which would sometimes lead to accessing the disposed object and throwing ObjectDisposedException.
I have also rearranged method calls in [SetVideoURI](https://github.com/xamarin/XamarinCommunityToolkit/blob/22b1d4ccf45555c2ed89ecb94e9ff93a5cf61ab3/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/Android/FormsVideoView.android.cs#L53) to avoid calling the base method after the await, during which the instance could get disposed because the overridden method is async void. The only downside of this approach I could think of is that the metadata (video size and duration) may update after the video has already started. Maybe we could revert this and override Dispose and set a private field `isDisposed = true` and then after the await check if `isDisposed == false` to call the base method?

### Issues Fixed ###

- Fixes #1769
- Fixes #1571

### Behavioral Changes ###

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [x] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
