### PR TITLE
Add preserve all member to media element class (shared)

### DIFF
--- a/samples/XCT.Sample/Pages/TestCases/Issue1936.xaml
+++ b/samples/XCT.Sample/Pages/TestCases/Issue1936.xaml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<pages:BasePage xmlns="http://xamarin.com/schemas/2014/forms"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:pages="clr-namespace:Xamarin.CommunityToolkit.Sample.Pages"
+                xmlns:xct="http://xamarin.com/schemas/2020/toolkit"
+                x:Class="Xamarin.CommunityToolkit.Sample.Pages.TestCases.Issue1936Page">
+    <pages:BasePage.Resources>
+        <xct:TimeSpanToDoubleConverter x:Key="TimeSpanConverter" />
+    </pages:BasePage.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Label
+            Grid.Row="0"
+            Text="Slider should move and video position should change if dragged." />
+        <xct:MediaElement
+            Grid.Row="1"
+            x:Name="mediaElement"
+            HorizontalOptions="Fill"
+            Source="https://sec.ch9.ms/ch9/5d93/a1eab4bf-3288-4faf-81c4-294402a85d93/XamarinShow_mid.mp4" />
+        <Label
+            Grid.Row="2"
+            BindingContext="{x:Reference mediaElement}"
+            Text="{Binding Position}" />
+        <Slider
+            Grid.Row="3"
+            BindingContext="{x:Reference mediaElement}"
+            Maximum="{Binding Duration, Converter={StaticResource TimeSpanConverter}}"
+            Value="{Binding Position, Converter={StaticResource TimeSpanConverter}}" />
+    </Grid>
+</pages:BasePage>

--- a/samples/XCT.Sample/Pages/TestCases/Issue1936.xaml.cs
+++ b/samples/XCT.Sample/Pages/TestCases/Issue1936.xaml.cs
@@ -1,0 +1,10 @@
+﻿using Xamarin.Forms.Xaml;
+
+namespace Xamarin.CommunityToolkit.Sample.Pages.TestCases
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class Issue1936Page : BasePage
+	{
+		public Issue1936Page() => InitializeComponent();
+	}
+}

--- a/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
+++ b/samples/XCT.Sample/ViewModels/TestCases/TestCasesGalleryViewModel.cs
@@ -68,7 +68,12 @@ namespace Xamarin.CommunityToolkit.Sample.ViewModels.TestCases
 			new SectionModel(
 				typeof(Issue1978Page),
 				"TabView Issue GitHub #1978",
-				"TabView font family")
+				"TabView font family"),
+
+			new SectionModel(
+				typeof(Issue1936Page),
+				"MediaElement Issue GitHub #1936",
+				"Position property access")
 		};
 	}
 }

--- a/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
+++ b/samples/XCT.Sample/Xamarin.CommunityToolkit.Sample.csproj
@@ -21,6 +21,9 @@
   </ItemGroup>
   
   <ItemGroup>
+    <Compile Update="Pages\TestCases\Issue1936.xaml.cs">
+      <DependentUpon>Issue1936.xaml</DependentUpon>
+    </Compile>
     <Compile Update="Resx\AppResources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs
@@ -1,10 +1,11 @@
 ﻿using System;
-using System.ComponentModel;
 using Xamarin.CommunityToolkit.Core;
 using Xamarin.Forms;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.CommunityToolkit.UI.Views
 {
+	[Preserve(AllMembers = true)]
 	public class MediaElement : View, IMediaElementController
 	{
 		public static readonly BindableProperty AspectProperty =


### PR DESCRIPTION
### Description of Bug ###
Some properties of `MediaElement` class are removed by linker if not accessed from code (due to `IMediaElementController`?). To prevent this we should add [Preserve(AllMember=True)] to `MediaElement` class.

I think `MediaElement` is quite bugged. On some devices this change cause the application to hang, and I think the reason is because now that the MediaElement.Positon is called it will loop at line 95
https://github.com/xamarin/XamarinCommunityToolkit/blob/5a6062f3c3543acda3c36ca4683cd8fc7fe86ba7/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/MediaElement.shared.cs#L91-L97

Is there a reason why we can't get rid of this line?

### Issues Fixed ###

- Should fix #1936

### PR Checklist ###
- [ ] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)