### PR TITLE
fix TabViewIndicator position on RTL

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/TabView/TabView.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/TabView/TabView.shared.cs
@@ -1083,8 +1083,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 		void UpdateTabIndicatorPosition(View currentTabViewItem)
 		{
 			var width = TabIndicatorWidth > 0 ? (currentTabViewItem.Width - tabStripIndicator.Width) : 0;
-			var position = currentTabViewItem.X + (width / 2) - 1;
-			tabStripIndicator.TranslateTo(position, 0, tabIndicatorAnimationDuration, Easing.Linear);
+			var position = (currentTabViewItem.Width * SelectedIndex) + (width / 2) - 1;
+			tabStripIndicator.TranslateTo(FlowDirection == FlowDirection.RightToLeft ? -position : position, 0, tabIndicatorAnimationDuration, Easing.Linear);
 		}
 
 		internal virtual void OnTabSelectionChanged(TabSelectionChangedEventArgs e)


### PR DESCRIPTION
<!-- 
Hey there friend! First of all, thank you so much for this PR!
Some things that you should be aware of before opening this amazing PR❣

1. Before doing a lot of work, please check if there's an open issue for this chang, If not, please open an issue first so we can discuss upfront.

2. Please ensure this is a PR for a Bug Fix. The Xamarin Community Toolkit is no longer accepting New Features. Going forward, all New Features are being add to the .NET MAUI Community Toolkit: https://github.com/communitytoolkit/maui

3. Please ensure you are targeting the correct branch, `main`

Also make sure you've read our Contribution guide here: https://github.com/xamarin/XamarinCommunityToolkit/blob/pj/update-pr-template/CONTRIBUTING.md
-->

### Description of Bug ###

TabView - TabViewIndicator goes off the screen when flow direction is RTL. This is caused by the UpdateTabIndicatorPosition method not taking RTL into consideration when calculating the position to translate the indicator to.

### Issues Fixed ###
- Fixes #1982 

### Behavioral Changes ###

<!-- Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase. -->

### PR Checklist ###
<!-- Please check all the things you did here and double-check that you got it all, or state why you didn't do something -->
- [ ] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [ ] Rebased on top of main at time of PR
- [ ] Changes adhere to coding standard
<!-- If at all possible, please update/add the documentation on the repo below. We would very much appreciate that. If you are unable to, please consider at least opening an issue on the repo below so we know that Docs still need to be adjusted/created. Thanks! <3 -->
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
