### PR TITLE
Use media element play method when is looping is true and media is played to end (ios)

### DIFF
--- a/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
+++ b/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs
@@ -217,7 +217,8 @@ namespace Xamarin.CommunityToolkit.UI.Views
 			{
 				avPlayerViewController.Player?.Seek(CMTime.Zero);
 				Controller.Position = Position;
-				avPlayerViewController.Player?.Play();
+
+				Play();
 			}
 			else
 			{
@@ -264,6 +265,7 @@ namespace Xamarin.CommunityToolkit.UI.Views
 				case nameof(ToolKitMediaElement.Volume):
 					UpdateVolume();
 					break;
+
 				case nameof(ToolKitMediaElement.Speed):
 					UpdateSpeed();
 					break;


### PR DESCRIPTION
### Description of Bug ###
`Speed` is lost when `IsLooping=True` because `avPlayerViewController.Player?.Play();` is used to restart the player.

By using `Play()` the speed is respected.

https://github.com/xamarin/XamarinCommunityToolkit/blob/5a6062f3c3543acda3c36ca4683cd8fc7fe86ba7/src/CommunityToolkit/Xamarin.CommunityToolkit/Views/MediaElement/iOS/MediaElementRenderer.ios.cs#L290-L315

<!-- Describe your changes here that fix the bug. -->

### Issues Fixed ###

- Fixes #2002 (partially)

### Behavioral Changes ###

### PR Checklist ###
- [ ] Has a linked Issue, and the Issue has been `approved`
- [ ] Has tests (if omitted, state reason in description)
- [ ] Has samples (if omitted, state reason in description)
- [x] Rebased on top of main at time of PR
- [x] Changes adhere to coding standard
- [ ] Updated [documentation](https://github.com/MicrosoftDocs/xamarin-communitytoolkit)
