### PR TITLE
Migrate to backport-action

### DIFF
--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -5,20 +5,34 @@ on:
     types: [created]
 
 jobs:
-  launchBackportBuild:
+  setupBackport:
     runs-on: ubuntu-latest
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '@gitbot')
-
+    if: github.event.issue.pull_request != '' && startswith(github.event.comment.body, '@gitbot backport')
+    outputs:
+      target_branch: ${{ steps.parse_comment.outputs.target_branch }}
     steps:
-      - uses: xamarin/backport-bot-action@v1.0
-        with:
-          pull_request_url: ${{ github.event.issue.pull_request.url }}
-          comment_body: ${{ github.event.comment.body }}
-          comment_author: ${{ github.actor }}
-          github_repository: ${{ github.repository }}
-          ado_organization: ${{ secrets.ADO_PROJECTCOLLECTION }}
-          ado_project: ${{ secrets.ADO_PROJECT }}
-          backport_pipeline_id: ${{ secrets.BACKPORT_PIPELINEID }}
-          ado_build_pat: ${{ secrets.ADO_BUILDPAT }}
-          github_account_pat: ${{ secrets.SERVICEACCOUNT_PAT }}
-          use_fork: 'false'
+      - name: Parse Comment
+        id: parse_comment
+        run: |
+          Write-Host "Parsing $env:COMMENT"
+          ($botName, $backport, $backportTargetBranch) = [System.Text.RegularExpressions.Regex]::Split("$env:COMMENT", "\s+")
+          echo "::set-output name=target_branch::$backportTargetBranch"
+        shell: pwsh
+        env:
+          COMMENT: "${{ github.event.comment.body }}"
+
+  launchBackportBuild:
+    needs: setupBackport
+    uses: xamarin/backport-bot-action/.github/workflows/backport-action.yml@v1.1
+    with:
+      pull_request_url: ${{ github.event.issue.pull_request.url }}
+      target_branch: ${{ needs.setupBackport.outputs.target_branch }}
+      comment_author: ${{ github.actor }}
+      github_repository: ${{ github.repository }}
+      use_fork: false
+    secrets:
+      ado_organization: ${{ secrets.ADO_PROJECTCOLLECTION }}
+      ado_project: ${{ secrets.ADO_PROJECT }}
+      backport_pipeline_id: ${{ secrets.BACKPORT_PIPELINEID }}
+      ado_build_pat: ${{ secrets.ADO_BUILDPAT }}
+      github_account_pat: ${{ secrets.SERVICEACCOUNT_PAT }}


### PR DESCRIPTION
### Description of Issue ###

Remove dependency on outdated `backport-bot-action`.  This is part of an overall effort to ensure all repos that support backports are using the latest `backport-action` template

### Issues Fixed ###

Removes dependency on outdated `backport-bot-action`

### Behavioral Changes ###

Requires the `@gitbot backport` text be specified at the beginning of a PR comment as opposed to appearing anywhere in the comment text

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [ ] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [X] Rebased on top of main at time of PR
- [X] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
