### PR TITLE
added additional ctor to AccessibilityListener to avoid app crash

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Effects/Touch/PlatformTouchEffect.android.cs
@@ -5,6 +5,7 @@ using Android.Content;
 using Android.Content.Res;
 using Android.Graphics.Drawables;
 using Android.OS;
+using Android.Runtime;
 using Android.Views;
 using Android.Views.Accessibility;
 using Android.Widget;
@@ -485,6 +486,11 @@ namespace Xamarin.CommunityToolkit.Android.Effects
 
 			internal AccessibilityListener(PlatformTouchEffect platformTouchEffect)
 				=> this.platformTouchEffect = platformTouchEffect;
+
+			public AccessibilityListener(IntPtr handle, JniHandleOwnership transfer)
+                : base(handle, transfer)
+			{
+			}
 
 			public void OnAccessibilityStateChanged(bool enabled)
 				=> platformTouchEffect?.UpdateClickHandler();


### PR DESCRIPTION
### Description of Bug ###

Added additional ctor `AccessibilityListener(IntPtr handle, JniHandleOwnership transfer)` in order to fix #1923.

### Issues Fixed ###

- Fixes #1923

### Behavioral Changes ###

None.

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [ ] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
