### PR TITLE
CameraView: fixed leak on UWP not cleaning up MediaCapture object for preview

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/UWP/CameraViewRenderer.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/UWP/CameraViewRenderer.uwp.cs
@@ -365,7 +365,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			{
 				Control.Source = mediaCapture;
 				await mediaCapture.StartPreviewAsync();
-				isPreviewing = false;
+				isPreviewing = true;
 				IsBusy = false;
 				Available = true;
 			}


### PR DESCRIPTION
### Description of Bug ###

This fixes the bug from issue #1950 by correctly setting `isPreviewing` so that at clean-up time, the `MediaCapture` object is cleaned up properly.

### Issues Fixed ###

- Fixes #1950

### Behavioral Changes ###

The `CameraView` on UWP doesn't leak normal and GPU memory anymore.

### PR Checklist ###
- [x] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
