### PR TITLE
Fix tab view item font family (ios and uwp)

### DIFF
--- a/samples/XCT.Sample/Pages/TestCases/Issue1978.xaml
+++ b/samples/XCT.Sample/Pages/TestCases/Issue1978.xaml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                xmlns:vm="clr-namespace:Xamarin.CommunityToolkit.Sample.ViewModels.TestCases"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.TestCases.Issue1978Page">
+    <pages:BasePage.BindingContext>
+        <vm:Issue1978ViewModel />
+    </pages:BasePage.BindingContext>
+    <ContentPage.Content>
+        <xct:TabView>
+            <xct:TabViewItem Text="&#xf09d;"
+                             TextColor="Green"
+                             FontSize="24" FontSizeSelected="28"
+                             FontFamily="FARegular"
+                             IsSelected="True">
+                <Label Text="TabViewItem text should be an icon."
+                       HorizontalTextAlignment="Center" />
+            </xct:TabViewItem>
+            <xct:TabViewItem Text="&#xf09d;"
+                             TextColor="Black"
+                             FontSize="24" FontSizeSelected="28"
+                             FontFamily="FARegular">
+                <Label Text="TabViewItem text should be an icon."
+                       HorizontalTextAlignment="Center" />
+            </xct:TabViewItem>
+        </xct:TabView>
+    </ContentPage.Content>
+</pages:BasePage>

--- a/samples/XCT.Sample/Pages/TestCases/Issue1978.xaml.cs
+++ b/samples/XCT.Sample/Pages/TestCases/Issue1978.xaml.cs
@@ -1,0 +1,13 @@
+﻿using Xamarin.Forms.Xaml;
+
+namespace Xamarin.CommunityToolkit.Sample.Pages.TestCases
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class Issue1978Page : BasePage
+	{
+		public Issue1978Page()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/samples/XCT.Sample/ViewModels/TestCases/Issue1978ViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/TestCases/Issue1978ViewModel.cs
@@ -1,0 +1,9 @@
+﻿namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases
+{
+	public class Issue1978ViewModel : BaseViewModel
+	{
+		public Issue1978ViewModel()
+		{
+		}
+	}
+}

--- a/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
@@ -63,7 +63,12 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases
 			new SectionModel(
 				typeof(Issue1900Page),
 				"BadgeView Issue GitHub #1900",
-				"BadgeView default text")
+				"BadgeView default text"),
+
+			new SectionModel(
+				typeof(Issue1978Page),
+				"TabView Issue GitHub #1978",
+				"TabView font family")
 		};
 	}
 }

--- a/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
+++ b/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
@@ -32,6 +32,9 @@
     <EmbeddedResource Update="Pages\TestCases\Issue1900.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="Pages\TestCases\Issue1978.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Pages\TestCases\Popups\PopupModalPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/TabView/CupertinoTabViewItemTemplate.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/TabView/CupertinoTabViewItemTemplate.shared.cs
@@ -69,6 +69,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			text.SetBinding(Label.TextColorProperty, "CurrentTextColor");
 			text.SetBinding(Label.FontSizeProperty, "CurrentFontSize");
 			text.SetBinding(Label.FontAttributesProperty, "CurrentFontAttributes");
+			text.SetBinding(Label.FontFamilyProperty, "CurrentFontFamily");
 
 			badge.SetBinding(TabBadgeView.BackgroundColorProperty, "CurrentBadgeBackgroundColor");
 			badge.SetBinding(TabBadgeView.BorderColorProperty, "CurrentBadgeBorderColor");

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/TabView/WindowsTabViewItemTemplate.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/TabView/WindowsTabViewItemTemplate.shared.cs
@@ -65,6 +65,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			text.SetBinding(Label.TextColorProperty, "CurrentTextColor");
 			text.SetBinding(Label.FontSizeProperty, "CurrentFontSize");
 			text.SetBinding(Label.FontAttributesProperty, "CurrentFontAttributes");
+			text.SetBinding(Label.FontFamilyProperty, "CurrentFontFamily");
 
 			badge.SetBinding(TabBadgeView.BackgroundColorProperty, "CurrentBadgeBackgroundColor");
 			badge.SetBinding(TabBadgeView.TextProperty, "BadgeText");


### PR DESCRIPTION
### Description of Bug ###
TabViewItem font is never set in iOS and UWP, resulting in default font being displayed.

### Issues Fixed ###

- Fixes #1978 

<details>
<summary><h3>Before</h3></summary>
<table>
<tr><th width='33%'>Android</th><th width='33%'>iOS</th><th width='33%'>UWP</th></tr>
<tr>
<td><img src='https://github.com/xamarin/XamarinCommunityToolkit/assets/25205086/678505db-a884-4b61-890d-0a26bf5b2015' /></td>
<td><img src='https://github.com/xamarin/XamarinCommunityToolkit/assets/25205086/2d949500-73c4-45b6-8b37-dfce81bb3b3d' /></td>
<td><img src='https://github.com/xamarin/XamarinCommunityToolkit/assets/25205086/a1d489c0-1173-4dca-adb2-deb6e759ea31' /></td>
</tr>
</table>
</details>
<details>
<summary><h3>After</h3></summary>
<table>
<tr><th width='33%'>Android</th><th width='33%'>iOS</th><th width='33%'>UWP</th></tr>
<tr>
<td><img src='https://github.com/xamarin/XamarinCommunityToolkit/assets/25205086/ccac972d-e77c-4b84-b32c-b82e906e1966' /></td>
<td><img src='https://github.com/xamarin/XamarinCommunityToolkit/assets/25205086/22879c30-2a5c-417a-97f2-a3df0b7f58a8' /></td>
<td><img src='https://github.com/xamarin/XamarinCommunityToolkit/assets/25205086/d4f8b465-c2f3-45c5-966b-671ab7d68ecc' /></td>
</tr>
</table>
</details>

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [ ] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)