### PR TITLE
CameraView: only request microphone permission when CaptureMode is set to Video in UWP

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/UWP/CameraViewRenderer.uwp.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/CameraView/UWP/CameraViewRenderer.uwp.cs
@@ -245,6 +245,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			switch (e.PropertyName)
 			{
 				case nameof(CameraView.CameraOptions):
+				case nameof(CameraView.CaptureMode):
 					await CleanupCameraAsync();
 					await InitializeCameraAsync();
 					break;
@@ -333,8 +334,12 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				return;
 			}
 
-			var audioDevice = await DeviceInformation.FindAllAsync(DeviceClass.AudioCapture);
-			var selectedAudioDevice = audioDevice.Count == 0 ? null : audioDevice[0].Id;
+			string? selectedAudioDevice = null;
+			if (Element.CaptureMode == CameraCaptureMode.Video)
+			{
+				var audioDevice = await DeviceInformation.FindAllAsync(DeviceClass.AudioCapture);
+				selectedAudioDevice = audioDevice.Count == 0 ? null : audioDevice[0].Id;
+			}
 
 			mediaCapture = new MediaCapture();
 			try
@@ -345,7 +350,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 					MediaCategory = MediaCategory.Media,
 					StreamingCaptureMode = selectedAudioDevice == null ? StreamingCaptureMode.Video : StreamingCaptureMode.AudioAndVideo,
 					AudioProcessing = Windows.Media.AudioProcessing.Default,
-					AudioDeviceId = selectedAudioDevice
+					AudioDeviceId = selectedAudioDevice ?? string.Empty,
 				});
 				flash = await Lamp.GetDefaultAsync();
 


### PR DESCRIPTION
### Description of Bug ###

This fixes the CameraView on UWP to request microphone permission when CaptureMode is only set to Photo.

### Issues Fixed ###

- Fixes #1962

### Behavioral Changes ###

The UWP app can then remove the microphone permission if not use anywhere else.

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [x] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
