### PR TITLE
Fix badge view default text "0"

### DIFF
--- a/samples/XCT.Sample/Pages/TestCases/Issue1900.xaml
+++ b/samples/XCT.Sample/Pages/TestCases/Issue1900.xaml
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.TestCases"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.TestCases.Issue1900Page">
+    <pages:BasePage.BindingContext>
+        <vm:Issue1900ViewModel />
+    </pages:BasePage.BindingContext>
+    <ContentPage.Content>
+        <Grid RowDefinitions="*, *, auto"
+              Padding="12">
+            <xct:BadgeView Text="{Binding Counter}"
+                           AutoHide="False"
+                           VerticalOptions="Center"
+                           Grid.Row="0">
+                <Label Text="Badge should be visible and display 0 as text"
+                       Margin="6" />
+            </xct:BadgeView>
+            <xct:BadgeView Text="{Binding Counter}"
+                           VerticalOptions="Center"
+                           Grid.Row="1">
+                <Label Text="Badge should not be visible"
+                       Margin="6" />
+            </xct:BadgeView>
+            <Button Text="Increment"
+                    Command="{Binding ClickCommand}" 
+                    Grid.Row="2" />
+        </Grid>
+    </ContentPage.Content>
+</pages:BasePage>

--- a/samples/XCT.Sample/Pages/TestCases/Issue1900.xaml.cs
+++ b/samples/XCT.Sample/Pages/TestCases/Issue1900.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.CommunityToolkit.Sample.Pages.TestCases
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class Issue1900Page : BasePage
+	{
+		public Issue1900Page()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/samples/XCT.Sample/ViewModels/TestCases/Issue1900ViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/TestCases/Issue1900ViewModel.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using System.Windows.Input;
+using Xamarin.CommunityToolkit.ObjectModel;
+
+namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases
+{
+	public class Issue1900ViewModel : BaseViewModel
+	{
+		int counter;
+
+		public int Counter
+		{
+			get => counter;
+			set => SetProperty(ref counter, value);
+		}
+
+		public ICommand ClickCommand => new AsyncCommand(Click);
+
+		public Issue1900ViewModel()
+		{
+		}
+
+		Task Click()
+		{
+			Counter++;
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
@@ -49,7 +49,7 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases
 				typeof(SnackBarActionExceptionPage),
 				"SnackBar Action Exception",
 				"Exception in SnackBar's action doesn't crash the app."),
-			
+
 			new SectionModel(
 				typeof(Issue1883Page),
 				"SnackBar iOS issue GitHub #1883",
@@ -58,7 +58,12 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases
 			new SectionModel(
 				typeof(DrawingViewInExpanderPage),
 				"DrawingView in expander",
-				"DrawingView in Expander Page")
+				"DrawingView in Expander Page"),
+
+			new SectionModel(
+				typeof(Issue1900Page),
+				"BadgeView Issue GitHub #1900",
+				"BadgeView default text")
 		};
 	}
 }

--- a/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
+++ b/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
@@ -29,6 +29,9 @@
   </ItemGroup>
   
   <ItemGroup>
+    <EmbeddedResource Update="Pages\TestCases\Issue1900.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Pages\TestCases\Popups\PopupModalPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
@@ -52,8 +55,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\CommunityToolkit\Xamarin.CommunityToolkit\Xamarin.CommunityToolkit.csproj" />
     <ProjectReference Include="..\..\src\Markup\Xamarin.CommunityToolkit.Markup\Xamarin.CommunityToolkit.Markup.csproj" />
-    <ProjectReference Include="..\..\src\SourceGenerator\Xamarin.CommunityToolkit.SourceGenerator\Xamarin.CommunityToolkit.SourceGenerator.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\..\src\SourceGenerator\Xamarin.CommunityToolkit.SourceGenerator\Xamarin.CommunityToolkit.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BadgeView/BadgeView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/BadgeView/BadgeView.shared.cs
@@ -266,6 +266,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 
 		protected override void OnControlInitialized(Grid control)
 		{
+			BadgeText.Text = Text;
 			BadgeIndicatorBackground.Content = BadgeText;
 
 			BadgeIndicatorContainer.Children.Add(BadgeIndicatorBackground);


### PR DESCRIPTION
### Description of Bug ###
BadgeView default Text value is never set.

The Text property has a default value of 0, but it is never set to the actual label. This prevents the BadgeView from being displayed if it is bound to a property with a value of 0 and AutoHide is set to false.

### Issues Fixed ###

- Fixes #1900 

### Before
<img src="https://user-images.githubusercontent.com/25205086/228349329-50fb4af7-c552-40a1-b282-7bbf2e1c544c.png" width="400" />

### After
<img src="https://user-images.githubusercontent.com/25205086/228349370-8bfb1d18-2506-471f-b86d-02aa62288ebe.png" width="400" />

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [ ] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
