### PR TITLE
CameraView fix rotating on Android

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
@@ -408,7 +408,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 							rotatedImage?.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
 
 							Sound(MediaActionSoundType.ShutterClick);
-							OnPhoto(this, (filePath, stream.ToArray(), rotation));
+							OnPhoto(this, (filePath, stream.ToArray(), 0));
 							rotatedImage?.Recycle();
 							rotatedImage?.Dispose();
 

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/Android/CameraFragment.android.cs
@@ -417,6 +417,11 @@ namespace Xamarin.CommunityToolkit.UI.Views
 						}
 					}
 				}
+				else
+				{
+					Sound(MediaActionSoundType.ShutterClick);
+					OnPhoto(this, (filePath, bytes, rotation));
+				}
 			};
 
 			photoReader.SetOnImageAvailableListener(readerListener, backgroundHandler);


### PR DESCRIPTION
### Description of Bug ###

On Android, the camera activity is correctly rotated, but the resulting image isn't rotated according to the current device orientation. Instead the rotation angle is passed to the event `RaiseMediaCaptured`. The PR takes the changes from @jfversluis from PR #1871, which already does the image rotation, and passes rotation angle 0 to `RaiseMediaCaptured` in order to be compatible with potentially existing rotation code on user's side.

Note that this change targets the droid-cameraview-rotation branch that @jfversluis already has done the main work, per PR #1871.

### Issues Fixed ###

- Fixes #1695
- Supersedes #1871

### Behavioral Changes ###

There should be no changes, since the photo now has been rotated already and the new rotation angle 0 is passed to the user.

### PR Checklist ###

- [x] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
